### PR TITLE
feat: add ngtcp2_crypto_quictls support

### DIFF
--- a/extras.nim
+++ b/extras.nim
@@ -12,3 +12,83 @@ type
     struct_st_ptls_handshake_properties_t_anon0_t_server_t_selected_psk_binder_t
   ptls_handshake_properties_t_anon0_t_server_t_cookie_t* =
     struct_st_ptls_handshake_properties_t_anon0_t_server_t_cookie_t
+
+# OpenSSL/QuicTLS crypto support
+# OpenSSL/QuicTLS type definitions
+type
+  SSL_CTX* = pointer
+  OSSL_ENCRYPTION_LEVEL* = enum
+    OSSL_ENCRYPTION_LEVEL_INITIAL = 0
+    OSSL_ENCRYPTION_LEVEL_EARLY_DATA = 1
+    OSSL_ENCRYPTION_LEVEL_HANDSHAKE = 2
+    OSSL_ENCRYPTION_LEVEL_APPLICATION = 3
+
+# ngtcp2_crypto_quictls error constants
+const
+  NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_X509_LOOKUP* = -10001
+  NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_CLIENT_HELLO_CB* = -10002
+
+# ngtcp2_crypto_quictls function bindings
+when not declared(ngtcp2_crypto_quictls_init):
+  proc ngtcp2_crypto_quictls_init*(): cint {.
+    cdecl, importc: "ngtcp2_crypto_quictls_init"
+  .}
+
+else:
+  static:
+    hint(
+      "Declaration of " & "ngtcp2_crypto_quictls_init" &
+        " already exists, not redeclaring"
+    )
+
+when not declared(ngtcp2_crypto_quictls_from_ossl_encryption_level):
+  proc ngtcp2_crypto_quictls_from_ossl_encryption_level*(
+    ossl_level: OSSL_ENCRYPTION_LEVEL
+  ): ngtcp2_encryption_level_553648745 {.
+    cdecl, importc: "ngtcp2_crypto_quictls_from_ossl_encryption_level"
+  .}
+
+else:
+  static:
+    hint(
+      "Declaration of " & "ngtcp2_crypto_quictls_from_ossl_encryption_level" &
+        " already exists, not redeclaring"
+    )
+
+when not declared(ngtcp2_crypto_quictls_from_ngtcp2_encryption_level):
+  proc ngtcp2_crypto_quictls_from_ngtcp2_encryption_level*(
+    encryption_level: ngtcp2_encryption_level_553648745
+  ): OSSL_ENCRYPTION_LEVEL {.
+    cdecl, importc: "ngtcp2_crypto_quictls_from_ngtcp2_encryption_level"
+  .}
+
+else:
+  static:
+    hint(
+      "Declaration of " & "ngtcp2_crypto_quictls_from_ngtcp2_encryption_level" &
+        " already exists, not redeclaring"
+    )
+
+when not declared(ngtcp2_crypto_quictls_configure_server_context):
+  proc ngtcp2_crypto_quictls_configure_server_context*(
+    ssl_ctx: SSL_CTX
+  ): cint {.cdecl, importc: "ngtcp2_crypto_quictls_configure_server_context".}
+
+else:
+  static:
+    hint(
+      "Declaration of " & "ngtcp2_crypto_quictls_configure_server_context" &
+        " already exists, not redeclaring"
+    )
+
+when not declared(ngtcp2_crypto_quictls_configure_client_context):
+  proc ngtcp2_crypto_quictls_configure_client_context*(
+    ssl_ctx: SSL_CTX
+  ): cint {.cdecl, importc: "ngtcp2_crypto_quictls_configure_client_context".}
+
+else:
+  static:
+    hint(
+      "Declaration of " & "ngtcp2_crypto_quictls_configure_client_context" &
+        " already exists, not redeclaring"
+    )

--- a/ngtcp2.nim
+++ b/ngtcp2.nim
@@ -34,6 +34,10 @@ const picotlsInclude       = root/"libs"/"picotls"/"include"
 {.passc: fmt"-I{ngtcp2LibIncludes}".}
 {.passc: fmt"-I{picotlsInclude}".}
 
+# QuicTLS/OpenSSL crypto support
+{.passc: "-DNGTCP2_CRYPTO_QUICTLS".}
+{.passc: "-I/usr/include/openssl".}
+
 {.compile: "./libs/picotls/picotlsvs/picotls/wintimeofday.c".}
 {.compile: "./libs/picotls/lib/pembase64.c".}
 {.compile: "./libs/picotls/lib/hpke.c".}
@@ -96,41 +100,41 @@ when not declared(ownSizeOf):
     newLit(x.getSize)
 
 type
-  enum_ngtcp2_pkt_type_536871390* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_pkt_type_553648605* {.size: sizeof(cuint).} = enum
     NGTCP2_PKT_INITIAL = 16, NGTCP2_PKT_0RTT = 17, NGTCP2_PKT_HANDSHAKE = 18,
     NGTCP2_PKT_RETRY = 19, NGTCP2_PKT_1RTT = 64,
     NGTCP2_PKT_VERSION_NEGOTIATION = 128, NGTCP2_PKT_STATELESS_RESET = 129
 type
-  enum_ngtcp2_path_validation_result_536871394* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_path_validation_result_553648609* {.size: sizeof(cuint).} = enum
     NGTCP2_PATH_VALIDATION_RESULT_SUCCESS = 0,
     NGTCP2_PATH_VALIDATION_RESULT_FAILURE = 1,
     NGTCP2_PATH_VALIDATION_RESULT_ABORTED = 2
 type
-  enum_ngtcp2_cc_algo_536871461* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_cc_algo_553648676* {.size: sizeof(cuint).} = enum
     NGTCP2_CC_ALGO_RENO = 0, NGTCP2_CC_ALGO_CUBIC = 1, NGTCP2_CC_ALGO_BBR = 2
 type
-  enum_ngtcp2_token_type_536871473* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_token_type_553648688* {.size: sizeof(cuint).} = enum
     NGTCP2_TOKEN_TYPE_UNKNOWN = 0, NGTCP2_TOKEN_TYPE_RETRY = 1,
     NGTCP2_TOKEN_TYPE_NEW_TOKEN = 2
 type
-  enum_ngtcp2_encryption_level_536871527* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_encryption_level_553648742* {.size: sizeof(cuint).} = enum
     NGTCP2_ENCRYPTION_LEVEL_INITIAL = 0, NGTCP2_ENCRYPTION_LEVEL_HANDSHAKE = 1,
     NGTCP2_ENCRYPTION_LEVEL_1RTT = 2, NGTCP2_ENCRYPTION_LEVEL_0RTT = 3
 type
-  enum_ngtcp2_connection_id_status_type_536871575* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_connection_id_status_type_553648790* {.size: sizeof(cuint).} = enum
     NGTCP2_CONNECTION_ID_STATUS_TYPE_ACTIVATE = 0,
     NGTCP2_CONNECTION_ID_STATUS_TYPE_DEACTIVATE = 1
 type
-  enum_ngtcp2_ccerr_type_536871611* {.size: sizeof(cuint).} = enum
+  enum_ngtcp2_ccerr_type_553648826* {.size: sizeof(cuint).} = enum
     NGTCP2_CCERR_TYPE_TRANSPORT = 0, NGTCP2_CCERR_TYPE_APPLICATION = 1,
     NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION = 2, NGTCP2_CCERR_TYPE_IDLE_CLOSE = 3,
     NGTCP2_CCERR_TYPE_DROP_CONN = 4, NGTCP2_CCERR_TYPE_RETRY = 5
 type
-  enum_en_ptls_hash_final_mode_t_536871675* {.size: sizeof(cuint).} = enum
+  enum_en_ptls_hash_final_mode_t_553648890* {.size: sizeof(cuint).} = enum
     PTLS_HASH_FINAL_MODE_FREE = 0, PTLS_HASH_FINAL_MODE_RESET = 1,
     PTLS_HASH_FINAL_MODE_SNAPSHOT = 2
 type
-  enum_en_ptls_early_data_acceptance_t_536871777* {.size: sizeof(cuint).} = enum
+  enum_en_ptls_early_data_acceptance_t_553648992* {.size: sizeof(cuint).} = enum
     PTLS_EARLY_DATA_ACCEPTANCE_UNKNOWN = 0, PTLS_EARLY_DATA_REJECTED = 1,
     PTLS_EARLY_DATA_ACCEPTED = 2
 when not declared(struct_st_ptls_t):
@@ -139,54 +143,6 @@ when not declared(struct_st_ptls_t):
 else:
   static :
     hint("Declaration of " & "struct_st_ptls_t" &
-        " already exists, not redeclaring")
-when not declared(UINT64_MAX):
-  type
-    UINT64_MAX* = object
-else:
-  static :
-    hint("Declaration of " & "UINT64_MAX" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_key_schedule_t):
-  type
-    struct_st_ptls_key_schedule_t* = object
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_key_schedule_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_conn):
-  type
-    struct_ngtcp2_conn* = object
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_conn" &
-        " already exists, not redeclaring")
-when not declared(struct_x509_store_st):
-  type
-    struct_x509_store_st* = object
-else:
-  static :
-    hint("Declaration of " & "struct_x509_store_st" &
-        " already exists, not redeclaring")
-when not declared(struct_x509_st):
-  type
-    struct_x509_st* = object
-else:
-  static :
-    hint("Declaration of " & "struct_x509_st" &
-        " already exists, not redeclaring")
-when not declared(struct_evp_md_st):
-  type
-    struct_evp_md_st* = object
-else:
-  static :
-    hint("Declaration of " & "struct_evp_md_st" &
-        " already exists, not redeclaring")
-when not declared(NGTCP2_PROTO_VER_V1):
-  type
-    NGTCP2_PROTO_VER_V1* = object
-else:
-  static :
-    hint("Declaration of " & "NGTCP2_PROTO_VER_V1" &
         " already exists, not redeclaring")
 when not declared(compiler_thread):
   type
@@ -202,20 +158,6 @@ else:
   static :
     hint("Declaration of " & "struct_evp_pkey_st" &
         " already exists, not redeclaring")
-when not declared(struct_evp_cipher_ctx_st):
-  type
-    struct_evp_cipher_ctx_st* = object
-else:
-  static :
-    hint("Declaration of " & "struct_evp_cipher_ctx_st" &
-        " already exists, not redeclaring")
-when not declared(struct_stack_st_X509):
-  type
-    struct_stack_st_X509* = object
-else:
-  static :
-    hint("Declaration of " & "struct_stack_st_X509" &
-        " already exists, not redeclaring")
 when not declared(struct_hmac_ctx_st):
   type
     struct_hmac_ctx_st* = object
@@ -223,12 +165,33 @@ else:
   static :
     hint("Declaration of " & "struct_hmac_ctx_st" &
         " already exists, not redeclaring")
-when not declared(struct_evp_mac_ctx_st):
+when not declared(struct_st_ptls_key_schedule_t):
   type
-    struct_evp_mac_ctx_st* = object
+    struct_st_ptls_key_schedule_t* = object
 else:
   static :
-    hint("Declaration of " & "struct_evp_mac_ctx_st" &
+    hint("Declaration of " & "struct_st_ptls_key_schedule_t" &
+        " already exists, not redeclaring")
+when not declared(struct_evp_cipher_ctx_st):
+  type
+    struct_evp_cipher_ctx_st* = object
+else:
+  static :
+    hint("Declaration of " & "struct_evp_cipher_ctx_st" &
+        " already exists, not redeclaring")
+when not declared(struct_x509_st):
+  type
+    struct_x509_st* = object
+else:
+  static :
+    hint("Declaration of " & "struct_x509_st" &
+        " already exists, not redeclaring")
+when not declared(struct_x509_store_st):
+  type
+    struct_x509_store_st* = object
+else:
+  static :
+    hint("Declaration of " & "struct_x509_store_st" &
         " already exists, not redeclaring")
 when not declared(struct_st_ptls_traffic_protection_t):
   type
@@ -237,40 +200,81 @@ else:
   static :
     hint("Declaration of " & "struct_st_ptls_traffic_protection_t" &
         " already exists, not redeclaring")
+when not declared(struct_evp_md_st):
+  type
+    struct_evp_md_st* = object
+else:
+  static :
+    hint("Declaration of " & "struct_evp_md_st" &
+        " already exists, not redeclaring")
+when not declared(struct_stack_st_X509):
+  type
+    struct_stack_st_X509* = object
+else:
+  static :
+    hint("Declaration of " & "struct_stack_st_X509" &
+        " already exists, not redeclaring")
+when not declared(NGTCP2_PROTO_VER_V1):
+  type
+    NGTCP2_PROTO_VER_V1* = object
+else:
+  static :
+    hint("Declaration of " & "NGTCP2_PROTO_VER_V1" &
+        " already exists, not redeclaring")
+when not declared(struct_evp_mac_ctx_st):
+  type
+    struct_evp_mac_ctx_st* = object
+else:
+  static :
+    hint("Declaration of " & "struct_evp_mac_ctx_st" &
+        " already exists, not redeclaring")
+when not declared(UINT64_MAX):
+  type
+    UINT64_MAX* = object
+else:
+  static :
+    hint("Declaration of " & "UINT64_MAX" & " already exists, not redeclaring")
+when not declared(struct_ngtcp2_conn):
+  type
+    struct_ngtcp2_conn* = object
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_conn" &
+        " already exists, not redeclaring")
 type
-  ngtcp2_ssize_536871370 = ptrdiff_t_536871373 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:98:19
-  ptrdiff_t_536871372 = clong ## Generated based on /usr/include/clang/18.1.3/include/__stddef_ptrdiff_t.h:18:26
-  ngtcp2_malloc_536871374 = proc (a0: csize_t; a1: pointer): pointer {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:107:17
-  ngtcp2_free_536871376 = proc (a0: pointer; a1: pointer): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:116:16
-  ngtcp2_calloc_536871378 = proc (a0: csize_t; a1: csize_t; a2: pointer): pointer {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:125:17
-  ngtcp2_realloc_536871380 = proc (a0: pointer; a1: csize_t; a2: pointer): pointer {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:134:17
-  struct_ngtcp2_mem_536871382 {.pure, inheritable, bycopy.} = object
-    user_data*: pointer      ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:180:16
-    malloc*: ngtcp2_malloc_536871375
-    free*: ngtcp2_free_536871377
-    calloc*: ngtcp2_calloc_536871379
-    realloc*: ngtcp2_realloc_536871381
-  ngtcp2_mem_536871384 = struct_ngtcp2_mem_536871383 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:206:3
-  struct_ngtcp2_pkt_info_536871386 {.pure, inheritable, bycopy.} = object
-    ecn* {.align(8'i64).}: uint8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:481:32
-  ngtcp2_pkt_info_536871388 = struct_ngtcp2_pkt_info_536871387 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:489:3
-  ngtcp2_pkt_type_536871392 = enum_ngtcp2_pkt_type_536871391 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:855:3
-  ngtcp2_path_validation_result_536871396 = enum_ngtcp2_path_validation_result_536871395 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1036:3
-  ngtcp2_tstamp_536871398 = uint64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1045:18
-  ngtcp2_duration_536871400 = uint64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1054:18
-  struct_ngtcp2_cid_536871402 {.pure, inheritable, bycopy.} = object
-    datalen*: csize_t        ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1061:16
+  ngtcp2_ssize_553648585 = ptrdiff_t_553648588 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:98:19
+  ptrdiff_t_553648587 = clong ## Generated based on /usr/include/clang/18.1.3/include/__stddef_ptrdiff_t.h:18:26
+  ngtcp2_malloc_553648589 = proc (a0: csize_t; a1: pointer): pointer {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:107:17
+  ngtcp2_free_553648591 = proc (a0: pointer; a1: pointer): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:116:16
+  ngtcp2_calloc_553648593 = proc (a0: csize_t; a1: csize_t; a2: pointer): pointer {.
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:125:17
+  ngtcp2_realloc_553648595 = proc (a0: pointer; a1: csize_t; a2: pointer): pointer {.
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:134:17
+  struct_ngtcp2_mem_553648597 {.pure, inheritable, bycopy.} = object
+    user_data*: pointer      ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:180:16
+    malloc*: ngtcp2_malloc_553648590
+    free*: ngtcp2_free_553648592
+    calloc*: ngtcp2_calloc_553648594
+    realloc*: ngtcp2_realloc_553648596
+  ngtcp2_mem_553648599 = struct_ngtcp2_mem_553648598 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:206:3
+  struct_ngtcp2_pkt_info_553648601 {.pure, inheritable, bycopy.} = object
+    ecn* {.align(8'i64).}: uint8 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:481:32
+  ngtcp2_pkt_info_553648603 = struct_ngtcp2_pkt_info_553648602 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:489:3
+  ngtcp2_pkt_type_553648607 = enum_ngtcp2_pkt_type_553648606 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:855:3
+  ngtcp2_path_validation_result_553648611 = enum_ngtcp2_path_validation_result_553648610 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1036:3
+  ngtcp2_tstamp_553648613 = uint64 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1045:18
+  ngtcp2_duration_553648615 = uint64 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1054:18
+  struct_ngtcp2_cid_553648617 {.pure, inheritable, bycopy.} = object
+    datalen*: csize_t        ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1061:16
     data*: array[20'i64, uint8]
-  ngtcp2_cid_536871404 = struct_ngtcp2_cid_536871403 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1070:3
-  struct_ngtcp2_vec_536871406 {.pure, inheritable, bycopy.} = object
-    base*: ptr uint8         ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1078:16
+  ngtcp2_cid_553648619 = struct_ngtcp2_cid_553648618 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1070:3
+  struct_ngtcp2_vec_553648621 {.pure, inheritable, bycopy.} = object
+    base*: ptr uint8         ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1078:16
     len*: csize_t
-  ngtcp2_vec_536871408 = struct_ngtcp2_vec_536871407 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1088:3
-  struct_ngtcp2_pkt_hd_536871410 {.pure, inheritable, bycopy.} = object
-    dcid*: ngtcp2_cid_536871405 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1113:16
-    scid*: ngtcp2_cid_536871405
+  ngtcp2_vec_553648623 = struct_ngtcp2_vec_553648622 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1088:3
+  struct_ngtcp2_pkt_hd_553648625 {.pure, inheritable, bycopy.} = object
+    dcid*: ngtcp2_cid_553648620 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1113:16
+    scid*: ngtcp2_cid_553648620
     pkt_num*: int64
     token*: ptr uint8
     tokenlen*: csize_t
@@ -279,65 +283,65 @@ type
     version*: uint32
     type_field*: uint8
     flags*: uint8
-  ngtcp2_pkt_hd_536871412 = struct_ngtcp2_pkt_hd_536871411 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1162:3
-  struct_ngtcp2_pkt_stateless_reset_536871414 {.pure, inheritable, bycopy.} = object
-    stateless_reset_token*: array[16'i64, uint8] ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1169:16
+  ngtcp2_pkt_hd_553648627 = struct_ngtcp2_pkt_hd_553648626 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1162:3
+  struct_ngtcp2_pkt_stateless_reset_553648629 {.pure, inheritable, bycopy.} = object
+    stateless_reset_token*: array[16'i64, uint8] ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1169:16
     rand*: ptr uint8
     randlen*: csize_t
-  ngtcp2_pkt_stateless_reset_536871416 = struct_ngtcp2_pkt_stateless_reset_536871415 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1183:3
-  ngtcp2_sockaddr_536871418 = struct_sockaddr_536871421 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1285:25
-  struct_sockaddr_536871420 {.pure, inheritable, bycopy.} = object
-    sa_family*: sa_family_t_536871842 ## Generated based on /usr/include/x86_64-linux-gnu/bits/socket.h:183:8
+  ngtcp2_pkt_stateless_reset_553648631 = struct_ngtcp2_pkt_stateless_reset_553648630 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1183:3
+  ngtcp2_sockaddr_553648633 = struct_sockaddr_553648636 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1285:25
+  struct_sockaddr_553648635 {.pure, inheritable, bycopy.} = object
+    sa_family*: sa_family_t_553649057 ## Generated based on /usr/include/x86_64-linux-gnu/bits/socket.h:183:8
     sa_data*: array[14'i64, cschar]
-  ngtcp2_sockaddr_in_536871422 = struct_sockaddr_in_536871425 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1293:28
-  struct_sockaddr_in_536871424 {.pure, inheritable, bycopy.} = object
-    sin_family*: sa_family_t_536871842 ## Generated based on /usr/include/netinet/in.h:247:8
-    sin_port*: in_port_t_536871844
-    sin_addr*: struct_in_addr_536871798
+  ngtcp2_sockaddr_in_553648637 = struct_sockaddr_in_553648640 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1293:28
+  struct_sockaddr_in_553648639 {.pure, inheritable, bycopy.} = object
+    sin_family*: sa_family_t_553649057 ## Generated based on /usr/include/netinet/in.h:247:8
+    sin_port*: in_port_t_553649059
+    sin_addr*: struct_in_addr_553649013
     sin_zero*: array[8'i64, uint8]
-  ngtcp2_sockaddr_in6_536871426 = struct_sockaddr_in6_536871429 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1301:29
-  struct_sockaddr_in6_536871428 {.pure, inheritable, bycopy.} = object
-    sin6_family*: sa_family_t_536871842 ## Generated based on /usr/include/netinet/in.h:262:8
-    sin6_port*: in_port_t_536871844
+  ngtcp2_sockaddr_in6_553648641 = struct_sockaddr_in6_553648644 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1301:29
+  struct_sockaddr_in6_553648643 {.pure, inheritable, bycopy.} = object
+    sin6_family*: sa_family_t_553649057 ## Generated based on /usr/include/netinet/in.h:262:8
+    sin6_port*: in_port_t_553649059
     sin6_flowinfo*: uint32
-    sin6_addr*: struct_in6_addr_536871792
+    sin6_addr*: struct_in6_addr_553649007
     sin6_scope_id*: uint32
-  ngtcp2_socklen_536871430 = socklen_t_536871433 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1309:19
-  socklen_t_536871432 = compiler_socklen_t_536871846 ## Generated based on /usr/include/x86_64-linux-gnu/bits/socket.h:33:21
-  union_ngtcp2_sockaddr_union_536871434 {.union, bycopy.} = object
-    sa*: ngtcp2_sockaddr_536871419 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1318:15
-    in_field*: ngtcp2_sockaddr_in_536871423
-    in6*: ngtcp2_sockaddr_in6_536871427
-  ngtcp2_sockaddr_union_536871436 = union_ngtcp2_sockaddr_union_536871435 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1322:3
-  struct_ngtcp2_preferred_addr_536871438 {.pure, inheritable, bycopy.} = object
-    cid*: ngtcp2_cid_536871405 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1330:16
-    ipv4*: ngtcp2_sockaddr_in_536871423
-    ipv6*: ngtcp2_sockaddr_in6_536871427
+  ngtcp2_socklen_553648645 = socklen_t_553648648 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1309:19
+  socklen_t_553648647 = compiler_socklen_t_553649061 ## Generated based on /usr/include/x86_64-linux-gnu/bits/socket.h:33:21
+  union_ngtcp2_sockaddr_union_553648649 {.union, bycopy.} = object
+    sa*: ngtcp2_sockaddr_553648634 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1318:15
+    in_field*: ngtcp2_sockaddr_in_553648638
+    in6*: ngtcp2_sockaddr_in6_553648642
+  ngtcp2_sockaddr_union_553648651 = union_ngtcp2_sockaddr_union_553648650 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1322:3
+  struct_ngtcp2_preferred_addr_553648653 {.pure, inheritable, bycopy.} = object
+    cid*: ngtcp2_cid_553648620 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1330:16
+    ipv4*: ngtcp2_sockaddr_in_553648638
+    ipv6*: ngtcp2_sockaddr_in6_553648642
     ipv4_present*: uint8
     ipv6_present*: uint8
     stateless_reset_token*: array[16'i64, uint8]
-  ngtcp2_preferred_addr_536871440 = struct_ngtcp2_preferred_addr_536871439 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1357:3
-  struct_ngtcp2_version_info_536871442 {.pure, inheritable, bycopy.} = object
-    chosen_version*: uint32  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1365:16
+  ngtcp2_preferred_addr_553648655 = struct_ngtcp2_preferred_addr_553648654 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1357:3
+  struct_ngtcp2_version_info_553648657 {.pure, inheritable, bycopy.} = object
+    chosen_version*: uint32  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1365:16
     available_versions*: ptr uint8
     available_versionslen*: csize_t
-  ngtcp2_version_info_536871444 = struct_ngtcp2_version_info_536871443 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1382:3
-  struct_ngtcp2_transport_params_536871446 {.pure, inheritable, bycopy.} = object
-    preferred_addr*: ngtcp2_preferred_addr_536871441 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1393:16
-    original_dcid*: ngtcp2_cid_536871405
-    initial_scid*: ngtcp2_cid_536871405
-    retry_scid*: ngtcp2_cid_536871405
+  ngtcp2_version_info_553648659 = struct_ngtcp2_version_info_553648658 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1382:3
+  struct_ngtcp2_transport_params_553648661 {.pure, inheritable, bycopy.} = object
+    preferred_addr*: ngtcp2_preferred_addr_553648656 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1393:16
+    original_dcid*: ngtcp2_cid_553648620
+    initial_scid*: ngtcp2_cid_553648620
+    retry_scid*: ngtcp2_cid_553648620
     initial_max_stream_data_bidi_local*: uint64
     initial_max_stream_data_bidi_remote*: uint64
     initial_max_stream_data_uni*: uint64
     initial_max_data*: uint64
     initial_max_streams_bidi*: uint64
     initial_max_streams_uni*: uint64
-    max_idle_timeout*: ngtcp2_duration_536871401
+    max_idle_timeout*: ngtcp2_duration_553648616
     max_udp_payload_size*: uint64
     active_connection_id_limit*: uint64
     ack_delay_exponent*: uint64
-    max_ack_delay*: ngtcp2_duration_536871401
+    max_ack_delay*: ngtcp2_duration_553648616
     max_datagram_frame_size*: uint64
     stateless_reset_token_present*: uint8
     disable_active_migration*: uint8
@@ -347,43 +351,43 @@ type
     preferred_addr_present*: uint8
     stateless_reset_token*: array[16'i64, uint8]
     grease_quic_bit*: uint8
-    version_info*: ngtcp2_version_info_536871445
+    version_info*: ngtcp2_version_info_553648660
     version_info_present*: uint8
-  ngtcp2_transport_params_536871448 = struct_ngtcp2_transport_params_536871447 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1553:3
-  struct_ngtcp2_conn_info_536871450 {.pure, inheritable, bycopy.} = object
-    latest_rtt*: ngtcp2_duration_536871401 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1563:16
-    min_rtt*: ngtcp2_duration_536871401
-    smoothed_rtt*: ngtcp2_duration_536871401
-    rttvar*: ngtcp2_duration_536871401
+  ngtcp2_transport_params_553648663 = struct_ngtcp2_transport_params_553648662 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1553:3
+  struct_ngtcp2_conn_info_553648665 {.pure, inheritable, bycopy.} = object
+    latest_rtt*: ngtcp2_duration_553648616 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1563:16
+    min_rtt*: ngtcp2_duration_553648616
+    smoothed_rtt*: ngtcp2_duration_553648616
+    rttvar*: ngtcp2_duration_553648616
     cwnd*: uint64
     ssthresh*: uint64
     bytes_in_flight*: uint64
-  ngtcp2_conn_info_536871459 = struct_ngtcp2_conn_info_536871451 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1595:3
-  ngtcp2_cc_algo_536871463 = enum_ngtcp2_cc_algo_536871462 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1615:3
-  ngtcp2_printf_536871465 = proc (a0: pointer; a1: cstring): void {.cdecl,
-      varargs.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1624:16
-  struct_ngtcp2_rand_ctx_536871467 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1654:16
-  ngtcp2_rand_ctx_536871469 = struct_ngtcp2_rand_ctx_536871468 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1660:3
-  ngtcp2_qlog_write_536871471 = proc (a0: pointer; a1: uint32; a2: pointer;
-                                      a3: csize_t): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1671:16
-  ngtcp2_token_type_536871475 = enum_ngtcp2_token_type_536871474 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1695:3
-  struct_ngtcp2_settings_536871477 {.pure, inheritable, bycopy.} = object
-    qlog_write*: ngtcp2_qlog_write_536871472 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1706:16
-    cc_algo*: ngtcp2_cc_algo_536871464
-    initial_ts*: ngtcp2_tstamp_536871399
-    initial_rtt*: ngtcp2_duration_536871401
-    log_printf*: ngtcp2_printf_536871466
+  ngtcp2_conn_info_553648667 = struct_ngtcp2_conn_info_553648666 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1595:3
+  ngtcp2_cc_algo_553648678 = enum_ngtcp2_cc_algo_553648677 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1615:3
+  ngtcp2_printf_553648680 = proc (a0: pointer; a1: cstring): void {.cdecl,
+      varargs.}              ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1624:16
+  struct_ngtcp2_rand_ctx_553648682 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1654:16
+  ngtcp2_rand_ctx_553648684 = struct_ngtcp2_rand_ctx_553648683 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1660:3
+  ngtcp2_qlog_write_553648686 = proc (a0: pointer; a1: uint32; a2: pointer;
+                                      a3: csize_t): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1671:16
+  ngtcp2_token_type_553648690 = enum_ngtcp2_token_type_553648689 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1695:3
+  struct_ngtcp2_settings_553648692 {.pure, inheritable, bycopy.} = object
+    qlog_write*: ngtcp2_qlog_write_553648687 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1706:16
+    cc_algo*: ngtcp2_cc_algo_553648679
+    initial_ts*: ngtcp2_tstamp_553648614
+    initial_rtt*: ngtcp2_duration_553648616
+    log_printf*: ngtcp2_printf_553648681
     max_tx_udp_payload_size*: csize_t
     token*: ptr uint8
     tokenlen*: csize_t
-    token_type*: ngtcp2_token_type_536871476
-    rand_ctx*: ngtcp2_rand_ctx_536871470
+    token_type*: ngtcp2_token_type_553648691
+    rand_ctx*: ngtcp2_rand_ctx_553648685
     max_window*: uint64
     max_stream_window*: uint64
     ack_thresh*: csize_t
     no_tx_udp_payload_size_shaping*: uint8
-    handshake_timeout*: ngtcp2_duration_536871401
+    handshake_timeout*: ngtcp2_duration_553648616
     preferred_versions*: ptr uint32
     preferred_versionslen*: csize_t
     available_versions*: ptr uint32
@@ -393,233 +397,233 @@ type
     initial_pkt_num*: uint32
     pmtud_probes*: ptr uint16
     pmtud_probeslen*: csize_t
-  ngtcp2_settings_536871479 = struct_ngtcp2_settings_536871478 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1912:3
-  struct_ngtcp2_addr_536871481 {.pure, inheritable, bycopy.} = object
-    addr_field*: ptr ngtcp2_sockaddr_536871419 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1919:16
-    addrlen*: ngtcp2_socklen_536871431
-  ngtcp2_addr_536871483 = struct_ngtcp2_addr_536871482 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1930:3
-  struct_ngtcp2_path_536871485 {.pure, inheritable, bycopy.} = object
-    local*: ngtcp2_addr_536871484 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1938:16
-    remote*: ngtcp2_addr_536871484
+  ngtcp2_settings_553648694 = struct_ngtcp2_settings_553648693 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1912:3
+  struct_ngtcp2_addr_553648696 {.pure, inheritable, bycopy.} = object
+    addr_field*: ptr ngtcp2_sockaddr_553648634 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1919:16
+    addrlen*: ngtcp2_socklen_553648646
+  ngtcp2_addr_553648698 = struct_ngtcp2_addr_553648697 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1930:3
+  struct_ngtcp2_path_553648700 {.pure, inheritable, bycopy.} = object
+    local*: ngtcp2_addr_553648699 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1938:16
+    remote*: ngtcp2_addr_553648699
     user_data*: pointer
-  ngtcp2_path_536871487 = struct_ngtcp2_path_536871486 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1962:3
-  struct_ngtcp2_path_storage_536871489 {.pure, inheritable, bycopy.} = object
-    path*: ngtcp2_path_536871488 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1970:16
-    local_addrbuf*: ngtcp2_sockaddr_union_536871437
-    remote_addrbuf*: ngtcp2_sockaddr_union_536871437
-  ngtcp2_path_storage_536871491 = struct_ngtcp2_path_storage_536871490 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1983:3
-  struct_ngtcp2_crypto_md_536871493 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1991:16
-  ngtcp2_crypto_md_536871495 = struct_ngtcp2_crypto_md_536871494 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1997:3
-  struct_ngtcp2_crypto_aead_536871497 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2004:16
+  ngtcp2_path_553648702 = struct_ngtcp2_path_553648701 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1962:3
+  struct_ngtcp2_path_storage_553648704 {.pure, inheritable, bycopy.} = object
+    path*: ngtcp2_path_553648703 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1970:16
+    local_addrbuf*: ngtcp2_sockaddr_union_553648652
+    remote_addrbuf*: ngtcp2_sockaddr_union_553648652
+  ngtcp2_path_storage_553648706 = struct_ngtcp2_path_storage_553648705 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1983:3
+  struct_ngtcp2_crypto_md_553648708 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1991:16
+  ngtcp2_crypto_md_553648710 = struct_ngtcp2_crypto_md_553648709 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1997:3
+  struct_ngtcp2_crypto_aead_553648712 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2004:16
     max_overhead*: csize_t
-  ngtcp2_crypto_aead_536871499 = struct_ngtcp2_crypto_aead_536871498 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2015:3
-  struct_ngtcp2_crypto_cipher_536871501 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2023:16
-  ngtcp2_crypto_cipher_536871503 = struct_ngtcp2_crypto_cipher_536871502 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2029:3
-  struct_ngtcp2_crypto_aead_ctx_536871505 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2039:16
-  ngtcp2_crypto_aead_ctx_536871507 = struct_ngtcp2_crypto_aead_ctx_536871506 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2045:3
-  struct_ngtcp2_crypto_cipher_ctx_536871509 {.pure, inheritable, bycopy.} = object
-    native_handle*: pointer  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2055:16
-  ngtcp2_crypto_cipher_ctx_536871511 = struct_ngtcp2_crypto_cipher_ctx_536871510 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2061:3
-  struct_ngtcp2_crypto_ctx_536871513 {.pure, inheritable, bycopy.} = object
-    aead*: ngtcp2_crypto_aead_536871500 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2073:16
-    md*: ngtcp2_crypto_md_536871496
-    hp*: ngtcp2_crypto_cipher_536871504
+  ngtcp2_crypto_aead_553648714 = struct_ngtcp2_crypto_aead_553648713 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2015:3
+  struct_ngtcp2_crypto_cipher_553648716 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2023:16
+  ngtcp2_crypto_cipher_553648718 = struct_ngtcp2_crypto_cipher_553648717 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2029:3
+  struct_ngtcp2_crypto_aead_ctx_553648720 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2039:16
+  ngtcp2_crypto_aead_ctx_553648722 = struct_ngtcp2_crypto_aead_ctx_553648721 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2045:3
+  struct_ngtcp2_crypto_cipher_ctx_553648724 {.pure, inheritable, bycopy.} = object
+    native_handle*: pointer  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2055:16
+  ngtcp2_crypto_cipher_ctx_553648726 = struct_ngtcp2_crypto_cipher_ctx_553648725 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2061:3
+  struct_ngtcp2_crypto_ctx_553648728 {.pure, inheritable, bycopy.} = object
+    aead*: ngtcp2_crypto_aead_553648715 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2073:16
+    md*: ngtcp2_crypto_md_553648711
+    hp*: ngtcp2_crypto_cipher_553648719
     max_encryption*: uint64
     max_decryption_failure*: uint64
-  ngtcp2_crypto_ctx_536871515 = struct_ngtcp2_crypto_ctx_536871514 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2096:3
-  struct_ngtcp2_version_cid_536871517 {.pure, inheritable, bycopy.} = object
-    version*: uint32         ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2198:16
+  ngtcp2_crypto_ctx_553648730 = struct_ngtcp2_crypto_ctx_553648729 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2096:3
+  struct_ngtcp2_version_cid_553648732 {.pure, inheritable, bycopy.} = object
+    version*: uint32         ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2198:16
     dcid*: ptr uint8
     dcidlen*: csize_t
     scid*: ptr uint8
     scidlen*: csize_t
-  ngtcp2_version_cid_536871519 = struct_ngtcp2_version_cid_536871518 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2221:3
-  ngtcp2_conn_536871521 = struct_ngtcp2_conn ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2391:28
-  ngtcp2_client_initial_536871523 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2411:15
-  ngtcp2_recv_client_initial_536871525 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_cid_536871405; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2428:15
-  ngtcp2_encryption_level_536871529 = enum_ngtcp2_encryption_level_536871528 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2456:3
-  ngtcp2_recv_crypto_data_536871531 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ngtcp2_encryption_level_536871530; a2: uint64; a3: ptr uint8;
-      a4: csize_t; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2493:15
-  ngtcp2_handshake_completed_536871533 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2508:15
-  ngtcp2_handshake_confirmed_536871535 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2521:15
-  ngtcp2_recv_version_negotiation_536871537 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_pkt_hd_536871413; a2: ptr uint32; a3: csize_t; a4: pointer): cint {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2536:15
-  ngtcp2_recv_retry_536871539 = proc (a0: ptr ngtcp2_conn_536871522;
-                                      a1: ptr ngtcp2_pkt_hd_536871413;
-                                      a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2559:15
-  ngtcp2_encrypt_536871541 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_aead_536871500;
-                                   a2: ptr ngtcp2_crypto_aead_ctx_536871508;
+  ngtcp2_version_cid_553648734 = struct_ngtcp2_version_cid_553648733 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2221:3
+  ngtcp2_conn_553648736 = struct_ngtcp2_conn ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2391:28
+  ngtcp2_client_initial_553648738 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2411:15
+  ngtcp2_recv_client_initial_553648740 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_cid_553648620; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2428:15
+  ngtcp2_encryption_level_553648744 = enum_ngtcp2_encryption_level_553648743 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2456:3
+  ngtcp2_recv_crypto_data_553648746 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ngtcp2_encryption_level_553648745; a2: uint64; a3: ptr uint8;
+      a4: csize_t; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2493:15
+  ngtcp2_handshake_completed_553648748 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2508:15
+  ngtcp2_handshake_confirmed_553648750 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2521:15
+  ngtcp2_recv_version_negotiation_553648752 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_pkt_hd_553648628; a2: ptr uint32; a3: csize_t; a4: pointer): cint {.
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2536:15
+  ngtcp2_recv_retry_553648754 = proc (a0: ptr ngtcp2_conn_553648737;
+                                      a1: ptr ngtcp2_pkt_hd_553648628;
+                                      a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2559:15
+  ngtcp2_encrypt_553648756 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_aead_553648715;
+                                   a2: ptr ngtcp2_crypto_aead_ctx_553648723;
                                    a3: ptr uint8; a4: csize_t; a5: ptr uint8;
                                    a6: csize_t; a7: ptr uint8; a8: csize_t): cint {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2584:15
-  ngtcp2_decrypt_536871543 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_aead_536871500;
-                                   a2: ptr ngtcp2_crypto_aead_ctx_536871508;
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2584:15
+  ngtcp2_decrypt_553648758 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_aead_553648715;
+                                   a2: ptr ngtcp2_crypto_aead_ctx_553648723;
                                    a3: ptr uint8; a4: csize_t; a5: ptr uint8;
                                    a6: csize_t; a7: ptr uint8; a8: csize_t): cint {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2613:15
-  ngtcp2_hp_mask_536871545 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_cipher_536871504;
-                                   a2: ptr ngtcp2_crypto_cipher_ctx_536871512;
-                                   a3: ptr uint8): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2642:15
-  ngtcp2_recv_stream_data_536871547 = proc (a0: ptr ngtcp2_conn_536871522;
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2613:15
+  ngtcp2_hp_mask_553648760 = proc (a0: ptr uint8; a1: ptr ngtcp2_crypto_cipher_553648719;
+                                   a2: ptr ngtcp2_crypto_cipher_ctx_553648727;
+                                   a3: ptr uint8): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2642:15
+  ngtcp2_recv_stream_data_553648762 = proc (a0: ptr ngtcp2_conn_553648737;
       a1: uint32; a2: int64; a3: uint64; a4: ptr uint8; a5: csize_t;
-      a6: pointer; a7: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2698:15
-  ngtcp2_stream_open_536871549 = proc (a0: ptr ngtcp2_conn_536871522; a1: int64;
-                                       a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2715:15
-  ngtcp2_stream_close_536871551 = proc (a0: ptr ngtcp2_conn_536871522;
+      a6: pointer; a7: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2698:15
+  ngtcp2_stream_open_553648764 = proc (a0: ptr ngtcp2_conn_553648737; a1: int64;
+                                       a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2715:15
+  ngtcp2_stream_close_553648766 = proc (a0: ptr ngtcp2_conn_553648737;
                                         a1: uint32; a2: int64; a3: uint64;
-                                        a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2764:15
-  ngtcp2_stream_reset_536871553 = proc (a0: ptr ngtcp2_conn_536871522;
+                                        a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2764:15
+  ngtcp2_stream_reset_553648768 = proc (a0: ptr ngtcp2_conn_553648737;
                                         a1: int64; a2: uint64; a3: uint64;
-                                        a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2778:15
-  ngtcp2_acked_stream_data_offset_536871555 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: int64; a2: uint64; a3: uint64; a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2804:15
-  ngtcp2_recv_stateless_reset_536871557 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_pkt_stateless_reset_536871417; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2819:15
-  ngtcp2_extend_max_streams_536871559 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2835:15
-  ngtcp2_extend_max_stream_data_536871561 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: int64; a2: uint64; a3: pointer; a4: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2850:15
-  ngtcp2_rand_536871563 = proc (a0: ptr uint8; a1: csize_t;
-                                a2: ptr ngtcp2_rand_ctx_536871470): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2863:16
-  ngtcp2_get_new_connection_id_536871565 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_cid_536871405; a2: ptr uint8; a3: csize_t; a4: pointer): cint {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2882:15
-  ngtcp2_remove_connection_id_536871567 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_cid_536871405; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2899:15
-  ngtcp2_update_key_536871569 = proc (a0: ptr ngtcp2_conn_536871522;
+                                        a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2778:15
+  ngtcp2_acked_stream_data_offset_553648770 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: int64; a2: uint64; a3: uint64; a4: pointer; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2804:15
+  ngtcp2_recv_stateless_reset_553648772 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_pkt_stateless_reset_553648632; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2819:15
+  ngtcp2_extend_max_streams_553648774 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2835:15
+  ngtcp2_extend_max_stream_data_553648776 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: int64; a2: uint64; a3: pointer; a4: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2850:15
+  ngtcp2_rand_553648778 = proc (a0: ptr uint8; a1: csize_t;
+                                a2: ptr ngtcp2_rand_ctx_553648685): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2863:16
+  ngtcp2_get_new_connection_id_553648780 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_cid_553648620; a2: ptr uint8; a3: csize_t; a4: pointer): cint {.
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2882:15
+  ngtcp2_remove_connection_id_553648782 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_cid_553648620; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2899:15
+  ngtcp2_update_key_553648784 = proc (a0: ptr ngtcp2_conn_553648737;
                                       a1: ptr uint8; a2: ptr uint8;
-                                      a3: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                      a3: ptr ngtcp2_crypto_aead_ctx_553648723;
                                       a4: ptr uint8;
-                                      a5: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                      a5: ptr ngtcp2_crypto_aead_ctx_553648723;
                                       a6: ptr uint8; a7: ptr uint8;
                                       a8: ptr uint8; a9: csize_t; a10: pointer): cint {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2927:15
-  ngtcp2_path_validation_536871571 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: uint32; a2: ptr ngtcp2_path_536871488; a3: ptr ngtcp2_path_536871488;
-      a4: ngtcp2_path_validation_result_536871397; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2984:15
-  ngtcp2_select_preferred_addr_536871573 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_path_536871488; a2: ptr ngtcp2_preferred_addr_536871441;
-      a3: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3016:15
-  ngtcp2_connection_id_status_type_536871577 = enum_ngtcp2_connection_id_status_type_536871576 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3039:3
-  ngtcp2_connection_id_status_536871579 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ngtcp2_connection_id_status_type_536871578; a2: uint64;
-      a3: ptr ngtcp2_cid_536871405; a4: ptr uint8; a5: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3058:15
-  ngtcp2_recv_new_token_536871581 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr uint8; a2: csize_t; a3: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3075:15
-  ngtcp2_delete_crypto_aead_ctx_536871583 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_crypto_aead_ctx_536871508; a2: pointer): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3086:16
-  ngtcp2_delete_crypto_cipher_ctx_536871585 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr ngtcp2_crypto_cipher_ctx_536871512; a2: pointer): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3098:16
-  ngtcp2_recv_datagram_536871587 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: uint32; a2: ptr uint8; a3: csize_t; a4: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3138:15
-  ngtcp2_ack_datagram_536871589 = proc (a0: ptr ngtcp2_conn_536871522;
-                                        a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3153:15
-  ngtcp2_lost_datagram_536871591 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3169:15
-  ngtcp2_get_path_challenge_data_536871593 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: ptr uint8; a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3185:15
-  ngtcp2_stream_stop_sending_536871595 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: int64; a2: uint64; a3: pointer; a4: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3201:15
-  ngtcp2_version_negotiation_536871597 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: uint32; a2: ptr ngtcp2_cid_536871405; a3: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3224:15
-  ngtcp2_recv_key_536871599 = proc (a0: ptr ngtcp2_conn_536871522;
-                                    a1: ngtcp2_encryption_level_536871530;
-                                    a2: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3238:15
-  ngtcp2_tls_early_data_rejected_536871601 = proc (a0: ptr ngtcp2_conn_536871522;
-      a1: pointer): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3252:15
-  struct_ngtcp2_callbacks_536871603 {.pure, inheritable, bycopy.} = object
-    client_initial*: ngtcp2_client_initial_536871524 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3263:16
-    recv_client_initial*: ngtcp2_recv_client_initial_536871526
-    recv_crypto_data*: ngtcp2_recv_crypto_data_536871532
-    handshake_completed*: ngtcp2_handshake_completed_536871534
-    recv_version_negotiation*: ngtcp2_recv_version_negotiation_536871538
-    encrypt*: ngtcp2_encrypt_536871542
-    decrypt*: ngtcp2_decrypt_536871544
-    hp_mask*: ngtcp2_hp_mask_536871546
-    recv_stream_data*: ngtcp2_recv_stream_data_536871548
-    acked_stream_data_offset*: ngtcp2_acked_stream_data_offset_536871556
-    stream_open*: ngtcp2_stream_open_536871550
-    stream_close*: ngtcp2_stream_close_536871552
-    recv_stateless_reset*: ngtcp2_recv_stateless_reset_536871558
-    recv_retry*: ngtcp2_recv_retry_536871540
-    extend_max_local_streams_bidi*: ngtcp2_extend_max_streams_536871560
-    extend_max_local_streams_uni*: ngtcp2_extend_max_streams_536871560
-    rand*: ngtcp2_rand_536871564
-    get_new_connection_id*: ngtcp2_get_new_connection_id_536871566
-    remove_connection_id*: ngtcp2_remove_connection_id_536871568
-    update_key*: ngtcp2_update_key_536871570
-    path_validation*: ngtcp2_path_validation_536871572
-    select_preferred_addr*: ngtcp2_select_preferred_addr_536871574
-    stream_reset*: ngtcp2_stream_reset_536871554
-    extend_max_remote_streams_bidi*: ngtcp2_extend_max_streams_536871560
-    extend_max_remote_streams_uni*: ngtcp2_extend_max_streams_536871560
-    extend_max_stream_data*: ngtcp2_extend_max_stream_data_536871562
-    dcid_status*: ngtcp2_connection_id_status_536871580
-    handshake_confirmed*: ngtcp2_handshake_confirmed_536871536
-    recv_new_token*: ngtcp2_recv_new_token_536871582
-    delete_crypto_aead_ctx*: ngtcp2_delete_crypto_aead_ctx_536871584
-    delete_crypto_cipher_ctx*: ngtcp2_delete_crypto_cipher_ctx_536871586
-    recv_datagram*: ngtcp2_recv_datagram_536871588
-    ack_datagram*: ngtcp2_ack_datagram_536871590
-    lost_datagram*: ngtcp2_lost_datagram_536871592
-    get_path_challenge_data*: ngtcp2_get_path_challenge_data_536871594
-    stream_stop_sending*: ngtcp2_stream_stop_sending_536871596
-    version_negotiation*: ngtcp2_version_negotiation_536871598
-    recv_rx_key*: ngtcp2_recv_key_536871600
-    recv_tx_key*: ngtcp2_recv_key_536871600
-    tls_early_data_rejected*: ngtcp2_tls_early_data_rejected_536871602
-  ngtcp2_callbacks_536871605 = struct_ngtcp2_callbacks_536871604 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3521:3
-  struct_ngtcp2_cid_token_536871607 {.pure, inheritable, bycopy.} = object
-    seq*: uint64             ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4820:16
-    cid*: ngtcp2_cid_536871405
-    ps*: ngtcp2_path_storage_536871492
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2927:15
+  ngtcp2_path_validation_553648786 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: uint32; a2: ptr ngtcp2_path_553648703; a3: ptr ngtcp2_path_553648703;
+      a4: ngtcp2_path_validation_result_553648612; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2984:15
+  ngtcp2_select_preferred_addr_553648788 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_path_553648703; a2: ptr ngtcp2_preferred_addr_553648656;
+      a3: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3016:15
+  ngtcp2_connection_id_status_type_553648792 = enum_ngtcp2_connection_id_status_type_553648791 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3039:3
+  ngtcp2_connection_id_status_553648794 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ngtcp2_connection_id_status_type_553648793; a2: uint64;
+      a3: ptr ngtcp2_cid_553648620; a4: ptr uint8; a5: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3058:15
+  ngtcp2_recv_new_token_553648796 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr uint8; a2: csize_t; a3: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3075:15
+  ngtcp2_delete_crypto_aead_ctx_553648798 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_crypto_aead_ctx_553648723; a2: pointer): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3086:16
+  ngtcp2_delete_crypto_cipher_ctx_553648800 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr ngtcp2_crypto_cipher_ctx_553648727; a2: pointer): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3098:16
+  ngtcp2_recv_datagram_553648802 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: uint32; a2: ptr uint8; a3: csize_t; a4: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3138:15
+  ngtcp2_ack_datagram_553648804 = proc (a0: ptr ngtcp2_conn_553648737;
+                                        a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3153:15
+  ngtcp2_lost_datagram_553648806 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: uint64; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3169:15
+  ngtcp2_get_path_challenge_data_553648808 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: ptr uint8; a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3185:15
+  ngtcp2_stream_stop_sending_553648810 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: int64; a2: uint64; a3: pointer; a4: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3201:15
+  ngtcp2_version_negotiation_553648812 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: uint32; a2: ptr ngtcp2_cid_553648620; a3: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3224:15
+  ngtcp2_recv_key_553648814 = proc (a0: ptr ngtcp2_conn_553648737;
+                                    a1: ngtcp2_encryption_level_553648745;
+                                    a2: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3238:15
+  ngtcp2_tls_early_data_rejected_553648816 = proc (a0: ptr ngtcp2_conn_553648737;
+      a1: pointer): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3252:15
+  struct_ngtcp2_callbacks_553648818 {.pure, inheritable, bycopy.} = object
+    client_initial*: ngtcp2_client_initial_553648739 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3263:16
+    recv_client_initial*: ngtcp2_recv_client_initial_553648741
+    recv_crypto_data*: ngtcp2_recv_crypto_data_553648747
+    handshake_completed*: ngtcp2_handshake_completed_553648749
+    recv_version_negotiation*: ngtcp2_recv_version_negotiation_553648753
+    encrypt*: ngtcp2_encrypt_553648757
+    decrypt*: ngtcp2_decrypt_553648759
+    hp_mask*: ngtcp2_hp_mask_553648761
+    recv_stream_data*: ngtcp2_recv_stream_data_553648763
+    acked_stream_data_offset*: ngtcp2_acked_stream_data_offset_553648771
+    stream_open*: ngtcp2_stream_open_553648765
+    stream_close*: ngtcp2_stream_close_553648767
+    recv_stateless_reset*: ngtcp2_recv_stateless_reset_553648773
+    recv_retry*: ngtcp2_recv_retry_553648755
+    extend_max_local_streams_bidi*: ngtcp2_extend_max_streams_553648775
+    extend_max_local_streams_uni*: ngtcp2_extend_max_streams_553648775
+    rand*: ngtcp2_rand_553648779
+    get_new_connection_id*: ngtcp2_get_new_connection_id_553648781
+    remove_connection_id*: ngtcp2_remove_connection_id_553648783
+    update_key*: ngtcp2_update_key_553648785
+    path_validation*: ngtcp2_path_validation_553648787
+    select_preferred_addr*: ngtcp2_select_preferred_addr_553648789
+    stream_reset*: ngtcp2_stream_reset_553648769
+    extend_max_remote_streams_bidi*: ngtcp2_extend_max_streams_553648775
+    extend_max_remote_streams_uni*: ngtcp2_extend_max_streams_553648775
+    extend_max_stream_data*: ngtcp2_extend_max_stream_data_553648777
+    dcid_status*: ngtcp2_connection_id_status_553648795
+    handshake_confirmed*: ngtcp2_handshake_confirmed_553648751
+    recv_new_token*: ngtcp2_recv_new_token_553648797
+    delete_crypto_aead_ctx*: ngtcp2_delete_crypto_aead_ctx_553648799
+    delete_crypto_cipher_ctx*: ngtcp2_delete_crypto_cipher_ctx_553648801
+    recv_datagram*: ngtcp2_recv_datagram_553648803
+    ack_datagram*: ngtcp2_ack_datagram_553648805
+    lost_datagram*: ngtcp2_lost_datagram_553648807
+    get_path_challenge_data*: ngtcp2_get_path_challenge_data_553648809
+    stream_stop_sending*: ngtcp2_stream_stop_sending_553648811
+    version_negotiation*: ngtcp2_version_negotiation_553648813
+    recv_rx_key*: ngtcp2_recv_key_553648815
+    recv_tx_key*: ngtcp2_recv_key_553648815
+    tls_early_data_rejected*: ngtcp2_tls_early_data_rejected_553648817
+  ngtcp2_callbacks_553648820 = struct_ngtcp2_callbacks_553648819 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3521:3
+  struct_ngtcp2_cid_token_553648822 {.pure, inheritable, bycopy.} = object
+    seq*: uint64             ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4820:16
+    cid*: ngtcp2_cid_553648620
+    ps*: ngtcp2_path_storage_553648707
     token*: array[16'i64, uint8]
     token_present*: uint8
-  ngtcp2_cid_token_536871609 = struct_ngtcp2_cid_token_536871608 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4844:3
-  ngtcp2_ccerr_type_536871613 = enum_ngtcp2_ccerr_type_536871612 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5245:3
-  struct_ngtcp2_ccerr_536871615 {.pure, inheritable, bycopy.} = object
-    type_field*: ngtcp2_ccerr_type_536871614 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5253:16
+  ngtcp2_cid_token_553648824 = struct_ngtcp2_cid_token_553648823 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4844:3
+  ngtcp2_ccerr_type_553648828 = enum_ngtcp2_ccerr_type_553648827 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5245:3
+  struct_ngtcp2_ccerr_553648830 {.pure, inheritable, bycopy.} = object
+    type_field*: ngtcp2_ccerr_type_553648829 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5253:16
     error_code*: uint64
     frame_type*: uint64
     reason*: ptr uint8
     reasonlen*: csize_t
-  ngtcp2_ccerr_536871617 = struct_ngtcp2_ccerr_536871616 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5281:3
-  struct_ngtcp2_info_536871619 {.pure, inheritable, bycopy.} = object
-    age*: cint               ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5675:16
+  ngtcp2_ccerr_553648832 = struct_ngtcp2_ccerr_553648831 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5281:3
+  struct_ngtcp2_info_553648834 {.pure, inheritable, bycopy.} = object
+    age*: cint               ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5675:16
     version_num*: cint
     version_str*: cstring
-  ngtcp2_info_536871621 = struct_ngtcp2_info_536871620 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5693:3
-  ngtcp2_crypto_conn_ref_536871623 = struct_ngtcp2_crypto_conn_ref_536871626 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:950:3
-  struct_ngtcp2_crypto_conn_ref_536871625 {.pure, inheritable, bycopy.} = object
-    get_conn*: ngtcp2_crypto_get_conn_536871628 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:940:16
+  ngtcp2_info_553648836 = struct_ngtcp2_info_553648835 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5693:3
+  ngtcp2_crypto_conn_ref_553648838 = struct_ngtcp2_crypto_conn_ref_553648841 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:950:3
+  struct_ngtcp2_crypto_conn_ref_553648840 {.pure, inheritable, bycopy.} = object
+    get_conn*: ngtcp2_crypto_get_conn_553648843 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:940:16
     user_data*: pointer
-  ngtcp2_crypto_get_conn_536871627 = proc (a0: ptr ngtcp2_crypto_conn_ref_536871624): ptr ngtcp2_conn_536871522 {.
-      cdecl.}                ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:930:24
-  ptls_t_536871629 = struct_st_ptls_t ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:323:26
-  ptls_context_t_536871631 = struct_st_ptls_context_t_536871634 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:324:34
+  ngtcp2_crypto_get_conn_553648842 = proc (a0: ptr ngtcp2_crypto_conn_ref_553648839): ptr ngtcp2_conn_553648737 {.
+      cdecl.}                ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:930:24
+  ptls_t_553648844 = struct_st_ptls_t ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:323:26
+  ptls_context_t_553648846 = struct_st_ptls_context_t_553648849 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:324:34
   struct_st_ptls_context_t_certificates_t {.pure, inheritable, bycopy.} = object
-    list*: ptr ptls_iovec_t_536871640
+    list*: ptr ptls_iovec_t_553648855
     count*: csize_t
   struct_st_ptls_context_t_pre_shared_key_t {.pure, inheritable, bycopy.} = object
-    identity*: ptls_iovec_t_536871640
-    secret*: ptls_iovec_t_536871640
-    hash*: ptr ptls_hash_algorithm_t_536871686
+    identity*: ptls_iovec_t_553648855
+    secret*: ptls_iovec_t_553648855
+    hash*: ptr ptls_hash_algorithm_t_553648901
   struct_st_ptls_context_t_ech_t_client_t {.pure, inheritable, bycopy.} = object
-    ciphers*: ptr ptr ptls_hpke_cipher_suite_t_536871706
-    kems*: ptr ptr ptls_hpke_kem_t_536871698
+    ciphers*: ptr ptr ptls_hpke_cipher_suite_t_553648921
+    kems*: ptr ptr ptls_hpke_kem_t_553648913
   struct_st_ptls_context_t_ech_t_server_t {.pure, inheritable, bycopy.} = object
-    create_opener*: ptr ptls_ech_create_opener_t_536871772
-    retry_configs*: ptls_iovec_t_536871640
+    create_opener*: ptr ptls_ech_create_opener_t_553648987
+    retry_configs*: ptls_iovec_t_553648855
   struct_st_ptls_context_t_ech_t {.pure, inheritable, bycopy.} = object
     client*: struct_st_ptls_context_t_ech_t_client_t
     server*: struct_st_ptls_context_t_ech_t_server_t
@@ -627,7 +631,7 @@ type
     bytes*: array[32'i64, uint8]
     is_set* {.bitsize: 1'i64.}: cuint
   struct_st_ptls_context_t_client_ca_names_t {.pure, inheritable, bycopy.} = object
-    list*: ptr ptls_iovec_t_536871640
+    list*: ptr ptls_iovec_t_553648855
     count*: csize_t
   struct_st_ptls_context_t_ticket_requests_t_client_t {.pure, inheritable,
       bycopy.} = object
@@ -639,18 +643,18 @@ type
   struct_st_ptls_context_t_ticket_requests_t {.pure, inheritable, bycopy.} = object
     client*: struct_st_ptls_context_t_ticket_requests_t_client_t
     server*: struct_st_ptls_context_t_ticket_requests_t_server_t
-  struct_st_ptls_context_t_536871633 {.pure, inheritable, bycopy.} = object
-    random_bytes*: proc (a0: pointer; a1: csize_t): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:854:8
-    get_time*: ptr ptls_get_time_t_536871718
-    key_exchanges*: ptr ptr ptls_key_exchange_algorithm_t_536871654
-    cipher_suites*: ptr ptr ptls_cipher_suite_t_536871690
+  struct_st_ptls_context_t_553648848 {.pure, inheritable, bycopy.} = object
+    random_bytes*: proc (a0: pointer; a1: csize_t): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:854:8
+    get_time*: ptr ptls_get_time_t_553648933
+    key_exchanges*: ptr ptr ptls_key_exchange_algorithm_t_553648869
+    cipher_suites*: ptr ptr ptls_cipher_suite_t_553648905
     certificates*: struct_st_ptls_context_t_certificates_t
     pre_shared_key*: struct_st_ptls_context_t_pre_shared_key_t
     ech*: struct_st_ptls_context_t_ech_t
-    on_client_hello*: ptr ptls_on_client_hello_t_536871722
-    emit_certificate*: ptr ptls_emit_certificate_t_536871726
-    sign_certificate*: ptr ptls_sign_certificate_t_536871734
-    verify_certificate*: ptr ptls_verify_certificate_t_536871738
+    on_client_hello*: ptr ptls_on_client_hello_t_553648937
+    emit_certificate*: ptr ptls_emit_certificate_t_553648941
+    sign_certificate*: ptr ptls_sign_certificate_t_553648949
+    verify_certificate*: ptr ptls_verify_certificate_t_553648953
     ticket_lifetime*: uint32
     max_early_data_size*: uint32
     max_buffer_size*: csize_t
@@ -663,108 +667,108 @@ type
     use_raw_public_keys* {.bitsize: 1'i64.}: cuint
     server_cipher_preference* {.bitsize: 1'i64.}: cuint
     server_cipher_chacha_priority* {.bitsize: 1'i64.}: cuint
-    encrypt_ticket*: ptr ptls_encrypt_ticket_t_536871742
-    save_ticket*: ptr ptls_save_ticket_t_536871746
-    log_event*: ptr ptls_log_event_t_536871750
-    update_open_count*: ptr ptls_update_open_count_t_536871756
-    update_traffic_key*: ptr ptls_update_traffic_key_t_536871760
-    decompress_certificate*: ptr ptls_decompress_certificate_t_536871768
-    on_extension*: ptr ptls_on_extension_t_536871764
-    tls12_cipher_suites*: ptr ptr ptls_cipher_suite_t_536871690
+    encrypt_ticket*: ptr ptls_encrypt_ticket_t_553648957
+    save_ticket*: ptr ptls_save_ticket_t_553648961
+    log_event*: ptr ptls_log_event_t_553648965
+    update_open_count*: ptr ptls_update_open_count_t_553648971
+    update_traffic_key*: ptr ptls_update_traffic_key_t_553648975
+    decompress_certificate*: ptr ptls_decompress_certificate_t_553648983
+    on_extension*: ptr ptls_on_extension_t_553648979
+    tls12_cipher_suites*: ptr ptr ptls_cipher_suite_t_553648905
     ticket_context*: struct_st_ptls_context_t_ticket_context_t
     client_ca_names*: struct_st_ptls_context_t_client_ca_names_t
     ticket_requests*: struct_st_ptls_context_t_ticket_requests_t
-  ptls_key_schedule_t_536871635 = struct_st_ptls_key_schedule_t ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:325:39
-  struct_st_ptls_iovec_t_536871637 {.pure, inheritable, bycopy.} = object
-    base*: ptr uint8         ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:330:16
+  ptls_key_schedule_t_553648850 = struct_st_ptls_key_schedule_t ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:325:39
+  struct_st_ptls_iovec_t_553648852 {.pure, inheritable, bycopy.} = object
+    base*: ptr uint8         ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:330:16
     len*: csize_t
-  ptls_iovec_t_536871639 = struct_st_ptls_iovec_t_536871638 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:333:3
-  struct_st_ptls_buffer_t_536871641 {.pure, inheritable, bycopy.} = object
-    base*: ptr uint8         ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:338:16
+  ptls_iovec_t_553648854 = struct_st_ptls_iovec_t_553648853 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:333:3
+  struct_st_ptls_buffer_t_553648856 {.pure, inheritable, bycopy.} = object
+    base*: ptr uint8         ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:338:16
     capacity*: csize_t
     off*: csize_t
     is_allocated*: uint8
     align_bits*: uint8
-  ptls_buffer_t_536871643 = struct_st_ptls_buffer_t_536871642 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:344:3
-  struct_st_ptls_key_exchange_context_t_536871645 {.pure, inheritable, bycopy.} = object
-    algo*: ptr struct_st_ptls_key_exchange_algorithm_t_536871648 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:349:16
-    pubkey*: ptls_iovec_t_536871640
-    on_exchange*: proc (a0: ptr ptr struct_st_ptls_key_exchange_context_t_536871646;
-                        a1: cint; a2: ptr ptls_iovec_t_536871640;
-                        a3: ptls_iovec_t_536871640): cint {.cdecl.}
-  struct_st_ptls_key_exchange_algorithm_t_536871647 {.pure, inheritable, bycopy.} = object
-    id*: uint16              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:371:22
-    create*: proc (a0: ptr struct_st_ptls_key_exchange_algorithm_t_536871648;
-                   a1: ptr ptr ptls_key_exchange_context_t_536871650): cint {.
+  ptls_buffer_t_553648858 = struct_st_ptls_buffer_t_553648857 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:344:3
+  struct_st_ptls_key_exchange_context_t_553648860 {.pure, inheritable, bycopy.} = object
+    algo*: ptr struct_st_ptls_key_exchange_algorithm_t_553648863 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:349:16
+    pubkey*: ptls_iovec_t_553648855
+    on_exchange*: proc (a0: ptr ptr struct_st_ptls_key_exchange_context_t_553648861;
+                        a1: cint; a2: ptr ptls_iovec_t_553648855;
+                        a3: ptls_iovec_t_553648855): cint {.cdecl.}
+  struct_st_ptls_key_exchange_algorithm_t_553648862 {.pure, inheritable, bycopy.} = object
+    id*: uint16              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:371:22
+    create*: proc (a0: ptr struct_st_ptls_key_exchange_algorithm_t_553648863;
+                   a1: ptr ptr ptls_key_exchange_context_t_553648865): cint {.
         cdecl.}
-    exchange*: proc (a0: ptr struct_st_ptls_key_exchange_algorithm_t_536871648;
-                     a1: ptr ptls_iovec_t_536871640; a2: ptr ptls_iovec_t_536871640;
-                     a3: ptls_iovec_t_536871640): cint {.cdecl.}
-    data*: intptr_t_536871652
+    exchange*: proc (a0: ptr struct_st_ptls_key_exchange_algorithm_t_553648863;
+                     a1: ptr ptls_iovec_t_553648855; a2: ptr ptls_iovec_t_553648855;
+                     a3: ptls_iovec_t_553648855): cint {.cdecl.}
+    data*: intptr_t_553648867
     name*: cstring
-  ptls_key_exchange_context_t_536871649 = struct_st_ptls_key_exchange_context_t_536871646 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:366:3
-  intptr_t_536871651 = clong ## Generated based on /usr/include/stdint.h:76:19
-  ptls_key_exchange_algorithm_t_536871653 = struct_st_ptls_key_exchange_algorithm_t_536871648 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:398:3
-  struct_st_ptls_cipher_context_t_536871655 {.pure, inheritable, bycopy.} = object
-    algo*: ptr struct_st_ptls_cipher_algorithm_t_536871658 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:403:16
-    do_dispose*: proc (a0: ptr struct_st_ptls_cipher_context_t_536871656): void {.
+  ptls_key_exchange_context_t_553648864 = struct_st_ptls_key_exchange_context_t_553648861 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:366:3
+  intptr_t_553648866 = clong ## Generated based on /usr/include/stdint.h:76:19
+  ptls_key_exchange_algorithm_t_553648868 = struct_st_ptls_key_exchange_algorithm_t_553648863 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:398:3
+  struct_st_ptls_cipher_context_t_553648870 {.pure, inheritable, bycopy.} = object
+    algo*: ptr struct_st_ptls_cipher_algorithm_t_553648873 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:403:16
+    do_dispose*: proc (a0: ptr struct_st_ptls_cipher_context_t_553648871): void {.
         cdecl.}
-    do_init*: proc (a0: ptr struct_st_ptls_cipher_context_t_536871656;
+    do_init*: proc (a0: ptr struct_st_ptls_cipher_context_t_553648871;
                     a1: pointer): void {.cdecl.}
-    do_transform*: proc (a0: ptr struct_st_ptls_cipher_context_t_536871656;
+    do_transform*: proc (a0: ptr struct_st_ptls_cipher_context_t_553648871;
                          a1: pointer; a2: pointer; a3: csize_t): void {.cdecl.}
-  struct_st_ptls_cipher_algorithm_t_536871657 {.pure, inheritable, bycopy.} = object
-    name*: cstring           ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:414:22
+  struct_st_ptls_cipher_algorithm_t_553648872 {.pure, inheritable, bycopy.} = object
+    name*: cstring           ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:414:22
     key_size*: csize_t
     block_size*: csize_t
     iv_size*: csize_t
     context_size*: csize_t
-    setup_crypto*: proc (a0: ptr ptls_cipher_context_t_536871660; a1: cint;
+    setup_crypto*: proc (a0: ptr ptls_cipher_context_t_553648875; a1: cint;
                          a2: pointer): cint {.cdecl.}
-  ptls_cipher_context_t_536871659 = struct_st_ptls_cipher_context_t_536871656 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:409:3
-  ptls_cipher_algorithm_t_536871661 = struct_st_ptls_cipher_algorithm_t_536871658 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:421:3
-  struct_st_ptls_aead_supplementary_encryption_t_536871663 {.pure, inheritable,
+  ptls_cipher_context_t_553648874 = struct_st_ptls_cipher_context_t_553648871 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:409:3
+  ptls_cipher_algorithm_t_553648876 = struct_st_ptls_cipher_algorithm_t_553648873 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:421:3
+  struct_st_ptls_aead_supplementary_encryption_t_553648878 {.pure, inheritable,
       bycopy.} = object
-    ctx*: ptr ptls_cipher_context_t_536871660 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:427:16
+    ctx*: ptr ptls_cipher_context_t_553648875 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:427:16
     input*: pointer
     output*: array[16'i64, uint8]
-  ptls_aead_supplementary_encryption_t_536871665 = struct_st_ptls_aead_supplementary_encryption_t_536871664 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:442:3
-  struct_st_ptls_aead_context_t_536871667 {.pure, inheritable, bycopy.} = object
-    algo*: ptr struct_st_ptls_aead_algorithm_t_536871670 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:450:16
-    dispose_crypto*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668): void {.
+  ptls_aead_supplementary_encryption_t_553648880 = struct_st_ptls_aead_supplementary_encryption_t_553648879 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:442:3
+  struct_st_ptls_aead_context_t_553648882 {.pure, inheritable, bycopy.} = object
+    algo*: ptr struct_st_ptls_aead_algorithm_t_553648885 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:450:16
+    dispose_crypto*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883): void {.
         cdecl.}
-    do_get_iv*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_get_iv*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                       a1: pointer): void {.cdecl.}
-    do_set_iv*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_set_iv*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                       a1: pointer): void {.cdecl.}
-    do_encrypt_init*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_encrypt_init*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                             a1: uint64; a2: pointer; a3: csize_t): void {.cdecl.}
-    do_encrypt_update*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_encrypt_update*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                               a1: pointer; a2: pointer; a3: csize_t): csize_t {.
         cdecl.}
-    do_encrypt_final*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_encrypt_final*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                              a1: pointer): csize_t {.cdecl.}
-    do_encrypt*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_encrypt*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                        a1: pointer; a2: pointer; a3: csize_t; a4: uint64;
                        a5: pointer; a6: csize_t;
-                       a7: ptr ptls_aead_supplementary_encryption_t_536871666): void {.
+                       a7: ptr ptls_aead_supplementary_encryption_t_553648881): void {.
         cdecl.}
-    do_encrypt_v*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
-                         a1: pointer; a2: ptr ptls_iovec_t_536871640;
+    do_encrypt_v*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
+                         a1: pointer; a2: ptr ptls_iovec_t_553648855;
                          a3: csize_t; a4: uint64; a5: pointer; a6: csize_t): void {.
         cdecl.}
-    do_decrypt*: proc (a0: ptr struct_st_ptls_aead_context_t_536871668;
+    do_decrypt*: proc (a0: ptr struct_st_ptls_aead_context_t_553648883;
                        a1: pointer; a2: pointer; a3: csize_t; a4: uint64;
                        a5: pointer; a6: csize_t): csize_t {.cdecl.}
   struct_st_ptls_aead_algorithm_t_tls12_t {.pure, inheritable, bycopy.} = object
     fixed_iv_size*: csize_t
     record_iv_size*: csize_t
-  struct_st_ptls_aead_algorithm_t_536871669 {.pure, inheritable, bycopy.} = object
-    name*: cstring           ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:505:22
+  struct_st_ptls_aead_algorithm_t_553648884 {.pure, inheritable, bycopy.} = object
+    name*: cstring           ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:505:22
     confidentiality_limit*: uint64
     integrity_limit*: uint64
-    ctr_cipher*: ptr ptls_cipher_algorithm_t_536871662
-    ecb_cipher*: ptr ptls_cipher_algorithm_t_536871662
+    ctr_cipher*: ptr ptls_cipher_algorithm_t_553648877
+    ecb_cipher*: ptr ptls_cipher_algorithm_t_553648877
     key_size*: csize_t
     iv_size*: csize_t
     tag_size*: csize_t
@@ -772,65 +776,65 @@ type
     non_temporal* {.bitsize: 1'i64.}: cuint
     align_bits*: uint8
     context_size*: csize_t
-    setup_crypto*: proc (a0: ptr ptls_aead_context_t_536871672; a1: cint;
+    setup_crypto*: proc (a0: ptr ptls_aead_context_t_553648887; a1: cint;
                          a2: pointer; a3: pointer): cint {.cdecl.}
-  ptls_aead_context_t_536871671 = struct_st_ptls_aead_context_t_536871668 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:500:3
-  ptls_aead_algorithm_t_536871673 = struct_st_ptls_aead_algorithm_t_536871670 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:566:3
-  ptls_hash_final_mode_t_536871677 = enum_en_ptls_hash_final_mode_t_536871676 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:584:3
-  struct_st_ptls_hash_context_t_536871679 {.pure, inheritable, bycopy.} = object
-    update*: proc (a0: ptr struct_st_ptls_hash_context_t_536871680; a1: pointer;
-                   a2: csize_t): void {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:589:16
-    final*: proc (a0: ptr struct_st_ptls_hash_context_t_536871680; a1: pointer;
-                  a2: ptls_hash_final_mode_t_536871678): void {.cdecl.}
-    clone_private*: proc (a0: ptr struct_st_ptls_hash_context_t_536871680): ptr struct_st_ptls_hash_context_t_536871680 {.
+  ptls_aead_context_t_553648886 = struct_st_ptls_aead_context_t_553648883 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:500:3
+  ptls_aead_algorithm_t_553648888 = struct_st_ptls_aead_algorithm_t_553648885 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:566:3
+  ptls_hash_final_mode_t_553648892 = enum_en_ptls_hash_final_mode_t_553648891 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:584:3
+  struct_st_ptls_hash_context_t_553648894 {.pure, inheritable, bycopy.} = object
+    update*: proc (a0: ptr struct_st_ptls_hash_context_t_553648895; a1: pointer;
+                   a2: csize_t): void {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:589:16
+    final*: proc (a0: ptr struct_st_ptls_hash_context_t_553648895; a1: pointer;
+                  a2: ptls_hash_final_mode_t_553648893): void {.cdecl.}
+    clone_private*: proc (a0: ptr struct_st_ptls_hash_context_t_553648895): ptr struct_st_ptls_hash_context_t_553648895 {.
         cdecl.}
-  ptls_hash_context_t_536871681 = struct_st_ptls_hash_context_t_536871680 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:602:3
-  struct_st_ptls_hash_algorithm_t_536871683 {.pure, inheritable, bycopy.} = object
-    name*: cstring           ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:607:22
+  ptls_hash_context_t_553648896 = struct_st_ptls_hash_context_t_553648895 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:602:3
+  struct_st_ptls_hash_algorithm_t_553648898 {.pure, inheritable, bycopy.} = object
+    name*: cstring           ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:607:22
     block_size*: csize_t
     digest_size*: csize_t
-    create*: proc (): ptr ptls_hash_context_t_536871682 {.cdecl.}
+    create*: proc (): ptr ptls_hash_context_t_553648897 {.cdecl.}
     empty_digest*: array[64'i64, uint8]
-  ptls_hash_algorithm_t_536871685 = struct_st_ptls_hash_algorithm_t_536871684 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:628:3
-  struct_st_ptls_cipher_suite_t_536871687 {.pure, inheritable, bycopy.} = object
-    id*: uint16              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:630:22
-    aead*: ptr ptls_aead_algorithm_t_536871674
-    hash*: ptr ptls_hash_algorithm_t_536871686
+  ptls_hash_algorithm_t_553648900 = struct_st_ptls_hash_algorithm_t_553648899 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:628:3
+  struct_st_ptls_cipher_suite_t_553648902 {.pure, inheritable, bycopy.} = object
+    id*: uint16              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:630:22
+    aead*: ptr ptls_aead_algorithm_t_553648889
+    hash*: ptr ptls_hash_algorithm_t_553648901
     name*: cstring
-  ptls_cipher_suite_t_536871689 = struct_st_ptls_cipher_suite_t_536871688 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:647:3
-  struct_st_ptls_message_emitter_t_536871691 {.pure, inheritable, bycopy.} = object
-    buf*: ptr ptls_buffer_t_536871644 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:651:16
+  ptls_cipher_suite_t_553648904 = struct_st_ptls_cipher_suite_t_553648903 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:647:3
+  struct_st_ptls_message_emitter_t_553648906 {.pure, inheritable, bycopy.} = object
+    buf*: ptr ptls_buffer_t_553648859 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:651:16
     enc*: ptr struct_st_ptls_traffic_protection_t
     record_header_length*: csize_t
-    begin_message*: proc (a0: ptr struct_st_ptls_message_emitter_t_536871692): cint {.
+    begin_message*: proc (a0: ptr struct_st_ptls_message_emitter_t_553648907): cint {.
         cdecl.}
-    commit_message*: proc (a0: ptr struct_st_ptls_message_emitter_t_536871692): cint {.
+    commit_message*: proc (a0: ptr struct_st_ptls_message_emitter_t_553648907): cint {.
         cdecl.}
-  ptls_message_emitter_t_536871693 = struct_st_ptls_message_emitter_t_536871692 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:657:3
-  struct_st_ptls_hpke_kem_t_536871695 {.pure, inheritable, bycopy.} = object
-    id*: uint16              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:662:22
-    keyex*: ptr ptls_key_exchange_algorithm_t_536871654
-    hash*: ptr ptls_hash_algorithm_t_536871686
-  ptls_hpke_kem_t_536871697 = struct_st_ptls_hpke_kem_t_536871696 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:666:3
-  struct_st_ptls_hpke_cipher_suite_id_t_536871699 {.pure, inheritable, bycopy.} = object
-    kdf*: uint16             ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:668:16
+  ptls_message_emitter_t_553648908 = struct_st_ptls_message_emitter_t_553648907 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:657:3
+  struct_st_ptls_hpke_kem_t_553648910 {.pure, inheritable, bycopy.} = object
+    id*: uint16              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:662:22
+    keyex*: ptr ptls_key_exchange_algorithm_t_553648869
+    hash*: ptr ptls_hash_algorithm_t_553648901
+  ptls_hpke_kem_t_553648912 = struct_st_ptls_hpke_kem_t_553648911 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:666:3
+  struct_st_ptls_hpke_cipher_suite_id_t_553648914 {.pure, inheritable, bycopy.} = object
+    kdf*: uint16             ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:668:16
     aead*: uint16
-  ptls_hpke_cipher_suite_id_t_536871701 = struct_st_ptls_hpke_cipher_suite_id_t_536871700 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:671:3
-  struct_st_ptls_hpke_cipher_suite_t_536871703 {.pure, inheritable, bycopy.} = object
-    id*: ptls_hpke_cipher_suite_id_t_536871702 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:673:22
+  ptls_hpke_cipher_suite_id_t_553648916 = struct_st_ptls_hpke_cipher_suite_id_t_553648915 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:671:3
+  struct_st_ptls_hpke_cipher_suite_t_553648918 {.pure, inheritable, bycopy.} = object
+    id*: ptls_hpke_cipher_suite_id_t_553648917 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:673:22
     name*: cstring
-    hash*: ptr ptls_hash_algorithm_t_536871686
-    aead*: ptr ptls_aead_algorithm_t_536871674
-  ptls_hpke_cipher_suite_t_536871705 = struct_st_ptls_hpke_cipher_suite_t_536871704 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:678:3
-  struct_st_ptls_client_hello_psk_identity_t_536871707 {.pure, inheritable,
+    hash*: ptr ptls_hash_algorithm_t_553648901
+    aead*: ptr ptls_aead_algorithm_t_553648889
+  ptls_hpke_cipher_suite_t_553648920 = struct_st_ptls_hpke_cipher_suite_t_553648919 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:678:3
+  struct_st_ptls_client_hello_psk_identity_t_553648922 {.pure, inheritable,
       bycopy.} = object
-    identity*: ptls_iovec_t_536871640 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:690:16
+    identity*: ptls_iovec_t_553648855 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:690:16
     obfuscated_ticket_age*: uint32
-    binder*: ptls_iovec_t_536871640
-  ptls_client_hello_psk_identity_t_536871709 = struct_st_ptls_client_hello_psk_identity_t_536871708 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:694:3
+    binder*: ptls_iovec_t_553648855
+  ptls_client_hello_psk_identity_t_553648924 = struct_st_ptls_client_hello_psk_identity_t_553648923 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:694:3
   struct_st_ptls_on_client_hello_parameters_t_negotiated_protocols_t {.pure,
       inheritable, bycopy.} = object
-    list*: ptr ptls_iovec_t_536871640
+    list*: ptr ptls_iovec_t_553648855
     count*: csize_t
   struct_st_ptls_on_client_hello_parameters_t_signature_algorithms_t {.pure,
       inheritable, bycopy.} = object
@@ -846,118 +850,118 @@ type
     count*: csize_t
   struct_st_ptls_on_client_hello_parameters_t_psk_identities_t {.pure,
       inheritable, bycopy.} = object
-    list*: ptr ptls_client_hello_psk_identity_t_536871710
+    list*: ptr ptls_client_hello_psk_identity_t_553648925
     count*: csize_t
-  struct_st_ptls_on_client_hello_parameters_t_536871711 {.pure, inheritable,
+  struct_st_ptls_on_client_hello_parameters_t_553648926 {.pure, inheritable,
       bycopy.} = object
-    server_name*: ptls_iovec_t_536871640 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:699:16
-    raw_message*: ptls_iovec_t_536871640
-    cipher_suites*: ptls_iovec_t_536871640
+    server_name*: ptls_iovec_t_553648855 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:699:16
+    raw_message*: ptls_iovec_t_553648855
+    cipher_suites*: ptls_iovec_t_553648855
     negotiated_protocols*: struct_st_ptls_on_client_hello_parameters_t_negotiated_protocols_t
     signature_algorithms*: struct_st_ptls_on_client_hello_parameters_t_signature_algorithms_t
     certificate_compression_algorithms*: struct_st_ptls_on_client_hello_parameters_t_certificate_compression_algorithms_t
     server_certificate_types*: struct_st_ptls_on_client_hello_parameters_t_server_certificate_types_t
     psk_identities*: struct_st_ptls_on_client_hello_parameters_t_psk_identities_t
     incompatible_version* {.bitsize: 1'i64.}: cuint
-  ptls_on_client_hello_parameters_t_536871713 = struct_st_ptls_on_client_hello_parameters_t_536871712 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:739:3
-  struct_st_ptls_get_time_t_536871715 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_get_time_t_536871716): uint64 {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:744:1
-  ptls_get_time_t_536871717 = struct_st_ptls_get_time_t_536871716 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:744:1
-  struct_st_ptls_on_client_hello_t_536871719 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_on_client_hello_t_536871720;
-               a1: ptr ptls_t_536871630;
-               a2: ptr ptls_on_client_hello_parameters_t_536871714): cint {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:749:1
-  ptls_on_client_hello_t_536871721 = struct_st_ptls_on_client_hello_t_536871720 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:749:1
-  struct_st_ptls_emit_certificate_t_536871723 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_emit_certificate_t_536871724;
-               a1: ptr ptls_t_536871630; a2: ptr ptls_message_emitter_t_536871694;
-               a3: ptr ptls_key_schedule_t_536871636; a4: ptls_iovec_t_536871640;
-               a5: cint; a6: ptr uint16; a7: csize_t): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:753:1
-  ptls_emit_certificate_t_536871725 = struct_st_ptls_emit_certificate_t_536871724 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:753:1
-  struct_st_ptls_async_job_t_536871727 {.pure, inheritable, bycopy.} = object
-    destroy_private*: proc (a0: ptr struct_st_ptls_async_job_t_536871728): void {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:763:16
-    get_fd*: proc (a0: ptr struct_st_ptls_async_job_t_536871728): cint {.cdecl.}
-    set_completion_callback*: proc (a0: ptr struct_st_ptls_async_job_t_536871728;
+  ptls_on_client_hello_parameters_t_553648928 = struct_st_ptls_on_client_hello_parameters_t_553648927 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:739:3
+  struct_st_ptls_get_time_t_553648930 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_get_time_t_553648931): uint64 {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:744:1
+  ptls_get_time_t_553648932 = struct_st_ptls_get_time_t_553648931 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:744:1
+  struct_st_ptls_on_client_hello_t_553648934 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_on_client_hello_t_553648935;
+               a1: ptr ptls_t_553648845;
+               a2: ptr ptls_on_client_hello_parameters_t_553648929): cint {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:749:1
+  ptls_on_client_hello_t_553648936 = struct_st_ptls_on_client_hello_t_553648935 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:749:1
+  struct_st_ptls_emit_certificate_t_553648938 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_emit_certificate_t_553648939;
+               a1: ptr ptls_t_553648845; a2: ptr ptls_message_emitter_t_553648909;
+               a3: ptr ptls_key_schedule_t_553648851; a4: ptls_iovec_t_553648855;
+               a5: cint; a6: ptr uint16; a7: csize_t): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:753:1
+  ptls_emit_certificate_t_553648940 = struct_st_ptls_emit_certificate_t_553648939 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:753:1
+  struct_st_ptls_async_job_t_553648942 {.pure, inheritable, bycopy.} = object
+    destroy_private*: proc (a0: ptr struct_st_ptls_async_job_t_553648943): void {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:763:16
+    get_fd*: proc (a0: ptr struct_st_ptls_async_job_t_553648943): cint {.cdecl.}
+    set_completion_callback*: proc (a0: ptr struct_st_ptls_async_job_t_553648943;
                                     a1: proc (a0: pointer): void {.cdecl.};
                                     a2: pointer): void {.cdecl.}
-  ptls_async_job_t_536871729 = struct_st_ptls_async_job_t_536871728 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:773:3
-  struct_st_ptls_sign_certificate_t_536871731 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_sign_certificate_t_536871732;
-               a1: ptr ptls_t_536871630; a2: ptr ptr ptls_async_job_t_536871730;
-               a3: ptr uint16; a4: ptr ptls_buffer_t_536871644;
-               a5: ptls_iovec_t_536871640; a6: ptr uint16; a7: csize_t): cint {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:778:1
-  ptls_sign_certificate_t_536871733 = struct_st_ptls_sign_certificate_t_536871732 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:778:1
-  struct_st_ptls_verify_certificate_t_536871735 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_verify_certificate_t_536871736;
-               a1: ptr ptls_t_536871630; a2: cstring; a3: proc (a0: pointer;
-        a1: uint16; a2: ptls_iovec_t_536871640; a3: ptls_iovec_t_536871640): cint {.
-        cdecl.}; a4: ptr pointer; a5: ptr ptls_iovec_t_536871640; a6: csize_t): cint {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:789:16
+  ptls_async_job_t_553648944 = struct_st_ptls_async_job_t_553648943 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:773:3
+  struct_st_ptls_sign_certificate_t_553648946 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_sign_certificate_t_553648947;
+               a1: ptr ptls_t_553648845; a2: ptr ptr ptls_async_job_t_553648945;
+               a3: ptr uint16; a4: ptr ptls_buffer_t_553648859;
+               a5: ptls_iovec_t_553648855; a6: ptr uint16; a7: csize_t): cint {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:778:1
+  ptls_sign_certificate_t_553648948 = struct_st_ptls_sign_certificate_t_553648947 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:778:1
+  struct_st_ptls_verify_certificate_t_553648950 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_verify_certificate_t_553648951;
+               a1: ptr ptls_t_553648845; a2: cstring; a3: proc (a0: pointer;
+        a1: uint16; a2: ptls_iovec_t_553648855; a3: ptls_iovec_t_553648855): cint {.
+        cdecl.}; a4: ptr pointer; a5: ptr ptls_iovec_t_553648855; a6: csize_t): cint {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:789:16
     algos*: ptr uint16
-  ptls_verify_certificate_t_536871737 = struct_st_ptls_verify_certificate_t_536871736 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:797:3
-  struct_st_ptls_encrypt_ticket_t_536871739 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_encrypt_ticket_t_536871740;
-               a1: ptr ptls_t_536871630; a2: cint; a3: ptr ptls_buffer_t_536871644;
-               a4: ptls_iovec_t_536871640): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:804:1
-  ptls_encrypt_ticket_t_536871741 = struct_st_ptls_encrypt_ticket_t_536871740 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:804:1
-  struct_st_ptls_save_ticket_t_536871743 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_save_ticket_t_536871744; a1: ptr ptls_t_536871630;
-               a2: ptls_iovec_t_536871640): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:808:1
-  ptls_save_ticket_t_536871745 = struct_st_ptls_save_ticket_t_536871744 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:808:1
-  struct_st_ptls_log_event_t_536871747 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_log_event_t_536871748; a1: ptr ptls_t_536871630;
-               a2: cstring; a3: cstring): void {.cdecl, varargs.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:812:16
-  ptls_log_event_t_536871749 = struct_st_ptls_log_event_t_536871748 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:815:3
-  struct_st_ptls_update_open_count_t_536871751 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_update_open_count_t_536871752; a1: ssize_t_536871754): void {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:819:1
-  ssize_t_536871753 = compiler_ssize_t_536871848 ## Generated based on /usr/include/x86_64-linux-gnu/sys/types.h:108:19
-  ptls_update_open_count_t_536871755 = struct_st_ptls_update_open_count_t_536871752 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:819:1
-  struct_st_ptls_update_traffic_key_t_536871757 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_update_traffic_key_t_536871758;
-               a1: ptr ptls_t_536871630; a2: cint; a3: csize_t; a4: pointer): cint {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:824:1
-  ptls_update_traffic_key_t_536871759 = struct_st_ptls_update_traffic_key_t_536871758 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:824:1
-  struct_st_ptls_on_extension_t_536871761 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_on_extension_t_536871762; a1: ptr ptls_t_536871630;
-               a2: uint8; a3: uint16; a4: ptls_iovec_t_536871640): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:828:1
-  ptls_on_extension_t_536871763 = struct_st_ptls_on_extension_t_536871762 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:828:1
-  struct_st_ptls_decompress_certificate_t_536871765 {.pure, inheritable, bycopy.} = object
-    supported_algorithms*: ptr uint16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:832:16
-    cb*: proc (a0: ptr struct_st_ptls_decompress_certificate_t_536871766;
-               a1: ptr ptls_t_536871630; a2: uint16; a3: ptls_iovec_t_536871640;
-               a4: ptls_iovec_t_536871640): cint {.cdecl.}
-  ptls_decompress_certificate_t_536871767 = struct_st_ptls_decompress_certificate_t_536871766 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:842:3
-  struct_st_ptls_ech_create_opener_t_536871769 {.pure, inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_ech_create_opener_t_536871770;
-               a1: ptr ptr ptls_hpke_kem_t_536871698;
-               a2: ptr ptr ptls_hpke_cipher_suite_t_536871706; a3: ptr ptls_t_536871630;
-               a4: uint8; a5: ptls_hpke_cipher_suite_id_t_536871702;
-               a6: ptls_iovec_t_536871640; a7: ptls_iovec_t_536871640): ptr ptls_aead_context_t_536871672 {.
-        cdecl.}              ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:848:1
-  ptls_ech_create_opener_t_536871771 = struct_st_ptls_ech_create_opener_t_536871770 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:848:1
-  struct_st_ptls_raw_extension_t_536871773 {.pure, inheritable, bycopy.} = object
-    type_field*: uint16      ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1059:16
-    data*: ptls_iovec_t_536871640
-  ptls_raw_extension_t_536871775 = struct_st_ptls_raw_extension_t_536871774 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1062:3
-  ptls_early_data_acceptance_t_536871779 = enum_en_ptls_early_data_acceptance_t_536871778 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1068:3
+  ptls_verify_certificate_t_553648952 = struct_st_ptls_verify_certificate_t_553648951 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:797:3
+  struct_st_ptls_encrypt_ticket_t_553648954 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_encrypt_ticket_t_553648955;
+               a1: ptr ptls_t_553648845; a2: cint; a3: ptr ptls_buffer_t_553648859;
+               a4: ptls_iovec_t_553648855): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:804:1
+  ptls_encrypt_ticket_t_553648956 = struct_st_ptls_encrypt_ticket_t_553648955 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:804:1
+  struct_st_ptls_save_ticket_t_553648958 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_save_ticket_t_553648959; a1: ptr ptls_t_553648845;
+               a2: ptls_iovec_t_553648855): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:808:1
+  ptls_save_ticket_t_553648960 = struct_st_ptls_save_ticket_t_553648959 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:808:1
+  struct_st_ptls_log_event_t_553648962 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_log_event_t_553648963; a1: ptr ptls_t_553648845;
+               a2: cstring; a3: cstring): void {.cdecl, varargs.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:812:16
+  ptls_log_event_t_553648964 = struct_st_ptls_log_event_t_553648963 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:815:3
+  struct_st_ptls_update_open_count_t_553648966 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_update_open_count_t_553648967; a1: ssize_t_553648969): void {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:819:1
+  ssize_t_553648968 = compiler_ssize_t_553649063 ## Generated based on /usr/include/x86_64-linux-gnu/sys/types.h:108:19
+  ptls_update_open_count_t_553648970 = struct_st_ptls_update_open_count_t_553648967 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:819:1
+  struct_st_ptls_update_traffic_key_t_553648972 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_update_traffic_key_t_553648973;
+               a1: ptr ptls_t_553648845; a2: cint; a3: csize_t; a4: pointer): cint {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:824:1
+  ptls_update_traffic_key_t_553648974 = struct_st_ptls_update_traffic_key_t_553648973 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:824:1
+  struct_st_ptls_on_extension_t_553648976 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_on_extension_t_553648977; a1: ptr ptls_t_553648845;
+               a2: uint8; a3: uint16; a4: ptls_iovec_t_553648855): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:828:1
+  ptls_on_extension_t_553648978 = struct_st_ptls_on_extension_t_553648977 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:828:1
+  struct_st_ptls_decompress_certificate_t_553648980 {.pure, inheritable, bycopy.} = object
+    supported_algorithms*: ptr uint16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:832:16
+    cb*: proc (a0: ptr struct_st_ptls_decompress_certificate_t_553648981;
+               a1: ptr ptls_t_553648845; a2: uint16; a3: ptls_iovec_t_553648855;
+               a4: ptls_iovec_t_553648855): cint {.cdecl.}
+  ptls_decompress_certificate_t_553648982 = struct_st_ptls_decompress_certificate_t_553648981 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:842:3
+  struct_st_ptls_ech_create_opener_t_553648984 {.pure, inheritable, bycopy.} = object
+    cb*: proc (a0: ptr struct_st_ptls_ech_create_opener_t_553648985;
+               a1: ptr ptr ptls_hpke_kem_t_553648913;
+               a2: ptr ptr ptls_hpke_cipher_suite_t_553648921; a3: ptr ptls_t_553648845;
+               a4: uint8; a5: ptls_hpke_cipher_suite_id_t_553648917;
+               a6: ptls_iovec_t_553648855; a7: ptls_iovec_t_553648855): ptr ptls_aead_context_t_553648887 {.
+        cdecl.}              ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:848:1
+  ptls_ech_create_opener_t_553648986 = struct_st_ptls_ech_create_opener_t_553648985 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:848:1
+  struct_st_ptls_raw_extension_t_553648988 {.pure, inheritable, bycopy.} = object
+    type_field*: uint16      ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1059:16
+    data*: ptls_iovec_t_553648855
+  ptls_raw_extension_t_553648990 = struct_st_ptls_raw_extension_t_553648989 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1062:3
+  ptls_early_data_acceptance_t_553648994 = enum_en_ptls_early_data_acceptance_t_553648993 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1068:3
   struct_st_ptls_handshake_properties_t_anon0_t_client_t_negotiated_protocols_t {.
       pure, inheritable, bycopy.} = object
-    list*: ptr ptls_iovec_t_536871640
+    list*: ptr ptls_iovec_t_553648855
     count*: csize_t
   struct_st_ptls_handshake_properties_t_anon0_t_client_t_ech_t {.pure,
       inheritable, bycopy.} = object
-    configs*: ptls_iovec_t_536871640
-    retry_configs*: ptr ptls_iovec_t_536871640
+    configs*: ptls_iovec_t_553648855
+    retry_configs*: ptr ptls_iovec_t_553648855
   struct_st_ptls_handshake_properties_t_anon0_t_client_t {.pure, inheritable,
       bycopy.} = object
     negotiated_protocols*: struct_st_ptls_handshake_properties_t_anon0_t_client_t_negotiated_protocols_t
-    session_ticket*: ptls_iovec_t_536871640
+    session_ticket*: ptls_iovec_t_553648855
     max_early_data_size*: ptr csize_t
-    early_data_acceptance*: ptls_early_data_acceptance_t_536871780
+    early_data_acceptance*: ptls_early_data_acceptance_t_553648995
     negotiate_before_key_exchange* {.bitsize: 1'i64.}: cuint
     ech*: struct_st_ptls_handshake_properties_t_anon0_t_client_t_ech_t
   struct_st_ptls_handshake_properties_t_anon0_t_server_t_selected_psk_binder_t {.
@@ -967,7 +971,7 @@ type
   struct_st_ptls_handshake_properties_t_anon0_t_server_t_cookie_t {.pure,
       inheritable, bycopy.} = object
     key*: pointer
-    additional_data*: ptls_iovec_t_536871640
+    additional_data*: ptls_iovec_t_553648855
   struct_st_ptls_handshake_properties_t_anon0_t_server_t {.pure, inheritable,
       bycopy.} = object
     selected_psk_binder*: struct_st_ptls_handshake_properties_t_anon0_t_server_t_selected_psk_binder_t
@@ -977,3844 +981,3844 @@ type
   struct_st_ptls_handshake_properties_t_anon0_t {.union, bycopy.} = object
     client*: struct_st_ptls_handshake_properties_t_anon0_t_client_t
     server*: struct_st_ptls_handshake_properties_t_anon0_t_server_t
-  struct_st_ptls_handshake_properties_t_536871781 {.pure, inheritable, bycopy.} = object
-    anon0*: struct_st_ptls_handshake_properties_t_anon0_t ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1078:16
-    additional_extensions*: ptr ptls_raw_extension_t_536871776
-    collect_extension*: proc (a0: ptr ptls_t_536871630;
-                              a1: ptr struct_st_ptls_handshake_properties_t_536871782;
+  struct_st_ptls_handshake_properties_t_553648996 {.pure, inheritable, bycopy.} = object
+    anon0*: struct_st_ptls_handshake_properties_t_anon0_t ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1078:16
+    additional_extensions*: ptr ptls_raw_extension_t_553648991
+    collect_extension*: proc (a0: ptr ptls_t_553648845;
+                              a1: ptr struct_st_ptls_handshake_properties_t_553648997;
                               a2: uint16): cint {.cdecl.}
-    collected_extensions*: proc (a0: ptr ptls_t_536871630;
-                                 a1: ptr struct_st_ptls_handshake_properties_t_536871782;
-                                 a2: ptr ptls_raw_extension_t_536871776): cint {.
+    collected_extensions*: proc (a0: ptr ptls_t_553648845;
+                                 a1: ptr struct_st_ptls_handshake_properties_t_553648997;
+                                 a2: ptr ptls_raw_extension_t_553648991): cint {.
         cdecl.}
-  ptls_handshake_properties_t_536871783 = struct_st_ptls_handshake_properties_t_536871782 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1167:3
-  struct_st_ptls_log_state_t_536871785 {.pure, inheritable, bycopy.} = object
-    active_conns*: uint32    ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1492:8
+  ptls_handshake_properties_t_553648998 = struct_st_ptls_handshake_properties_t_553648997 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1167:3
+  struct_st_ptls_log_state_t_553649000 {.pure, inheritable, bycopy.} = object
+    active_conns*: uint32    ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1492:8
     generation*: uint64
-  struct_st_ptls_log_point_t_536871787 {.pure, inheritable, bycopy.} = object
-    name*: cstring           ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1506:8
-    state*: struct_st_ptls_log_state_t_536871786
-  struct_st_ptls_log_conn_state_t_536871789 {.pure, inheritable, bycopy.} = object
-    random_private*: cfloat  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1514:16
-    address*: struct_in6_addr_536871792
-    state*: struct_st_ptls_log_state_t_536871786
+  struct_st_ptls_log_point_t_553649002 {.pure, inheritable, bycopy.} = object
+    name*: cstring           ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1506:8
+    state*: struct_st_ptls_log_state_t_553649001
+  struct_st_ptls_log_conn_state_t_553649004 {.pure, inheritable, bycopy.} = object
+    random_private*: cfloat  ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1514:16
+    address*: struct_in6_addr_553649007
+    state*: struct_st_ptls_log_state_t_553649001
   struct_in6_addr_compiler_in6_u_t {.union, bycopy.} = object
     compiler_u6_addr8*: array[16'i64, uint8]
     compiler_u6_addr16*: array[8'i64, uint16]
     compiler_u6_addr32*: array[4'i64, uint32]
-  struct_in6_addr_536871791 {.pure, inheritable, bycopy.} = object
+  struct_in6_addr_553649006 {.pure, inheritable, bycopy.} = object
     compiler_in6_u*: struct_in6_addr_compiler_in6_u_t ## Generated based on /usr/include/netinet/in.h:221:8
-  ptls_log_conn_state_t_536871793 = struct_st_ptls_log_conn_state_t_536871790 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1525:3
-  struct_st_ptls_log_t_536871795 {.pure, inheritable, bycopy.} = object
-    may_include_appdata* {.bitsize: 1'i64.}: cuint ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1535:15
-    dummy_conn_state*: ptls_log_conn_state_t_536871794
+  ptls_log_conn_state_t_553649008 = struct_st_ptls_log_conn_state_t_553649005 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1525:3
+  struct_st_ptls_log_t_553649010 {.pure, inheritable, bycopy.} = object
+    may_include_appdata* {.bitsize: 1'i64.}: cuint ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1535:15
+    dummy_conn_state*: ptls_log_conn_state_t_553649009
     internal_generation*: uint64
-  struct_in_addr_536871797 {.pure, inheritable, bycopy.} = object
-    s_addr*: in_addr_t_536871850 ## Generated based on /usr/include/netinet/in.h:31:8
-  EVP_PKEY_536871799 = struct_evp_pkey_st ## Generated based on /usr/include/openssl/types.h:107:28
-  struct_st_ptls_openssl_signature_scheme_t_536871801 {.pure, inheritable,
+  struct_in_addr_553649012 {.pure, inheritable, bycopy.} = object
+    s_addr*: in_addr_t_553649065 ## Generated based on /usr/include/netinet/in.h:31:8
+  EVP_PKEY_553649014 = struct_evp_pkey_st ## Generated based on /usr/include/openssl/types.h:107:28
+  struct_st_ptls_openssl_signature_scheme_t_553649016 {.pure, inheritable,
       bycopy.} = object
-    scheme_id*: uint16       ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:150:16
-    scheme_md*: proc (): ptr EVP_MD_536871804 {.cdecl.}
-  EVP_MD_536871803 = struct_evp_md_st ## Generated based on /usr/include/openssl/types.h:103:26
-  ptls_openssl_signature_scheme_t_536871805 = struct_st_ptls_openssl_signature_scheme_t_536871802 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:153:3
-  struct_st_ptls_openssl_sign_certificate_t_536871807 {.pure, inheritable,
+    scheme_id*: uint16       ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:150:16
+    scheme_md*: proc (): ptr EVP_MD_553649019 {.cdecl.}
+  EVP_MD_553649018 = struct_evp_md_st ## Generated based on /usr/include/openssl/types.h:103:26
+  ptls_openssl_signature_scheme_t_553649020 = struct_st_ptls_openssl_signature_scheme_t_553649017 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:153:3
+  struct_st_ptls_openssl_sign_certificate_t_553649022 {.pure, inheritable,
       bycopy.} = object
-    super*: ptls_sign_certificate_t_536871734 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:165:16
-    key*: ptr EVP_PKEY_536871800
-    schemes*: ptr ptls_openssl_signature_scheme_t_536871806
+    super*: ptls_sign_certificate_t_553648949 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:165:16
+    key*: ptr EVP_PKEY_553649015
+    schemes*: ptr ptls_openssl_signature_scheme_t_553649021
     async* {.bitsize: 1'i64.}: cuint
-  ptls_openssl_sign_certificate_t_536871809 = struct_st_ptls_openssl_sign_certificate_t_536871808 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:177:3
-  X509_536871811 = struct_x509_st ## Generated based on /usr/include/openssl/types.h:157:24
-  struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871813 {.pure,
+  ptls_openssl_sign_certificate_t_553649024 = struct_st_ptls_openssl_sign_certificate_t_553649023 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:177:3
+  X509_553649026 = struct_x509_st ## Generated based on /usr/include/openssl/types.h:157:24
+  struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649028 {.pure,
       inheritable, bycopy.} = object
-    super*: ptls_verify_certificate_t_536871738 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:183:16
-    expected_pubkey*: ptr EVP_PKEY_536871800
-  ptls_openssl_raw_pubkey_verify_certificate_t_536871815 = struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871814 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:186:3
-  struct_st_ptls_openssl_override_verify_certificate_t_536871817 {.pure,
+    super*: ptls_verify_certificate_t_553648953 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:183:16
+    expected_pubkey*: ptr EVP_PKEY_553649015
+  ptls_openssl_raw_pubkey_verify_certificate_t_553649030 = struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649029 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:186:3
+  struct_st_ptls_openssl_override_verify_certificate_t_553649032 {.pure,
       inheritable, bycopy.} = object
-    cb*: proc (a0: ptr struct_st_ptls_openssl_override_verify_certificate_t_536871818;
-               a1: ptr ptls_t_536871630; a2: cint; a3: cint; a4: ptr X509_536871812;
-               a5: ptr struct_stack_st_X509): cint {.cdecl.} ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:195:1
-  ptls_openssl_override_verify_certificate_t_536871819 = struct_st_ptls_openssl_override_verify_certificate_t_536871818 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:195:1
-  struct_st_ptls_openssl_verify_certificate_t_536871821 {.pure, inheritable,
+    cb*: proc (a0: ptr struct_st_ptls_openssl_override_verify_certificate_t_553649033;
+               a1: ptr ptls_t_553648845; a2: cint; a3: cint; a4: ptr X509_553649027;
+               a5: ptr struct_stack_st_X509): cint {.cdecl.} ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:195:1
+  ptls_openssl_override_verify_certificate_t_553649034 = struct_st_ptls_openssl_override_verify_certificate_t_553649033 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:195:1
+  struct_st_ptls_openssl_verify_certificate_t_553649036 {.pure, inheritable,
       bycopy.} = object
-    super*: ptls_verify_certificate_t_536871738 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:198:16
-    cert_store*: ptr X509_STORE_536871824
-    override_callback*: ptr ptls_openssl_override_verify_certificate_t_536871820
-  X509_STORE_536871823 = struct_x509_store_st ## Generated based on /usr/include/openssl/types.h:164:30
-  ptls_openssl_verify_certificate_t_536871825 = struct_st_ptls_openssl_verify_certificate_t_536871822 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:202:3
-  EVP_CIPHER_CTX_536871827 = struct_evp_cipher_ctx_st ## Generated based on /usr/include/openssl/types.h:102:34
-  HMAC_CTX_536871829 = struct_hmac_ctx_st ## Generated based on /usr/include/openssl/types.h:132:28
-  EVP_MAC_CTX_536871831 = struct_evp_mac_ctx_st ## Generated based on /usr/include/openssl/types.h:106:31
-  struct_ngtcp2_crypto_picotls_ctx_536871833 {.pure, inheritable, bycopy.} = object
-    ptls*: ptr ptls_t_536871630 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h:43:16
-    handshake_properties*: ptls_handshake_properties_t_536871784
-  ngtcp2_crypto_picotls_ctx_536871835 = struct_ngtcp2_crypto_picotls_ctx_536871834 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h:53:3
-  struct_ptls_cred_buffer_s_536871837 {.pure, inheritable, bycopy.} = object
-    base*: cstring           ## Generated based on /home/r/vacp2p/nim-ngtcp2/build/lib/includes/utils/cred_buffer.h:8:16
+    super*: ptls_verify_certificate_t_553648953 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:198:16
+    cert_store*: ptr X509_STORE_553649039
+    override_callback*: ptr ptls_openssl_override_verify_certificate_t_553649035
+  X509_STORE_553649038 = struct_x509_store_st ## Generated based on /usr/include/openssl/types.h:164:30
+  ptls_openssl_verify_certificate_t_553649040 = struct_st_ptls_openssl_verify_certificate_t_553649037 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:202:3
+  EVP_CIPHER_CTX_553649042 = struct_evp_cipher_ctx_st ## Generated based on /usr/include/openssl/types.h:102:34
+  HMAC_CTX_553649044 = struct_hmac_ctx_st ## Generated based on /usr/include/openssl/types.h:132:28
+  EVP_MAC_CTX_553649046 = struct_evp_mac_ctx_st ## Generated based on /usr/include/openssl/types.h:106:31
+  struct_ngtcp2_crypto_picotls_ctx_553649048 {.pure, inheritable, bycopy.} = object
+    ptls*: ptr ptls_t_553648845 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h:43:16
+    handshake_properties*: ptls_handshake_properties_t_553648999
+  ngtcp2_crypto_picotls_ctx_553649050 = struct_ngtcp2_crypto_picotls_ctx_553649049 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto_picotls.h:53:3
+  struct_ptls_cred_buffer_s_553649052 {.pure, inheritable, bycopy.} = object
+    base*: cstring           ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/utils/cred_buffer.h:8:16
     len*: csize_t
     off*: csize_t
     owns_base*: cint
-  ptls_cred_buffer_t_536871839 = struct_ptls_cred_buffer_s_536871838 ## Generated based on /home/r/vacp2p/nim-ngtcp2/build/lib/includes/utils/cred_buffer.h:16:3
-  sa_family_t_536871841 = cushort ## Generated based on /usr/include/x86_64-linux-gnu/bits/sockaddr.h:28:28
-  in_port_t_536871843 = uint16 ## Generated based on /usr/include/netinet/in.h:125:18
-  compiler_socklen_t_536871845 = cuint ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:210:23
-  compiler_ssize_t_536871847 = clong ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:194:27
-  in_addr_t_536871849 = uint32 ## Generated based on /usr/include/netinet/in.h:30:18
-  struct_st_ptls_update_open_count_t_536871752 = (when declared(
-      struct_st_ptls_update_open_count_t):
-    when ownSizeof(struct_st_ptls_update_open_count_t) !=
-        ownSizeof(struct_st_ptls_update_open_count_t_536871751):
+  ptls_cred_buffer_t_553649054 = struct_ptls_cred_buffer_s_553649053 ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/utils/cred_buffer.h:16:3
+  sa_family_t_553649056 = cushort ## Generated based on /usr/include/x86_64-linux-gnu/bits/sockaddr.h:28:28
+  in_port_t_553649058 = uint16 ## Generated based on /usr/include/netinet/in.h:125:18
+  compiler_socklen_t_553649060 = cuint ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:210:23
+  compiler_ssize_t_553649062 = clong ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:194:27
+  in_addr_t_553649064 = uint32 ## Generated based on /usr/include/netinet/in.h:30:18
+  ptls_hpke_kem_t_553648913 = (when declared(ptls_hpke_kem_t):
+    when ownSizeof(ptls_hpke_kem_t) != ownSizeof(ptls_hpke_kem_t_553648912):
       static :
-        warning("Declaration of " & "struct_st_ptls_update_open_count_t" &
+        warning("Declaration of " & "ptls_hpke_kem_t" &
             " exists but with different size")
-    struct_st_ptls_update_open_count_t
-   else:
-    struct_st_ptls_update_open_count_t_536871751)
-  struct_st_ptls_key_exchange_algorithm_t_536871648 = (when declared(
-      struct_st_ptls_key_exchange_algorithm_t):
-    when ownSizeof(struct_st_ptls_key_exchange_algorithm_t) !=
-        ownSizeof(struct_st_ptls_key_exchange_algorithm_t_536871647):
+    ptls_hpke_kem_t
+  else:
+    ptls_hpke_kem_t_553648912)
+  ngtcp2_recv_retry_553648755 = (when declared(ngtcp2_recv_retry):
+    when ownSizeof(ngtcp2_recv_retry) != ownSizeof(ngtcp2_recv_retry_553648754):
       static :
-        warning("Declaration of " & "struct_st_ptls_key_exchange_algorithm_t" &
+        warning("Declaration of " & "ngtcp2_recv_retry" &
             " exists but with different size")
-    struct_st_ptls_key_exchange_algorithm_t
-   else:
-    struct_st_ptls_key_exchange_algorithm_t_536871647)
-  ngtcp2_preferred_addr_536871441 = (when declared(ngtcp2_preferred_addr):
-    when ownSizeof(ngtcp2_preferred_addr) != ownSizeof(ngtcp2_preferred_addr_536871440):
+    ngtcp2_recv_retry
+  else:
+    ngtcp2_recv_retry_553648754)
+  X509_553649027 = (when declared(X509):
+    when ownSizeof(X509) != ownSizeof(X509_553649026):
       static :
-        warning("Declaration of " & "ngtcp2_preferred_addr" &
-            " exists but with different size")
-    ngtcp2_preferred_addr
-   else:
-    ngtcp2_preferred_addr_536871440)
-  ngtcp2_connection_id_status_type_536871578 = (when declared(
-      ngtcp2_connection_id_status_type):
-    when ownSizeof(ngtcp2_connection_id_status_type) !=
-        ownSizeof(ngtcp2_connection_id_status_type_536871577):
-      static :
-        warning("Declaration of " & "ngtcp2_connection_id_status_type" &
-            " exists but with different size")
-    ngtcp2_connection_id_status_type
-   else:
-    ngtcp2_connection_id_status_type_536871577)
-  struct_sockaddr_536871421 = (when declared(struct_sockaddr):
-    when ownSizeof(struct_sockaddr) != ownSizeof(struct_sockaddr_536871420):
-      static :
-        warning("Declaration of " & "struct_sockaddr" &
-            " exists but with different size")
-    struct_sockaddr
-   else:
-    struct_sockaddr_536871420)
-  struct_st_ptls_aead_algorithm_t_536871670 = (when declared(
-      struct_st_ptls_aead_algorithm_t):
-    when ownSizeof(struct_st_ptls_aead_algorithm_t) !=
-        ownSizeof(struct_st_ptls_aead_algorithm_t_536871669):
-      static :
-        warning("Declaration of " & "struct_st_ptls_aead_algorithm_t" &
-            " exists but with different size")
-    struct_st_ptls_aead_algorithm_t
-   else:
-    struct_st_ptls_aead_algorithm_t_536871669)
-  struct_st_ptls_hash_context_t_536871680 = (when declared(
-      struct_st_ptls_hash_context_t):
-    when ownSizeof(struct_st_ptls_hash_context_t) !=
-        ownSizeof(struct_st_ptls_hash_context_t_536871679):
-      static :
-        warning("Declaration of " & "struct_st_ptls_hash_context_t" &
-            " exists but with different size")
-    struct_st_ptls_hash_context_t
-   else:
-    struct_st_ptls_hash_context_t_536871679)
-  ngtcp2_encrypt_536871542 = (when declared(ngtcp2_encrypt):
-    when ownSizeof(ngtcp2_encrypt) != ownSizeof(ngtcp2_encrypt_536871541):
-      static :
-        warning("Declaration of " & "ngtcp2_encrypt" &
-            " exists but with different size")
-    ngtcp2_encrypt
-   else:
-    ngtcp2_encrypt_536871541)
-  struct_ngtcp2_ccerr_536871616 = (when declared(struct_ngtcp2_ccerr):
-    when ownSizeof(struct_ngtcp2_ccerr) != ownSizeof(struct_ngtcp2_ccerr_536871615):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_ccerr" &
-            " exists but with different size")
-    struct_ngtcp2_ccerr
-   else:
-    struct_ngtcp2_ccerr_536871615)
-  struct_st_ptls_message_emitter_t_536871692 = (when declared(
-      struct_st_ptls_message_emitter_t):
-    when ownSizeof(struct_st_ptls_message_emitter_t) !=
-        ownSizeof(struct_st_ptls_message_emitter_t_536871691):
-      static :
-        warning("Declaration of " & "struct_st_ptls_message_emitter_t" &
-            " exists but with different size")
-    struct_st_ptls_message_emitter_t
-   else:
-    struct_st_ptls_message_emitter_t_536871691)
-  ptls_hpke_cipher_suite_t_536871706 = (when declared(ptls_hpke_cipher_suite_t):
-    when ownSizeof(ptls_hpke_cipher_suite_t) !=
-        ownSizeof(ptls_hpke_cipher_suite_t_536871705):
-      static :
-        warning("Declaration of " & "ptls_hpke_cipher_suite_t" &
-            " exists but with different size")
-    ptls_hpke_cipher_suite_t
-   else:
-    ptls_hpke_cipher_suite_t_536871705)
-  ngtcp2_pkt_hd_536871413 = (when declared(ngtcp2_pkt_hd):
-    when ownSizeof(ngtcp2_pkt_hd) != ownSizeof(ngtcp2_pkt_hd_536871412):
-      static :
-        warning("Declaration of " & "ngtcp2_pkt_hd" &
-            " exists but with different size")
-    ngtcp2_pkt_hd
-   else:
-    ngtcp2_pkt_hd_536871412)
-  struct_sockaddr_in_536871425 = (when declared(struct_sockaddr_in):
-    when ownSizeof(struct_sockaddr_in) != ownSizeof(struct_sockaddr_in_536871424):
-      static :
-        warning("Declaration of " & "struct_sockaddr_in" &
-            " exists but with different size")
-    struct_sockaddr_in
-   else:
-    struct_sockaddr_in_536871424)
-  enum_ngtcp2_token_type_536871474 = (when declared(enum_ngtcp2_token_type):
-    when ownSizeof(enum_ngtcp2_token_type) != ownSizeof(enum_ngtcp2_token_type_536871473):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_token_type" &
-            " exists but with different size")
-    enum_ngtcp2_token_type
-   else:
-    enum_ngtcp2_token_type_536871473)
-  struct_ngtcp2_rand_ctx_536871468 = (when declared(struct_ngtcp2_rand_ctx):
-    when ownSizeof(struct_ngtcp2_rand_ctx) != ownSizeof(struct_ngtcp2_rand_ctx_536871467):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_rand_ctx" &
-            " exists but with different size")
-    struct_ngtcp2_rand_ctx
-   else:
-    struct_ngtcp2_rand_ctx_536871467)
-  ngtcp2_stream_open_536871550 = (when declared(ngtcp2_stream_open):
-    when ownSizeof(ngtcp2_stream_open) != ownSizeof(ngtcp2_stream_open_536871549):
-      static :
-        warning("Declaration of " & "ngtcp2_stream_open" &
-            " exists but with different size")
-    ngtcp2_stream_open
-   else:
-    ngtcp2_stream_open_536871549)
-  struct_sockaddr_in6_536871429 = (when declared(struct_sockaddr_in6):
-    when ownSizeof(struct_sockaddr_in6) != ownSizeof(struct_sockaddr_in6_536871428):
-      static :
-        warning("Declaration of " & "struct_sockaddr_in6" &
-            " exists but with different size")
-    struct_sockaddr_in6
-   else:
-    struct_sockaddr_in6_536871428)
-  enum_ngtcp2_ccerr_type_536871612 = (when declared(enum_ngtcp2_ccerr_type):
-    when ownSizeof(enum_ngtcp2_ccerr_type) != ownSizeof(enum_ngtcp2_ccerr_type_536871611):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_ccerr_type" &
-            " exists but with different size")
-    enum_ngtcp2_ccerr_type
-   else:
-    enum_ngtcp2_ccerr_type_536871611)
-  ptls_key_exchange_context_t_536871650 = (when declared(
-      ptls_key_exchange_context_t):
-    when ownSizeof(ptls_key_exchange_context_t) !=
-        ownSizeof(ptls_key_exchange_context_t_536871649):
-      static :
-        warning("Declaration of " & "ptls_key_exchange_context_t" &
-            " exists but with different size")
-    ptls_key_exchange_context_t
-   else:
-    ptls_key_exchange_context_t_536871649)
-  struct_st_ptls_on_client_hello_t_536871720 = (when declared(
-      struct_st_ptls_on_client_hello_t):
-    when ownSizeof(struct_st_ptls_on_client_hello_t) !=
-        ownSizeof(struct_st_ptls_on_client_hello_t_536871719):
-      static :
-        warning("Declaration of " & "struct_st_ptls_on_client_hello_t" &
-            " exists but with different size")
-    struct_st_ptls_on_client_hello_t
-   else:
-    struct_st_ptls_on_client_hello_t_536871719)
-  struct_st_ptls_on_extension_t_536871762 = (when declared(
-      struct_st_ptls_on_extension_t):
-    when ownSizeof(struct_st_ptls_on_extension_t) !=
-        ownSizeof(struct_st_ptls_on_extension_t_536871761):
-      static :
-        warning("Declaration of " & "struct_st_ptls_on_extension_t" &
-            " exists but with different size")
-    struct_st_ptls_on_extension_t
-   else:
-    struct_st_ptls_on_extension_t_536871761)
-  ngtcp2_stream_stop_sending_536871596 = (when declared(
-      ngtcp2_stream_stop_sending):
-    when ownSizeof(ngtcp2_stream_stop_sending) !=
-        ownSizeof(ngtcp2_stream_stop_sending_536871595):
-      static :
-        warning("Declaration of " & "ngtcp2_stream_stop_sending" &
-            " exists but with different size")
-    ngtcp2_stream_stop_sending
-   else:
-    ngtcp2_stream_stop_sending_536871595)
-  ngtcp2_sockaddr_in_536871423 = (when declared(ngtcp2_sockaddr_in):
-    when ownSizeof(ngtcp2_sockaddr_in) != ownSizeof(ngtcp2_sockaddr_in_536871422):
+        warning("Declaration of " & "X509" & " exists but with different size")
+    X509
+  else:
+    X509_553649026)
+  ngtcp2_sockaddr_in_553648638 = (when declared(ngtcp2_sockaddr_in):
+    when ownSizeof(ngtcp2_sockaddr_in) != ownSizeof(ngtcp2_sockaddr_in_553648637):
       static :
         warning("Declaration of " & "ngtcp2_sockaddr_in" &
             " exists but with different size")
     ngtcp2_sockaddr_in
-   else:
-    ngtcp2_sockaddr_in_536871422)
-  struct_ngtcp2_callbacks_536871604 = (when declared(struct_ngtcp2_callbacks):
-    when ownSizeof(struct_ngtcp2_callbacks) !=
-        ownSizeof(struct_ngtcp2_callbacks_536871603):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_callbacks" &
-            " exists but with different size")
-    struct_ngtcp2_callbacks
-   else:
-    struct_ngtcp2_callbacks_536871603)
-  ngtcp2_recv_datagram_536871588 = (when declared(ngtcp2_recv_datagram):
-    when ownSizeof(ngtcp2_recv_datagram) != ownSizeof(ngtcp2_recv_datagram_536871587):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_datagram" &
-            " exists but with different size")
-    ngtcp2_recv_datagram
-   else:
-    ngtcp2_recv_datagram_536871587)
-  ptls_cipher_suite_t_536871690 = (when declared(ptls_cipher_suite_t):
-    when ownSizeof(ptls_cipher_suite_t) != ownSizeof(ptls_cipher_suite_t_536871689):
-      static :
-        warning("Declaration of " & "ptls_cipher_suite_t" &
-            " exists but with different size")
-    ptls_cipher_suite_t
-   else:
-    ptls_cipher_suite_t_536871689)
-  ngtcp2_path_536871488 = (when declared(ngtcp2_path):
-    when ownSizeof(ngtcp2_path) != ownSizeof(ngtcp2_path_536871487):
-      static :
-        warning("Declaration of " & "ngtcp2_path" &
-            " exists but with different size")
-    ngtcp2_path
-   else:
-    ngtcp2_path_536871487)
-  ngtcp2_pkt_info_536871389 = (when declared(ngtcp2_pkt_info):
-    when ownSizeof(ngtcp2_pkt_info) != ownSizeof(ngtcp2_pkt_info_536871388):
-      static :
-        warning("Declaration of " & "ngtcp2_pkt_info" &
-            " exists but with different size")
-    ngtcp2_pkt_info
-   else:
-    ngtcp2_pkt_info_536871388)
-  ngtcp2_encryption_level_536871530 = (when declared(ngtcp2_encryption_level):
-    when ownSizeof(ngtcp2_encryption_level) !=
-        ownSizeof(ngtcp2_encryption_level_536871529):
-      static :
-        warning("Declaration of " & "ngtcp2_encryption_level" &
-            " exists but with different size")
-    ngtcp2_encryption_level
-   else:
-    ngtcp2_encryption_level_536871529)
-  struct_ngtcp2_info_536871620 = (when declared(struct_ngtcp2_info):
-    when ownSizeof(struct_ngtcp2_info) != ownSizeof(struct_ngtcp2_info_536871619):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_info" &
-            " exists but with different size")
-    struct_ngtcp2_info
-   else:
-    struct_ngtcp2_info_536871619)
-  ptls_encrypt_ticket_t_536871742 = (when declared(ptls_encrypt_ticket_t):
-    when ownSizeof(ptls_encrypt_ticket_t) != ownSizeof(ptls_encrypt_ticket_t_536871741):
-      static :
-        warning("Declaration of " & "ptls_encrypt_ticket_t" &
-            " exists but with different size")
-    ptls_encrypt_ticket_t
-   else:
-    ptls_encrypt_ticket_t_536871741)
-  struct_ngtcp2_crypto_aead_536871498 = (when declared(struct_ngtcp2_crypto_aead):
-    when ownSizeof(struct_ngtcp2_crypto_aead) !=
-        ownSizeof(struct_ngtcp2_crypto_aead_536871497):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_aead" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_aead
-   else:
-    struct_ngtcp2_crypto_aead_536871497)
-  enum_ngtcp2_path_validation_result_536871395 = (when declared(
-      enum_ngtcp2_path_validation_result):
-    when ownSizeof(enum_ngtcp2_path_validation_result) !=
-        ownSizeof(enum_ngtcp2_path_validation_result_536871394):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_path_validation_result" &
-            " exists but with different size")
-    enum_ngtcp2_path_validation_result
-   else:
-    enum_ngtcp2_path_validation_result_536871394)
-  ptls_message_emitter_t_536871694 = (when declared(ptls_message_emitter_t):
-    when ownSizeof(ptls_message_emitter_t) != ownSizeof(ptls_message_emitter_t_536871693):
+  else:
+    ngtcp2_sockaddr_in_553648637)
+  ptls_message_emitter_t_553648909 = (when declared(ptls_message_emitter_t):
+    when ownSizeof(ptls_message_emitter_t) != ownSizeof(ptls_message_emitter_t_553648908):
       static :
         warning("Declaration of " & "ptls_message_emitter_t" &
             " exists but with different size")
     ptls_message_emitter_t
-   else:
-    ptls_message_emitter_t_536871693)
-  EVP_CIPHER_CTX_536871828 = (when declared(EVP_CIPHER_CTX):
-    when ownSizeof(EVP_CIPHER_CTX) != ownSizeof(EVP_CIPHER_CTX_536871827):
+  else:
+    ptls_message_emitter_t_553648908)
+  struct_st_ptls_verify_certificate_t_553648951 = (when declared(
+      struct_st_ptls_verify_certificate_t):
+    when ownSizeof(struct_st_ptls_verify_certificate_t) !=
+        ownSizeof(struct_st_ptls_verify_certificate_t_553648950):
       static :
-        warning("Declaration of " & "EVP_CIPHER_CTX" &
+        warning("Declaration of " & "struct_st_ptls_verify_certificate_t" &
             " exists but with different size")
-    EVP_CIPHER_CTX
-   else:
-    EVP_CIPHER_CTX_536871827)
-  struct_ngtcp2_path_storage_536871490 = (when declared(
-      struct_ngtcp2_path_storage):
-    when ownSizeof(struct_ngtcp2_path_storage) !=
-        ownSizeof(struct_ngtcp2_path_storage_536871489):
+    struct_st_ptls_verify_certificate_t
+  else:
+    struct_st_ptls_verify_certificate_t_553648950)
+  struct_ngtcp2_transport_params_553648662 = (when declared(
+      struct_ngtcp2_transport_params):
+    when ownSizeof(struct_ngtcp2_transport_params) !=
+        ownSizeof(struct_ngtcp2_transport_params_553648661):
       static :
-        warning("Declaration of " & "struct_ngtcp2_path_storage" &
+        warning("Declaration of " & "struct_ngtcp2_transport_params" &
             " exists but with different size")
-    struct_ngtcp2_path_storage
-   else:
-    struct_ngtcp2_path_storage_536871489)
-  ngtcp2_crypto_aead_ctx_536871508 = (when declared(ngtcp2_crypto_aead_ctx):
-    when ownSizeof(ngtcp2_crypto_aead_ctx) != ownSizeof(ngtcp2_crypto_aead_ctx_536871507):
+    struct_ngtcp2_transport_params
+  else:
+    struct_ngtcp2_transport_params_553648661)
+  EVP_MAC_CTX_553649047 = (when declared(EVP_MAC_CTX):
+    when ownSizeof(EVP_MAC_CTX) != ownSizeof(EVP_MAC_CTX_553649046):
       static :
-        warning("Declaration of " & "ngtcp2_crypto_aead_ctx" &
+        warning("Declaration of " & "EVP_MAC_CTX" &
             " exists but with different size")
-    ngtcp2_crypto_aead_ctx
-   else:
-    ngtcp2_crypto_aead_ctx_536871507)
-  ngtcp2_settings_536871480 = (when declared(ngtcp2_settings):
-    when ownSizeof(ngtcp2_settings) != ownSizeof(ngtcp2_settings_536871479):
+    EVP_MAC_CTX
+  else:
+    EVP_MAC_CTX_553649046)
+  struct_st_ptls_log_state_t_553649001 = (when declared(
+      struct_st_ptls_log_state_t):
+    when ownSizeof(struct_st_ptls_log_state_t) !=
+        ownSizeof(struct_st_ptls_log_state_t_553649000):
       static :
-        warning("Declaration of " & "ngtcp2_settings" &
+        warning("Declaration of " & "struct_st_ptls_log_state_t" &
             " exists but with different size")
-    ngtcp2_settings
-   else:
-    ngtcp2_settings_536871479)
-  struct_st_ptls_context_t_536871634 = (when declared(struct_st_ptls_context_t):
-    when ownSizeof(struct_st_ptls_context_t) !=
-        ownSizeof(struct_st_ptls_context_t_536871633):
+    struct_st_ptls_log_state_t
+  else:
+    struct_st_ptls_log_state_t_553649000)
+  struct_st_ptls_client_hello_psk_identity_t_553648923 = (when declared(
+      struct_st_ptls_client_hello_psk_identity_t):
+    when ownSizeof(struct_st_ptls_client_hello_psk_identity_t) !=
+        ownSizeof(struct_st_ptls_client_hello_psk_identity_t_553648922):
       static :
-        warning("Declaration of " & "struct_st_ptls_context_t" &
+        warning("Declaration of " & "struct_st_ptls_client_hello_psk_identity_t" &
             " exists but with different size")
-    struct_st_ptls_context_t
-   else:
-    struct_st_ptls_context_t_536871633)
-  struct_st_ptls_aead_supplementary_encryption_t_536871664 = (when declared(
+    struct_st_ptls_client_hello_psk_identity_t
+  else:
+    struct_st_ptls_client_hello_psk_identity_t_553648922)
+  ptls_emit_certificate_t_553648941 = (when declared(ptls_emit_certificate_t):
+    when ownSizeof(ptls_emit_certificate_t) !=
+        ownSizeof(ptls_emit_certificate_t_553648940):
+      static :
+        warning("Declaration of " & "ptls_emit_certificate_t" &
+            " exists but with different size")
+    ptls_emit_certificate_t
+  else:
+    ptls_emit_certificate_t_553648940)
+  ngtcp2_path_validation_result_553648612 = (when declared(
+      ngtcp2_path_validation_result):
+    when ownSizeof(ngtcp2_path_validation_result) !=
+        ownSizeof(ngtcp2_path_validation_result_553648611):
+      static :
+        warning("Declaration of " & "ngtcp2_path_validation_result" &
+            " exists but with different size")
+    ngtcp2_path_validation_result
+  else:
+    ngtcp2_path_validation_result_553648611)
+  ngtcp2_ack_datagram_553648805 = (when declared(ngtcp2_ack_datagram):
+    when ownSizeof(ngtcp2_ack_datagram) != ownSizeof(ngtcp2_ack_datagram_553648804):
+      static :
+        warning("Declaration of " & "ngtcp2_ack_datagram" &
+            " exists but with different size")
+    ngtcp2_ack_datagram
+  else:
+    ngtcp2_ack_datagram_553648804)
+  ngtcp2_info_553648837 = (when declared(ngtcp2_info):
+    when ownSizeof(ngtcp2_info) != ownSizeof(ngtcp2_info_553648836):
+      static :
+        warning("Declaration of " & "ngtcp2_info" &
+            " exists but with different size")
+    ngtcp2_info
+  else:
+    ngtcp2_info_553648836)
+  struct_st_ptls_cipher_suite_t_553648903 = (when declared(
+      struct_st_ptls_cipher_suite_t):
+    when ownSizeof(struct_st_ptls_cipher_suite_t) !=
+        ownSizeof(struct_st_ptls_cipher_suite_t_553648902):
+      static :
+        warning("Declaration of " & "struct_st_ptls_cipher_suite_t" &
+            " exists but with different size")
+    struct_st_ptls_cipher_suite_t
+  else:
+    struct_st_ptls_cipher_suite_t_553648902)
+  struct_ngtcp2_crypto_picotls_ctx_553649049 = (when declared(
+      struct_ngtcp2_crypto_picotls_ctx):
+    when ownSizeof(struct_ngtcp2_crypto_picotls_ctx) !=
+        ownSizeof(struct_ngtcp2_crypto_picotls_ctx_553649048):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_picotls_ctx" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_picotls_ctx
+  else:
+    struct_ngtcp2_crypto_picotls_ctx_553649048)
+  struct_st_ptls_on_client_hello_t_553648935 = (when declared(
+      struct_st_ptls_on_client_hello_t):
+    when ownSizeof(struct_st_ptls_on_client_hello_t) !=
+        ownSizeof(struct_st_ptls_on_client_hello_t_553648934):
+      static :
+        warning("Declaration of " & "struct_st_ptls_on_client_hello_t" &
+            " exists but with different size")
+    struct_st_ptls_on_client_hello_t
+  else:
+    struct_st_ptls_on_client_hello_t_553648934)
+  ngtcp2_stream_close_553648767 = (when declared(ngtcp2_stream_close):
+    when ownSizeof(ngtcp2_stream_close) != ownSizeof(ngtcp2_stream_close_553648766):
+      static :
+        warning("Declaration of " & "ngtcp2_stream_close" &
+            " exists but with different size")
+    ngtcp2_stream_close
+  else:
+    ngtcp2_stream_close_553648766)
+  X509_STORE_553649039 = (when declared(X509_STORE):
+    when ownSizeof(X509_STORE) != ownSizeof(X509_STORE_553649038):
+      static :
+        warning("Declaration of " & "X509_STORE" &
+            " exists but with different size")
+    X509_STORE
+  else:
+    X509_STORE_553649038)
+  struct_ngtcp2_callbacks_553648819 = (when declared(struct_ngtcp2_callbacks):
+    when ownSizeof(struct_ngtcp2_callbacks) !=
+        ownSizeof(struct_ngtcp2_callbacks_553648818):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_callbacks" &
+            " exists but with different size")
+    struct_ngtcp2_callbacks
+  else:
+    struct_ngtcp2_callbacks_553648818)
+  struct_ngtcp2_info_553648835 = (when declared(struct_ngtcp2_info):
+    when ownSizeof(struct_ngtcp2_info) != ownSizeof(struct_ngtcp2_info_553648834):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_info" &
+            " exists but with different size")
+    struct_ngtcp2_info
+  else:
+    struct_ngtcp2_info_553648834)
+  ngtcp2_delete_crypto_aead_ctx_553648799 = (when declared(
+      ngtcp2_delete_crypto_aead_ctx):
+    when ownSizeof(ngtcp2_delete_crypto_aead_ctx) !=
+        ownSizeof(ngtcp2_delete_crypto_aead_ctx_553648798):
+      static :
+        warning("Declaration of " & "ngtcp2_delete_crypto_aead_ctx" &
+            " exists but with different size")
+    ngtcp2_delete_crypto_aead_ctx
+  else:
+    ngtcp2_delete_crypto_aead_ctx_553648798)
+  ptls_get_time_t_553648933 = (when declared(ptls_get_time_t):
+    when ownSizeof(ptls_get_time_t) != ownSizeof(ptls_get_time_t_553648932):
+      static :
+        warning("Declaration of " & "ptls_get_time_t" &
+            " exists but with different size")
+    ptls_get_time_t
+  else:
+    ptls_get_time_t_553648932)
+  ngtcp2_select_preferred_addr_553648789 = (when declared(
+      ngtcp2_select_preferred_addr):
+    when ownSizeof(ngtcp2_select_preferred_addr) !=
+        ownSizeof(ngtcp2_select_preferred_addr_553648788):
+      static :
+        warning("Declaration of " & "ngtcp2_select_preferred_addr" &
+            " exists but with different size")
+    ngtcp2_select_preferred_addr
+  else:
+    ngtcp2_select_preferred_addr_553648788)
+  ptls_update_traffic_key_t_553648975 = (when declared(ptls_update_traffic_key_t):
+    when ownSizeof(ptls_update_traffic_key_t) !=
+        ownSizeof(ptls_update_traffic_key_t_553648974):
+      static :
+        warning("Declaration of " & "ptls_update_traffic_key_t" &
+            " exists but with different size")
+    ptls_update_traffic_key_t
+  else:
+    ptls_update_traffic_key_t_553648974)
+  struct_st_ptls_log_t_553649011 = (when declared(struct_st_ptls_log_t):
+    when ownSizeof(struct_st_ptls_log_t) != ownSizeof(struct_st_ptls_log_t_553649010):
+      static :
+        warning("Declaration of " & "struct_st_ptls_log_t" &
+            " exists but with different size")
+    struct_st_ptls_log_t
+  else:
+    struct_st_ptls_log_t_553649010)
+  struct_ngtcp2_version_info_553648658 = (when declared(
+      struct_ngtcp2_version_info):
+    when ownSizeof(struct_ngtcp2_version_info) !=
+        ownSizeof(struct_ngtcp2_version_info_553648657):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_version_info" &
+            " exists but with different size")
+    struct_ngtcp2_version_info
+  else:
+    struct_ngtcp2_version_info_553648657)
+  enum_en_ptls_hash_final_mode_t_553648891 = (when declared(
+      enum_en_ptls_hash_final_mode_t):
+    when ownSizeof(enum_en_ptls_hash_final_mode_t) !=
+        ownSizeof(enum_en_ptls_hash_final_mode_t_553648890):
+      static :
+        warning("Declaration of " & "enum_en_ptls_hash_final_mode_t" &
+            " exists but with different size")
+    enum_en_ptls_hash_final_mode_t
+  else:
+    enum_en_ptls_hash_final_mode_t_553648890)
+  ngtcp2_encryption_level_553648745 = (when declared(ngtcp2_encryption_level):
+    when ownSizeof(ngtcp2_encryption_level) !=
+        ownSizeof(ngtcp2_encryption_level_553648744):
+      static :
+        warning("Declaration of " & "ngtcp2_encryption_level" &
+            " exists but with different size")
+    ngtcp2_encryption_level
+  else:
+    ngtcp2_encryption_level_553648744)
+  struct_st_ptls_update_open_count_t_553648967 = (when declared(
+      struct_st_ptls_update_open_count_t):
+    when ownSizeof(struct_st_ptls_update_open_count_t) !=
+        ownSizeof(struct_st_ptls_update_open_count_t_553648966):
+      static :
+        warning("Declaration of " & "struct_st_ptls_update_open_count_t" &
+            " exists but with different size")
+    struct_st_ptls_update_open_count_t
+  else:
+    struct_st_ptls_update_open_count_t_553648966)
+  ngtcp2_malloc_553648590 = (when declared(ngtcp2_malloc):
+    when ownSizeof(ngtcp2_malloc) != ownSizeof(ngtcp2_malloc_553648589):
+      static :
+        warning("Declaration of " & "ngtcp2_malloc" &
+            " exists but with different size")
+    ngtcp2_malloc
+  else:
+    ngtcp2_malloc_553648589)
+  struct_ngtcp2_pkt_hd_553648626 = (when declared(struct_ngtcp2_pkt_hd):
+    when ownSizeof(struct_ngtcp2_pkt_hd) != ownSizeof(struct_ngtcp2_pkt_hd_553648625):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_pkt_hd" &
+            " exists but with different size")
+    struct_ngtcp2_pkt_hd
+  else:
+    struct_ngtcp2_pkt_hd_553648625)
+  ngtcp2_conn_553648737 = (when declared(ngtcp2_conn):
+    when ownSizeof(ngtcp2_conn) != ownSizeof(ngtcp2_conn_553648736):
+      static :
+        warning("Declaration of " & "ngtcp2_conn" &
+            " exists but with different size")
+    ngtcp2_conn
+  else:
+    ngtcp2_conn_553648736)
+  ngtcp2_connection_id_status_553648795 = (when declared(
+      ngtcp2_connection_id_status):
+    when ownSizeof(ngtcp2_connection_id_status) !=
+        ownSizeof(ngtcp2_connection_id_status_553648794):
+      static :
+        warning("Declaration of " & "ngtcp2_connection_id_status" &
+            " exists but with different size")
+    ngtcp2_connection_id_status
+  else:
+    ngtcp2_connection_id_status_553648794)
+  ngtcp2_recv_key_553648815 = (when declared(ngtcp2_recv_key):
+    when ownSizeof(ngtcp2_recv_key) != ownSizeof(ngtcp2_recv_key_553648814):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_key" &
+            " exists but with different size")
+    ngtcp2_recv_key
+  else:
+    ngtcp2_recv_key_553648814)
+  ptls_key_exchange_context_t_553648865 = (when declared(
+      ptls_key_exchange_context_t):
+    when ownSizeof(ptls_key_exchange_context_t) !=
+        ownSizeof(ptls_key_exchange_context_t_553648864):
+      static :
+        warning("Declaration of " & "ptls_key_exchange_context_t" &
+            " exists but with different size")
+    ptls_key_exchange_context_t
+  else:
+    ptls_key_exchange_context_t_553648864)
+  struct_ngtcp2_crypto_aead_ctx_553648721 = (when declared(
+      struct_ngtcp2_crypto_aead_ctx):
+    when ownSizeof(struct_ngtcp2_crypto_aead_ctx) !=
+        ownSizeof(struct_ngtcp2_crypto_aead_ctx_553648720):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_aead_ctx" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_aead_ctx
+  else:
+    struct_ngtcp2_crypto_aead_ctx_553648720)
+  ptls_ech_create_opener_t_553648987 = (when declared(ptls_ech_create_opener_t):
+    when ownSizeof(ptls_ech_create_opener_t) !=
+        ownSizeof(ptls_ech_create_opener_t_553648986):
+      static :
+        warning("Declaration of " & "ptls_ech_create_opener_t" &
+            " exists but with different size")
+    ptls_ech_create_opener_t
+  else:
+    ptls_ech_create_opener_t_553648986)
+  struct_st_ptls_sign_certificate_t_553648947 = (when declared(
+      struct_st_ptls_sign_certificate_t):
+    when ownSizeof(struct_st_ptls_sign_certificate_t) !=
+        ownSizeof(struct_st_ptls_sign_certificate_t_553648946):
+      static :
+        warning("Declaration of " & "struct_st_ptls_sign_certificate_t" &
+            " exists but with different size")
+    struct_st_ptls_sign_certificate_t
+  else:
+    struct_st_ptls_sign_certificate_t_553648946)
+  ngtcp2_duration_553648616 = (when declared(ngtcp2_duration):
+    when ownSizeof(ngtcp2_duration) != ownSizeof(ngtcp2_duration_553648615):
+      static :
+        warning("Declaration of " & "ngtcp2_duration" &
+            " exists but with different size")
+    ngtcp2_duration
+  else:
+    ngtcp2_duration_553648615)
+  struct_sockaddr_in_553648640 = (when declared(struct_sockaddr_in):
+    when ownSizeof(struct_sockaddr_in) != ownSizeof(struct_sockaddr_in_553648639):
+      static :
+        warning("Declaration of " & "struct_sockaddr_in" &
+            " exists but with different size")
+    struct_sockaddr_in
+  else:
+    struct_sockaddr_in_553648639)
+  compiler_socklen_t_553649061 = (when declared(compiler_socklen_t):
+    when ownSizeof(compiler_socklen_t) != ownSizeof(compiler_socklen_t_553649060):
+      static :
+        warning("Declaration of " & "compiler_socklen_t" &
+            " exists but with different size")
+    compiler_socklen_t
+  else:
+    compiler_socklen_t_553649060)
+  ngtcp2_cc_algo_553648679 = (when declared(ngtcp2_cc_algo):
+    when ownSizeof(ngtcp2_cc_algo) != ownSizeof(ngtcp2_cc_algo_553648678):
+      static :
+        warning("Declaration of " & "ngtcp2_cc_algo" &
+            " exists but with different size")
+    ngtcp2_cc_algo
+  else:
+    ngtcp2_cc_algo_553648678)
+  ngtcp2_crypto_md_553648711 = (when declared(ngtcp2_crypto_md):
+    when ownSizeof(ngtcp2_crypto_md) != ownSizeof(ngtcp2_crypto_md_553648710):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_md" &
+            " exists but with different size")
+    ngtcp2_crypto_md
+  else:
+    ngtcp2_crypto_md_553648710)
+  struct_st_ptls_raw_extension_t_553648989 = (when declared(
+      struct_st_ptls_raw_extension_t):
+    when ownSizeof(struct_st_ptls_raw_extension_t) !=
+        ownSizeof(struct_st_ptls_raw_extension_t_553648988):
+      static :
+        warning("Declaration of " & "struct_st_ptls_raw_extension_t" &
+            " exists but with different size")
+    struct_st_ptls_raw_extension_t
+  else:
+    struct_st_ptls_raw_extension_t_553648988)
+  struct_ngtcp2_path_553648701 = (when declared(struct_ngtcp2_path):
+    when ownSizeof(struct_ngtcp2_path) != ownSizeof(struct_ngtcp2_path_553648700):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_path" &
+            " exists but with different size")
+    struct_ngtcp2_path
+  else:
+    struct_ngtcp2_path_553648700)
+  ngtcp2_decrypt_553648759 = (when declared(ngtcp2_decrypt):
+    when ownSizeof(ngtcp2_decrypt) != ownSizeof(ngtcp2_decrypt_553648758):
+      static :
+        warning("Declaration of " & "ngtcp2_decrypt" &
+            " exists but with different size")
+    ngtcp2_decrypt
+  else:
+    ngtcp2_decrypt_553648758)
+  ngtcp2_tstamp_553648614 = (when declared(ngtcp2_tstamp):
+    when ownSizeof(ngtcp2_tstamp) != ownSizeof(ngtcp2_tstamp_553648613):
+      static :
+        warning("Declaration of " & "ngtcp2_tstamp" &
+            " exists but with different size")
+    ngtcp2_tstamp
+  else:
+    ngtcp2_tstamp_553648613)
+  struct_st_ptls_key_exchange_context_t_553648861 = (when declared(
+      struct_st_ptls_key_exchange_context_t):
+    when ownSizeof(struct_st_ptls_key_exchange_context_t) !=
+        ownSizeof(struct_st_ptls_key_exchange_context_t_553648860):
+      static :
+        warning("Declaration of " & "struct_st_ptls_key_exchange_context_t" &
+            " exists but with different size")
+    struct_st_ptls_key_exchange_context_t
+  else:
+    struct_st_ptls_key_exchange_context_t_553648860)
+  ngtcp2_crypto_conn_ref_553648839 = (when declared(ngtcp2_crypto_conn_ref):
+    when ownSizeof(ngtcp2_crypto_conn_ref) != ownSizeof(ngtcp2_crypto_conn_ref_553648838):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_conn_ref" &
+            " exists but with different size")
+    ngtcp2_crypto_conn_ref
+  else:
+    ngtcp2_crypto_conn_ref_553648838)
+  ptls_raw_extension_t_553648991 = (when declared(ptls_raw_extension_t):
+    when ownSizeof(ptls_raw_extension_t) != ownSizeof(ptls_raw_extension_t_553648990):
+      static :
+        warning("Declaration of " & "ptls_raw_extension_t" &
+            " exists but with different size")
+    ptls_raw_extension_t
+  else:
+    ptls_raw_extension_t_553648990)
+  ngtcp2_recv_version_negotiation_553648753 = (when declared(
+      ngtcp2_recv_version_negotiation):
+    when ownSizeof(ngtcp2_recv_version_negotiation) !=
+        ownSizeof(ngtcp2_recv_version_negotiation_553648752):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_version_negotiation" &
+            " exists but with different size")
+    ngtcp2_recv_version_negotiation
+  else:
+    ngtcp2_recv_version_negotiation_553648752)
+  ptls_on_extension_t_553648979 = (when declared(ptls_on_extension_t):
+    when ownSizeof(ptls_on_extension_t) != ownSizeof(ptls_on_extension_t_553648978):
+      static :
+        warning("Declaration of " & "ptls_on_extension_t" &
+            " exists but with different size")
+    ptls_on_extension_t
+  else:
+    ptls_on_extension_t_553648978)
+  ptls_openssl_sign_certificate_t_553649025 = (when declared(
+      ptls_openssl_sign_certificate_t):
+    when ownSizeof(ptls_openssl_sign_certificate_t) !=
+        ownSizeof(ptls_openssl_sign_certificate_t_553649024):
+      static :
+        warning("Declaration of " & "ptls_openssl_sign_certificate_t" &
+            " exists but with different size")
+    ptls_openssl_sign_certificate_t
+  else:
+    ptls_openssl_sign_certificate_t_553649024)
+  struct_st_ptls_hpke_cipher_suite_id_t_553648915 = (when declared(
+      struct_st_ptls_hpke_cipher_suite_id_t):
+    when ownSizeof(struct_st_ptls_hpke_cipher_suite_id_t) !=
+        ownSizeof(struct_st_ptls_hpke_cipher_suite_id_t_553648914):
+      static :
+        warning("Declaration of " & "struct_st_ptls_hpke_cipher_suite_id_t" &
+            " exists but with different size")
+    struct_st_ptls_hpke_cipher_suite_id_t
+  else:
+    struct_st_ptls_hpke_cipher_suite_id_t_553648914)
+  struct_st_ptls_aead_supplementary_encryption_t_553648879 = (when declared(
       struct_st_ptls_aead_supplementary_encryption_t):
     when ownSizeof(struct_st_ptls_aead_supplementary_encryption_t) !=
-        ownSizeof(struct_st_ptls_aead_supplementary_encryption_t_536871663):
+        ownSizeof(struct_st_ptls_aead_supplementary_encryption_t_553648878):
       static :
         warning("Declaration of " &
             "struct_st_ptls_aead_supplementary_encryption_t" &
             " exists but with different size")
     struct_st_ptls_aead_supplementary_encryption_t
-   else:
-    struct_st_ptls_aead_supplementary_encryption_t_536871663)
-  ptls_cipher_algorithm_t_536871662 = (when declared(ptls_cipher_algorithm_t):
-    when ownSizeof(ptls_cipher_algorithm_t) !=
-        ownSizeof(ptls_cipher_algorithm_t_536871661):
+  else:
+    struct_st_ptls_aead_supplementary_encryption_t_553648878)
+  ngtcp2_crypto_aead_553648715 = (when declared(ngtcp2_crypto_aead):
+    when ownSizeof(ngtcp2_crypto_aead) != ownSizeof(ngtcp2_crypto_aead_553648714):
       static :
-        warning("Declaration of " & "ptls_cipher_algorithm_t" &
+        warning("Declaration of " & "ngtcp2_crypto_aead" &
             " exists but with different size")
-    ptls_cipher_algorithm_t
-   else:
-    ptls_cipher_algorithm_t_536871661)
-  ptls_openssl_sign_certificate_t_536871810 = (when declared(
-      ptls_openssl_sign_certificate_t):
-    when ownSizeof(ptls_openssl_sign_certificate_t) !=
-        ownSizeof(ptls_openssl_sign_certificate_t_536871809):
+    ngtcp2_crypto_aead
+  else:
+    ngtcp2_crypto_aead_553648714)
+  struct_ptls_cred_buffer_s_553649053 = (when declared(struct_ptls_cred_buffer_s):
+    when ownSizeof(struct_ptls_cred_buffer_s) !=
+        ownSizeof(struct_ptls_cred_buffer_s_553649052):
       static :
-        warning("Declaration of " & "ptls_openssl_sign_certificate_t" &
+        warning("Declaration of " & "struct_ptls_cred_buffer_s" &
             " exists but with different size")
-    ptls_openssl_sign_certificate_t
-   else:
-    ptls_openssl_sign_certificate_t_536871809)
-  struct_ngtcp2_path_536871486 = (when declared(struct_ngtcp2_path):
-    when ownSizeof(struct_ngtcp2_path) != ownSizeof(struct_ngtcp2_path_536871485):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_path" &
-            " exists but with different size")
-    struct_ngtcp2_path
-   else:
-    struct_ngtcp2_path_536871485)
-  ngtcp2_get_new_connection_id_536871566 = (when declared(
-      ngtcp2_get_new_connection_id):
-    when ownSizeof(ngtcp2_get_new_connection_id) !=
-        ownSizeof(ngtcp2_get_new_connection_id_536871565):
-      static :
-        warning("Declaration of " & "ngtcp2_get_new_connection_id" &
-            " exists but with different size")
-    ngtcp2_get_new_connection_id
-   else:
-    ngtcp2_get_new_connection_id_536871565)
-  ngtcp2_get_path_challenge_data_536871594 = (when declared(
-      ngtcp2_get_path_challenge_data):
-    when ownSizeof(ngtcp2_get_path_challenge_data) !=
-        ownSizeof(ngtcp2_get_path_challenge_data_536871593):
-      static :
-        warning("Declaration of " & "ngtcp2_get_path_challenge_data" &
-            " exists but with different size")
-    ngtcp2_get_path_challenge_data
-   else:
-    ngtcp2_get_path_challenge_data_536871593)
-  X509_536871812 = (when declared(X509):
-    when ownSizeof(X509) != ownSizeof(X509_536871811):
-      static :
-        warning("Declaration of " & "X509" & " exists but with different size")
-    X509
-   else:
-    X509_536871811)
-  ptls_key_schedule_t_536871636 = (when declared(ptls_key_schedule_t):
-    when ownSizeof(ptls_key_schedule_t) != ownSizeof(ptls_key_schedule_t_536871635):
+    struct_ptls_cred_buffer_s
+  else:
+    struct_ptls_cred_buffer_s_553649052)
+  ptls_key_schedule_t_553648851 = (when declared(ptls_key_schedule_t):
+    when ownSizeof(ptls_key_schedule_t) != ownSizeof(ptls_key_schedule_t_553648850):
       static :
         warning("Declaration of " & "ptls_key_schedule_t" &
             " exists but with different size")
     ptls_key_schedule_t
-   else:
-    ptls_key_schedule_t_536871635)
-  ptls_aead_supplementary_encryption_t_536871666 = (when declared(
+  else:
+    ptls_key_schedule_t_553648850)
+  ptls_verify_certificate_t_553648953 = (when declared(ptls_verify_certificate_t):
+    when ownSizeof(ptls_verify_certificate_t) !=
+        ownSizeof(ptls_verify_certificate_t_553648952):
+      static :
+        warning("Declaration of " & "ptls_verify_certificate_t" &
+            " exists but with different size")
+    ptls_verify_certificate_t
+  else:
+    ptls_verify_certificate_t_553648952)
+  ptls_encrypt_ticket_t_553648957 = (when declared(ptls_encrypt_ticket_t):
+    when ownSizeof(ptls_encrypt_ticket_t) != ownSizeof(ptls_encrypt_ticket_t_553648956):
+      static :
+        warning("Declaration of " & "ptls_encrypt_ticket_t" &
+            " exists but with different size")
+    ptls_encrypt_ticket_t
+  else:
+    ptls_encrypt_ticket_t_553648956)
+  ngtcp2_settings_553648695 = (when declared(ngtcp2_settings):
+    when ownSizeof(ngtcp2_settings) != ownSizeof(ngtcp2_settings_553648694):
+      static :
+        warning("Declaration of " & "ngtcp2_settings" &
+            " exists but with different size")
+    ngtcp2_settings
+  else:
+    ngtcp2_settings_553648694)
+  struct_st_ptls_get_time_t_553648931 = (when declared(struct_st_ptls_get_time_t):
+    when ownSizeof(struct_st_ptls_get_time_t) !=
+        ownSizeof(struct_st_ptls_get_time_t_553648930):
+      static :
+        warning("Declaration of " & "struct_st_ptls_get_time_t" &
+            " exists but with different size")
+    struct_st_ptls_get_time_t
+  else:
+    struct_st_ptls_get_time_t_553648930)
+  ptls_async_job_t_553648945 = (when declared(ptls_async_job_t):
+    when ownSizeof(ptls_async_job_t) != ownSizeof(ptls_async_job_t_553648944):
+      static :
+        warning("Declaration of " & "ptls_async_job_t" &
+            " exists but with different size")
+    ptls_async_job_t
+  else:
+    ptls_async_job_t_553648944)
+  struct_st_ptls_log_conn_state_t_553649005 = (when declared(
+      struct_st_ptls_log_conn_state_t):
+    when ownSizeof(struct_st_ptls_log_conn_state_t) !=
+        ownSizeof(struct_st_ptls_log_conn_state_t_553649004):
+      static :
+        warning("Declaration of " & "struct_st_ptls_log_conn_state_t" &
+            " exists but with different size")
+    struct_st_ptls_log_conn_state_t
+  else:
+    struct_st_ptls_log_conn_state_t_553649004)
+  struct_st_ptls_key_exchange_algorithm_t_553648863 = (when declared(
+      struct_st_ptls_key_exchange_algorithm_t):
+    when ownSizeof(struct_st_ptls_key_exchange_algorithm_t) !=
+        ownSizeof(struct_st_ptls_key_exchange_algorithm_t_553648862):
+      static :
+        warning("Declaration of " & "struct_st_ptls_key_exchange_algorithm_t" &
+            " exists but with different size")
+    struct_st_ptls_key_exchange_algorithm_t
+  else:
+    struct_st_ptls_key_exchange_algorithm_t_553648862)
+  ngtcp2_hp_mask_553648761 = (when declared(ngtcp2_hp_mask):
+    when ownSizeof(ngtcp2_hp_mask) != ownSizeof(ngtcp2_hp_mask_553648760):
+      static :
+        warning("Declaration of " & "ngtcp2_hp_mask" &
+            " exists but with different size")
+    ngtcp2_hp_mask
+  else:
+    ngtcp2_hp_mask_553648760)
+  EVP_MD_553649019 = (when declared(EVP_MD):
+    when ownSizeof(EVP_MD) != ownSizeof(EVP_MD_553649018):
+      static :
+        warning("Declaration of " & "EVP_MD" & " exists but with different size")
+    EVP_MD
+  else:
+    EVP_MD_553649018)
+  ptls_client_hello_psk_identity_t_553648925 = (when declared(
+      ptls_client_hello_psk_identity_t):
+    when ownSizeof(ptls_client_hello_psk_identity_t) !=
+        ownSizeof(ptls_client_hello_psk_identity_t_553648924):
+      static :
+        warning("Declaration of " & "ptls_client_hello_psk_identity_t" &
+            " exists but with different size")
+    ptls_client_hello_psk_identity_t
+  else:
+    ptls_client_hello_psk_identity_t_553648924)
+  struct_st_ptls_log_event_t_553648963 = (when declared(
+      struct_st_ptls_log_event_t):
+    when ownSizeof(struct_st_ptls_log_event_t) !=
+        ownSizeof(struct_st_ptls_log_event_t_553648962):
+      static :
+        warning("Declaration of " & "struct_st_ptls_log_event_t" &
+            " exists but with different size")
+    struct_st_ptls_log_event_t
+  else:
+    struct_st_ptls_log_event_t_553648962)
+  ngtcp2_recv_new_token_553648797 = (when declared(ngtcp2_recv_new_token):
+    when ownSizeof(ngtcp2_recv_new_token) != ownSizeof(ngtcp2_recv_new_token_553648796):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_new_token" &
+            " exists but with different size")
+    ngtcp2_recv_new_token
+  else:
+    ngtcp2_recv_new_token_553648796)
+  enum_en_ptls_early_data_acceptance_t_553648993 = (when declared(
+      enum_en_ptls_early_data_acceptance_t):
+    when ownSizeof(enum_en_ptls_early_data_acceptance_t) !=
+        ownSizeof(enum_en_ptls_early_data_acceptance_t_553648992):
+      static :
+        warning("Declaration of " & "enum_en_ptls_early_data_acceptance_t" &
+            " exists but with different size")
+    enum_en_ptls_early_data_acceptance_t
+  else:
+    enum_en_ptls_early_data_acceptance_t_553648992)
+  enum_ngtcp2_path_validation_result_553648610 = (when declared(
+      enum_ngtcp2_path_validation_result):
+    when ownSizeof(enum_ngtcp2_path_validation_result) !=
+        ownSizeof(enum_ngtcp2_path_validation_result_553648609):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_path_validation_result" &
+            " exists but with different size")
+    enum_ngtcp2_path_validation_result
+  else:
+    enum_ngtcp2_path_validation_result_553648609)
+  struct_st_ptls_hash_context_t_553648895 = (when declared(
+      struct_st_ptls_hash_context_t):
+    when ownSizeof(struct_st_ptls_hash_context_t) !=
+        ownSizeof(struct_st_ptls_hash_context_t_553648894):
+      static :
+        warning("Declaration of " & "struct_st_ptls_hash_context_t" &
+            " exists but with different size")
+    struct_st_ptls_hash_context_t
+  else:
+    struct_st_ptls_hash_context_t_553648894)
+  socklen_t_553648648 = (when declared(socklen_t):
+    when ownSizeof(socklen_t) != ownSizeof(socklen_t_553648647):
+      static :
+        warning("Declaration of " & "socklen_t" &
+            " exists but with different size")
+    socklen_t
+  else:
+    socklen_t_553648647)
+  struct_st_ptls_openssl_sign_certificate_t_553649023 = (when declared(
+      struct_st_ptls_openssl_sign_certificate_t):
+    when ownSizeof(struct_st_ptls_openssl_sign_certificate_t) !=
+        ownSizeof(struct_st_ptls_openssl_sign_certificate_t_553649022):
+      static :
+        warning("Declaration of " & "struct_st_ptls_openssl_sign_certificate_t" &
+            " exists but with different size")
+    struct_st_ptls_openssl_sign_certificate_t
+  else:
+    struct_st_ptls_openssl_sign_certificate_t_553649022)
+  in_port_t_553649059 = (when declared(in_port_t):
+    when ownSizeof(in_port_t) != ownSizeof(in_port_t_553649058):
+      static :
+        warning("Declaration of " & "in_port_t" &
+            " exists but with different size")
+    in_port_t
+  else:
+    in_port_t_553649058)
+  struct_ngtcp2_vec_553648622 = (when declared(struct_ngtcp2_vec):
+    when ownSizeof(struct_ngtcp2_vec) != ownSizeof(struct_ngtcp2_vec_553648621):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_vec" &
+            " exists but with different size")
+    struct_ngtcp2_vec
+  else:
+    struct_ngtcp2_vec_553648621)
+  ngtcp2_ccerr_type_553648829 = (when declared(ngtcp2_ccerr_type):
+    when ownSizeof(ngtcp2_ccerr_type) != ownSizeof(ngtcp2_ccerr_type_553648828):
+      static :
+        warning("Declaration of " & "ngtcp2_ccerr_type" &
+            " exists but with different size")
+    ngtcp2_ccerr_type
+  else:
+    ngtcp2_ccerr_type_553648828)
+  ptls_early_data_acceptance_t_553648995 = (when declared(
+      ptls_early_data_acceptance_t):
+    when ownSizeof(ptls_early_data_acceptance_t) !=
+        ownSizeof(ptls_early_data_acceptance_t_553648994):
+      static :
+        warning("Declaration of " & "ptls_early_data_acceptance_t" &
+            " exists but with different size")
+    ptls_early_data_acceptance_t
+  else:
+    ptls_early_data_acceptance_t_553648994)
+  ngtcp2_transport_params_553648664 = (when declared(ngtcp2_transport_params):
+    when ownSizeof(ngtcp2_transport_params) !=
+        ownSizeof(ngtcp2_transport_params_553648663):
+      static :
+        warning("Declaration of " & "ngtcp2_transport_params" &
+            " exists but with different size")
+    ngtcp2_transport_params
+  else:
+    ngtcp2_transport_params_553648663)
+  ngtcp2_acked_stream_data_offset_553648771 = (when declared(
+      ngtcp2_acked_stream_data_offset):
+    when ownSizeof(ngtcp2_acked_stream_data_offset) !=
+        ownSizeof(ngtcp2_acked_stream_data_offset_553648770):
+      static :
+        warning("Declaration of " & "ngtcp2_acked_stream_data_offset" &
+            " exists but with different size")
+    ngtcp2_acked_stream_data_offset
+  else:
+    ngtcp2_acked_stream_data_offset_553648770)
+  struct_st_ptls_iovec_t_553648853 = (when declared(struct_st_ptls_iovec_t):
+    when ownSizeof(struct_st_ptls_iovec_t) != ownSizeof(struct_st_ptls_iovec_t_553648852):
+      static :
+        warning("Declaration of " & "struct_st_ptls_iovec_t" &
+            " exists but with different size")
+    struct_st_ptls_iovec_t
+  else:
+    struct_st_ptls_iovec_t_553648852)
+  ptls_t_553648845 = (when declared(ptls_t):
+    when ownSizeof(ptls_t) != ownSizeof(ptls_t_553648844):
+      static :
+        warning("Declaration of " & "ptls_t" & " exists but with different size")
+    ptls_t
+  else:
+    ptls_t_553648844)
+  ngtcp2_free_553648592 = (when declared(ngtcp2_free):
+    when ownSizeof(ngtcp2_free) != ownSizeof(ngtcp2_free_553648591):
+      static :
+        warning("Declaration of " & "ngtcp2_free" &
+            " exists but with different size")
+    ngtcp2_free
+  else:
+    ngtcp2_free_553648591)
+  struct_st_ptls_cipher_context_t_553648871 = (when declared(
+      struct_st_ptls_cipher_context_t):
+    when ownSizeof(struct_st_ptls_cipher_context_t) !=
+        ownSizeof(struct_st_ptls_cipher_context_t_553648870):
+      static :
+        warning("Declaration of " & "struct_st_ptls_cipher_context_t" &
+            " exists but with different size")
+    struct_st_ptls_cipher_context_t
+  else:
+    struct_st_ptls_cipher_context_t_553648870)
+  ngtcp2_crypto_aead_ctx_553648723 = (when declared(ngtcp2_crypto_aead_ctx):
+    when ownSizeof(ngtcp2_crypto_aead_ctx) != ownSizeof(ngtcp2_crypto_aead_ctx_553648722):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_aead_ctx" &
+            " exists but with different size")
+    ngtcp2_crypto_aead_ctx
+  else:
+    ngtcp2_crypto_aead_ctx_553648722)
+  enum_ngtcp2_encryption_level_553648743 = (when declared(
+      enum_ngtcp2_encryption_level):
+    when ownSizeof(enum_ngtcp2_encryption_level) !=
+        ownSizeof(enum_ngtcp2_encryption_level_553648742):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_encryption_level" &
+            " exists but with different size")
+    enum_ngtcp2_encryption_level
+  else:
+    enum_ngtcp2_encryption_level_553648742)
+  ngtcp2_crypto_get_conn_553648843 = (when declared(ngtcp2_crypto_get_conn):
+    when ownSizeof(ngtcp2_crypto_get_conn) != ownSizeof(ngtcp2_crypto_get_conn_553648842):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_get_conn" &
+            " exists but with different size")
+    ngtcp2_crypto_get_conn
+  else:
+    ngtcp2_crypto_get_conn_553648842)
+  ptls_aead_supplementary_encryption_t_553648881 = (when declared(
       ptls_aead_supplementary_encryption_t):
     when ownSizeof(ptls_aead_supplementary_encryption_t) !=
-        ownSizeof(ptls_aead_supplementary_encryption_t_536871665):
+        ownSizeof(ptls_aead_supplementary_encryption_t_553648880):
       static :
         warning("Declaration of " & "ptls_aead_supplementary_encryption_t" &
             " exists but with different size")
     ptls_aead_supplementary_encryption_t
-   else:
-    ptls_aead_supplementary_encryption_t_536871665)
-  ptls_on_extension_t_536871764 = (when declared(ptls_on_extension_t):
-    when ownSizeof(ptls_on_extension_t) != ownSizeof(ptls_on_extension_t_536871763):
+  else:
+    ptls_aead_supplementary_encryption_t_553648880)
+  ngtcp2_sockaddr_553648634 = (when declared(ngtcp2_sockaddr):
+    when ownSizeof(ngtcp2_sockaddr) != ownSizeof(ngtcp2_sockaddr_553648633):
       static :
-        warning("Declaration of " & "ptls_on_extension_t" &
+        warning("Declaration of " & "ngtcp2_sockaddr" &
             " exists but with different size")
-    ptls_on_extension_t
-   else:
-    ptls_on_extension_t_536871763)
-  EVP_MAC_CTX_536871832 = (when declared(EVP_MAC_CTX):
-    when ownSizeof(EVP_MAC_CTX) != ownSizeof(EVP_MAC_CTX_536871831):
+    ngtcp2_sockaddr
+  else:
+    ngtcp2_sockaddr_553648633)
+  ngtcp2_crypto_ctx_553648731 = (when declared(ngtcp2_crypto_ctx):
+    when ownSizeof(ngtcp2_crypto_ctx) != ownSizeof(ngtcp2_crypto_ctx_553648730):
       static :
-        warning("Declaration of " & "EVP_MAC_CTX" &
+        warning("Declaration of " & "ngtcp2_crypto_ctx" &
             " exists but with different size")
-    EVP_MAC_CTX
-   else:
-    EVP_MAC_CTX_536871831)
-  ngtcp2_extend_max_streams_536871560 = (when declared(ngtcp2_extend_max_streams):
-    when ownSizeof(ngtcp2_extend_max_streams) !=
-        ownSizeof(ngtcp2_extend_max_streams_536871559):
+    ngtcp2_crypto_ctx
+  else:
+    ngtcp2_crypto_ctx_553648730)
+  enum_ngtcp2_connection_id_status_type_553648791 = (when declared(
+      enum_ngtcp2_connection_id_status_type):
+    when ownSizeof(enum_ngtcp2_connection_id_status_type) !=
+        ownSizeof(enum_ngtcp2_connection_id_status_type_553648790):
       static :
-        warning("Declaration of " & "ngtcp2_extend_max_streams" &
+        warning("Declaration of " & "enum_ngtcp2_connection_id_status_type" &
             " exists but with different size")
-    ngtcp2_extend_max_streams
-   else:
-    ngtcp2_extend_max_streams_536871559)
-  ngtcp2_sockaddr_in6_536871427 = (when declared(ngtcp2_sockaddr_in6):
-    when ownSizeof(ngtcp2_sockaddr_in6) != ownSizeof(ngtcp2_sockaddr_in6_536871426):
+    enum_ngtcp2_connection_id_status_type
+  else:
+    enum_ngtcp2_connection_id_status_type_553648790)
+  ptls_hash_algorithm_t_553648901 = (when declared(ptls_hash_algorithm_t):
+    when ownSizeof(ptls_hash_algorithm_t) != ownSizeof(ptls_hash_algorithm_t_553648900):
       static :
-        warning("Declaration of " & "ngtcp2_sockaddr_in6" &
+        warning("Declaration of " & "ptls_hash_algorithm_t" &
             " exists but with different size")
-    ngtcp2_sockaddr_in6
-   else:
-    ngtcp2_sockaddr_in6_536871426)
-  struct_ngtcp2_version_cid_536871518 = (when declared(struct_ngtcp2_version_cid):
-    when ownSizeof(struct_ngtcp2_version_cid) !=
-        ownSizeof(struct_ngtcp2_version_cid_536871517):
+    ptls_hash_algorithm_t
+  else:
+    ptls_hash_algorithm_t_553648900)
+  struct_st_ptls_emit_certificate_t_553648939 = (when declared(
+      struct_st_ptls_emit_certificate_t):
+    when ownSizeof(struct_st_ptls_emit_certificate_t) !=
+        ownSizeof(struct_st_ptls_emit_certificate_t_553648938):
       static :
-        warning("Declaration of " & "struct_ngtcp2_version_cid" &
+        warning("Declaration of " & "struct_st_ptls_emit_certificate_t" &
             " exists but with different size")
-    struct_ngtcp2_version_cid
-   else:
-    struct_ngtcp2_version_cid_536871517)
-  struct_in6_addr_536871792 = (when declared(struct_in6_addr):
-    when ownSizeof(struct_in6_addr) != ownSizeof(struct_in6_addr_536871791):
-      static :
-        warning("Declaration of " & "struct_in6_addr" &
-            " exists but with different size")
-    struct_in6_addr
-   else:
-    struct_in6_addr_536871791)
-  struct_st_ptls_hash_algorithm_t_536871684 = (when declared(
-      struct_st_ptls_hash_algorithm_t):
-    when ownSizeof(struct_st_ptls_hash_algorithm_t) !=
-        ownSizeof(struct_st_ptls_hash_algorithm_t_536871683):
-      static :
-        warning("Declaration of " & "struct_st_ptls_hash_algorithm_t" &
-            " exists but with different size")
-    struct_st_ptls_hash_algorithm_t
-   else:
-    struct_st_ptls_hash_algorithm_t_536871683)
-  ptls_iovec_t_536871640 = (when declared(ptls_iovec_t):
-    when ownSizeof(ptls_iovec_t) != ownSizeof(ptls_iovec_t_536871639):
-      static :
-        warning("Declaration of " & "ptls_iovec_t" &
-            " exists but with different size")
-    ptls_iovec_t
-   else:
-    ptls_iovec_t_536871639)
-  enum_ngtcp2_pkt_type_536871391 = (when declared(enum_ngtcp2_pkt_type):
-    when ownSizeof(enum_ngtcp2_pkt_type) != ownSizeof(enum_ngtcp2_pkt_type_536871390):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_pkt_type" &
-            " exists but with different size")
-    enum_ngtcp2_pkt_type
-   else:
-    enum_ngtcp2_pkt_type_536871390)
-  ngtcp2_version_cid_536871520 = (when declared(ngtcp2_version_cid):
-    when ownSizeof(ngtcp2_version_cid) != ownSizeof(ngtcp2_version_cid_536871519):
-      static :
-        warning("Declaration of " & "ngtcp2_version_cid" &
-            " exists but with different size")
-    ngtcp2_version_cid
-   else:
-    ngtcp2_version_cid_536871519)
-  ngtcp2_crypto_conn_ref_536871624 = (when declared(ngtcp2_crypto_conn_ref):
-    when ownSizeof(ngtcp2_crypto_conn_ref) != ownSizeof(ngtcp2_crypto_conn_ref_536871623):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_conn_ref" &
-            " exists but with different size")
-    ngtcp2_crypto_conn_ref
-   else:
-    ngtcp2_crypto_conn_ref_536871623)
-  ptls_buffer_t_536871644 = (when declared(ptls_buffer_t):
-    when ownSizeof(ptls_buffer_t) != ownSizeof(ptls_buffer_t_536871643):
-      static :
-        warning("Declaration of " & "ptls_buffer_t" &
-            " exists but with different size")
-    ptls_buffer_t
-   else:
-    ptls_buffer_t_536871643)
-  ptls_handshake_properties_t_536871784 = (when declared(
-      ptls_handshake_properties_t):
-    when ownSizeof(ptls_handshake_properties_t) !=
-        ownSizeof(ptls_handshake_properties_t_536871783):
-      static :
-        warning("Declaration of " & "ptls_handshake_properties_t" &
-            " exists but with different size")
-    ptls_handshake_properties_t
-   else:
-    ptls_handshake_properties_t_536871783)
-  ptls_aead_algorithm_t_536871674 = (when declared(ptls_aead_algorithm_t):
-    when ownSizeof(ptls_aead_algorithm_t) != ownSizeof(ptls_aead_algorithm_t_536871673):
-      static :
-        warning("Declaration of " & "ptls_aead_algorithm_t" &
-            " exists but with different size")
-    ptls_aead_algorithm_t
-   else:
-    ptls_aead_algorithm_t_536871673)
-  struct_st_ptls_on_client_hello_parameters_t_536871712 = (when declared(
+    struct_st_ptls_emit_certificate_t
+  else:
+    struct_st_ptls_emit_certificate_t_553648938)
+  struct_st_ptls_on_client_hello_parameters_t_553648927 = (when declared(
       struct_st_ptls_on_client_hello_parameters_t):
     when ownSizeof(struct_st_ptls_on_client_hello_parameters_t) !=
-        ownSizeof(struct_st_ptls_on_client_hello_parameters_t_536871711):
+        ownSizeof(struct_st_ptls_on_client_hello_parameters_t_553648926):
       static :
         warning("Declaration of " &
             "struct_st_ptls_on_client_hello_parameters_t" &
             " exists but with different size")
     struct_st_ptls_on_client_hello_parameters_t
-   else:
-    struct_st_ptls_on_client_hello_parameters_t_536871711)
-  ptls_early_data_acceptance_t_536871780 = (when declared(
-      ptls_early_data_acceptance_t):
-    when ownSizeof(ptls_early_data_acceptance_t) !=
-        ownSizeof(ptls_early_data_acceptance_t_536871779):
-      static :
-        warning("Declaration of " & "ptls_early_data_acceptance_t" &
-            " exists but with different size")
-    ptls_early_data_acceptance_t
-   else:
-    ptls_early_data_acceptance_t_536871779)
-  ngtcp2_token_type_536871476 = (when declared(ngtcp2_token_type):
-    when ownSizeof(ngtcp2_token_type) != ownSizeof(ngtcp2_token_type_536871475):
-      static :
-        warning("Declaration of " & "ngtcp2_token_type" &
-            " exists but with different size")
-    ngtcp2_token_type
-   else:
-    ngtcp2_token_type_536871475)
-  ptls_get_time_t_536871718 = (when declared(ptls_get_time_t):
-    when ownSizeof(ptls_get_time_t) != ownSizeof(ptls_get_time_t_536871717):
-      static :
-        warning("Declaration of " & "ptls_get_time_t" &
-            " exists but with different size")
-    ptls_get_time_t
-   else:
-    ptls_get_time_t_536871717)
-  ptls_decompress_certificate_t_536871768 = (when declared(
-      ptls_decompress_certificate_t):
-    when ownSizeof(ptls_decompress_certificate_t) !=
-        ownSizeof(ptls_decompress_certificate_t_536871767):
-      static :
-        warning("Declaration of " & "ptls_decompress_certificate_t" &
-            " exists but with different size")
-    ptls_decompress_certificate_t
-   else:
-    ptls_decompress_certificate_t_536871767)
-  ngtcp2_pkt_stateless_reset_536871417 = (when declared(
-      ngtcp2_pkt_stateless_reset):
-    when ownSizeof(ngtcp2_pkt_stateless_reset) !=
-        ownSizeof(ngtcp2_pkt_stateless_reset_536871416):
-      static :
-        warning("Declaration of " & "ngtcp2_pkt_stateless_reset" &
-            " exists but with different size")
-    ngtcp2_pkt_stateless_reset
-   else:
-    ngtcp2_pkt_stateless_reset_536871416)
-  intptr_t_536871652 = (when declared(intptr_t):
-    when ownSizeof(intptr_t) != ownSizeof(intptr_t_536871651):
-      static :
-        warning("Declaration of " & "intptr_t" &
-            " exists but with different size")
-    intptr_t
-   else:
-    intptr_t_536871651)
-  struct_ngtcp2_settings_536871478 = (when declared(struct_ngtcp2_settings):
-    when ownSizeof(struct_ngtcp2_settings) != ownSizeof(struct_ngtcp2_settings_536871477):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_settings" &
-            " exists but with different size")
-    struct_ngtcp2_settings
-   else:
-    struct_ngtcp2_settings_536871477)
-  compiler_socklen_t_536871846 = (when declared(compiler_socklen_t):
-    when ownSizeof(compiler_socklen_t) != ownSizeof(compiler_socklen_t_536871845):
-      static :
-        warning("Declaration of " & "compiler_socklen_t" &
-            " exists but with different size")
-    compiler_socklen_t
-   else:
-    compiler_socklen_t_536871845)
-  struct_ngtcp2_vec_536871407 = (when declared(struct_ngtcp2_vec):
-    when ownSizeof(struct_ngtcp2_vec) != ownSizeof(struct_ngtcp2_vec_536871406):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_vec" &
-            " exists but with different size")
-    struct_ngtcp2_vec
-   else:
-    struct_ngtcp2_vec_536871406)
-  ngtcp2_path_validation_536871572 = (when declared(ngtcp2_path_validation):
-    when ownSizeof(ngtcp2_path_validation) != ownSizeof(ngtcp2_path_validation_536871571):
-      static :
-        warning("Declaration of " & "ngtcp2_path_validation" &
-            " exists but with different size")
-    ngtcp2_path_validation
-   else:
-    ngtcp2_path_validation_536871571)
-  ptls_update_traffic_key_t_536871760 = (when declared(ptls_update_traffic_key_t):
-    when ownSizeof(ptls_update_traffic_key_t) !=
-        ownSizeof(ptls_update_traffic_key_t_536871759):
-      static :
-        warning("Declaration of " & "ptls_update_traffic_key_t" &
-            " exists but with different size")
-    ptls_update_traffic_key_t
-   else:
-    ptls_update_traffic_key_t_536871759)
-  ngtcp2_crypto_picotls_ctx_536871836 = (when declared(ngtcp2_crypto_picotls_ctx):
-    when ownSizeof(ngtcp2_crypto_picotls_ctx) !=
-        ownSizeof(ngtcp2_crypto_picotls_ctx_536871835):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_picotls_ctx" &
-            " exists but with different size")
-    ngtcp2_crypto_picotls_ctx
-   else:
-    ngtcp2_crypto_picotls_ctx_536871835)
-  ptls_t_536871630 = (when declared(ptls_t):
-    when ownSizeof(ptls_t) != ownSizeof(ptls_t_536871629):
-      static :
-        warning("Declaration of " & "ptls_t" & " exists but with different size")
-    ptls_t
-   else:
-    ptls_t_536871629)
-  struct_st_ptls_cipher_algorithm_t_536871658 = (when declared(
-      struct_st_ptls_cipher_algorithm_t):
-    when ownSizeof(struct_st_ptls_cipher_algorithm_t) !=
-        ownSizeof(struct_st_ptls_cipher_algorithm_t_536871657):
-      static :
-        warning("Declaration of " & "struct_st_ptls_cipher_algorithm_t" &
-            " exists but with different size")
-    struct_st_ptls_cipher_algorithm_t
-   else:
-    struct_st_ptls_cipher_algorithm_t_536871657)
-  ngtcp2_crypto_ctx_536871516 = (when declared(ngtcp2_crypto_ctx):
-    when ownSizeof(ngtcp2_crypto_ctx) != ownSizeof(ngtcp2_crypto_ctx_536871515):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_ctx" &
-            " exists but with different size")
-    ngtcp2_crypto_ctx
-   else:
-    ngtcp2_crypto_ctx_536871515)
-  struct_ngtcp2_crypto_conn_ref_536871626 = (when declared(
-      struct_ngtcp2_crypto_conn_ref):
-    when ownSizeof(struct_ngtcp2_crypto_conn_ref) !=
-        ownSizeof(struct_ngtcp2_crypto_conn_ref_536871625):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_conn_ref" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_conn_ref
-   else:
-    struct_ngtcp2_crypto_conn_ref_536871625)
-  struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871814 = (when declared(
-      struct_st_ptls_openssl_raw_pubkey_verify_certificate_t):
-    when ownSizeof(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t) !=
-        ownSizeof(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871813):
-      static :
-        warning("Declaration of " &
-            "struct_st_ptls_openssl_raw_pubkey_verify_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t
-   else:
-    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871813)
-  ngtcp2_crypto_cipher_ctx_536871512 = (when declared(ngtcp2_crypto_cipher_ctx):
-    when ownSizeof(ngtcp2_crypto_cipher_ctx) !=
-        ownSizeof(ngtcp2_crypto_cipher_ctx_536871511):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_cipher_ctx" &
-            " exists but with different size")
-    ngtcp2_crypto_cipher_ctx
-   else:
-    ngtcp2_crypto_cipher_ctx_536871511)
-  ngtcp2_printf_536871466 = (when declared(ngtcp2_printf):
-    when ownSizeof(ngtcp2_printf) != ownSizeof(ngtcp2_printf_536871465):
-      static :
-        warning("Declaration of " & "ngtcp2_printf" &
-            " exists but with different size")
-    ngtcp2_printf
-   else:
-    ngtcp2_printf_536871465)
-  struct_st_ptls_verify_certificate_t_536871736 = (when declared(
-      struct_st_ptls_verify_certificate_t):
-    when ownSizeof(struct_st_ptls_verify_certificate_t) !=
-        ownSizeof(struct_st_ptls_verify_certificate_t_536871735):
-      static :
-        warning("Declaration of " & "struct_st_ptls_verify_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_verify_certificate_t
-   else:
-    struct_st_ptls_verify_certificate_t_536871735)
-  struct_ngtcp2_crypto_picotls_ctx_536871834 = (when declared(
-      struct_ngtcp2_crypto_picotls_ctx):
-    when ownSizeof(struct_ngtcp2_crypto_picotls_ctx) !=
-        ownSizeof(struct_ngtcp2_crypto_picotls_ctx_536871833):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_picotls_ctx" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_picotls_ctx
-   else:
-    struct_ngtcp2_crypto_picotls_ctx_536871833)
-  ptls_hash_final_mode_t_536871678 = (when declared(ptls_hash_final_mode_t):
-    when ownSizeof(ptls_hash_final_mode_t) != ownSizeof(ptls_hash_final_mode_t_536871677):
-      static :
-        warning("Declaration of " & "ptls_hash_final_mode_t" &
-            " exists but with different size")
-    ptls_hash_final_mode_t
-   else:
-    ptls_hash_final_mode_t_536871677)
-  ngtcp2_handshake_completed_536871534 = (when declared(
-      ngtcp2_handshake_completed):
-    when ownSizeof(ngtcp2_handshake_completed) !=
-        ownSizeof(ngtcp2_handshake_completed_536871533):
-      static :
-        warning("Declaration of " & "ngtcp2_handshake_completed" &
-            " exists but with different size")
-    ngtcp2_handshake_completed
-   else:
-    ngtcp2_handshake_completed_536871533)
-  struct_st_ptls_cipher_context_t_536871656 = (when declared(
-      struct_st_ptls_cipher_context_t):
-    when ownSizeof(struct_st_ptls_cipher_context_t) !=
-        ownSizeof(struct_st_ptls_cipher_context_t_536871655):
-      static :
-        warning("Declaration of " & "struct_st_ptls_cipher_context_t" &
-            " exists but with different size")
-    struct_st_ptls_cipher_context_t
-   else:
-    struct_st_ptls_cipher_context_t_536871655)
-  enum_ngtcp2_cc_algo_536871462 = (when declared(enum_ngtcp2_cc_algo):
-    when ownSizeof(enum_ngtcp2_cc_algo) != ownSizeof(enum_ngtcp2_cc_algo_536871461):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_cc_algo" &
-            " exists but with different size")
-    enum_ngtcp2_cc_algo
-   else:
-    enum_ngtcp2_cc_algo_536871461)
-  ngtcp2_duration_536871401 = (when declared(ngtcp2_duration):
-    when ownSizeof(ngtcp2_duration) != ownSizeof(ngtcp2_duration_536871400):
-      static :
-        warning("Declaration of " & "ngtcp2_duration" &
-            " exists but with different size")
-    ngtcp2_duration
-   else:
-    ngtcp2_duration_536871400)
-  struct_ngtcp2_cid_536871403 = (when declared(struct_ngtcp2_cid):
-    when ownSizeof(struct_ngtcp2_cid) != ownSizeof(struct_ngtcp2_cid_536871402):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_cid" &
-            " exists but with different size")
-    struct_ngtcp2_cid
-   else:
-    struct_ngtcp2_cid_536871402)
-  in_port_t_536871844 = (when declared(in_port_t):
-    when ownSizeof(in_port_t) != ownSizeof(in_port_t_536871843):
-      static :
-        warning("Declaration of " & "in_port_t" &
-            " exists but with different size")
-    in_port_t
-   else:
-    in_port_t_536871843)
-  struct_st_ptls_update_traffic_key_t_536871758 = (when declared(
-      struct_st_ptls_update_traffic_key_t):
-    when ownSizeof(struct_st_ptls_update_traffic_key_t) !=
-        ownSizeof(struct_st_ptls_update_traffic_key_t_536871757):
-      static :
-        warning("Declaration of " & "struct_st_ptls_update_traffic_key_t" &
-            " exists but with different size")
-    struct_st_ptls_update_traffic_key_t
-   else:
-    struct_st_ptls_update_traffic_key_t_536871757)
-  ngtcp2_vec_536871409 = (when declared(ngtcp2_vec):
-    when ownSizeof(ngtcp2_vec) != ownSizeof(ngtcp2_vec_536871408):
-      static :
-        warning("Declaration of " & "ngtcp2_vec" &
-            " exists but with different size")
-    ngtcp2_vec
-   else:
-    ngtcp2_vec_536871408)
-  ptls_save_ticket_t_536871746 = (when declared(ptls_save_ticket_t):
-    when ownSizeof(ptls_save_ticket_t) != ownSizeof(ptls_save_ticket_t_536871745):
-      static :
-        warning("Declaration of " & "ptls_save_ticket_t" &
-            " exists but with different size")
-    ptls_save_ticket_t
-   else:
-    ptls_save_ticket_t_536871745)
-  ngtcp2_recv_stateless_reset_536871558 = (when declared(
-      ngtcp2_recv_stateless_reset):
-    when ownSizeof(ngtcp2_recv_stateless_reset) !=
-        ownSizeof(ngtcp2_recv_stateless_reset_536871557):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_stateless_reset" &
-            " exists but with different size")
-    ngtcp2_recv_stateless_reset
-   else:
-    ngtcp2_recv_stateless_reset_536871557)
-  ngtcp2_crypto_md_536871496 = (when declared(ngtcp2_crypto_md):
-    when ownSizeof(ngtcp2_crypto_md) != ownSizeof(ngtcp2_crypto_md_536871495):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_md" &
-            " exists but with different size")
-    ngtcp2_crypto_md
-   else:
-    ngtcp2_crypto_md_536871495)
-  enum_ngtcp2_connection_id_status_type_536871576 = (when declared(
-      enum_ngtcp2_connection_id_status_type):
-    when ownSizeof(enum_ngtcp2_connection_id_status_type) !=
-        ownSizeof(enum_ngtcp2_connection_id_status_type_536871575):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_connection_id_status_type" &
-            " exists but with different size")
-    enum_ngtcp2_connection_id_status_type
-   else:
-    enum_ngtcp2_connection_id_status_type_536871575)
-  ngtcp2_recv_key_536871600 = (when declared(ngtcp2_recv_key):
-    when ownSizeof(ngtcp2_recv_key) != ownSizeof(ngtcp2_recv_key_536871599):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_key" &
-            " exists but with different size")
-    ngtcp2_recv_key
-   else:
-    ngtcp2_recv_key_536871599)
-  ngtcp2_remove_connection_id_536871568 = (when declared(
-      ngtcp2_remove_connection_id):
-    when ownSizeof(ngtcp2_remove_connection_id) !=
-        ownSizeof(ngtcp2_remove_connection_id_536871567):
-      static :
-        warning("Declaration of " & "ngtcp2_remove_connection_id" &
-            " exists but with different size")
-    ngtcp2_remove_connection_id
-   else:
-    ngtcp2_remove_connection_id_536871567)
-  ngtcp2_recv_retry_536871540 = (when declared(ngtcp2_recv_retry):
-    when ownSizeof(ngtcp2_recv_retry) != ownSizeof(ngtcp2_recv_retry_536871539):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_retry" &
-            " exists but with different size")
-    ngtcp2_recv_retry
-   else:
-    ngtcp2_recv_retry_536871539)
-  ngtcp2_recv_crypto_data_536871532 = (when declared(ngtcp2_recv_crypto_data):
-    when ownSizeof(ngtcp2_recv_crypto_data) !=
-        ownSizeof(ngtcp2_recv_crypto_data_536871531):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_crypto_data" &
-            " exists but with different size")
-    ngtcp2_recv_crypto_data
-   else:
-    ngtcp2_recv_crypto_data_536871531)
-  ngtcp2_cid_token_536871610 = (when declared(ngtcp2_cid_token):
-    when ownSizeof(ngtcp2_cid_token) != ownSizeof(ngtcp2_cid_token_536871609):
-      static :
-        warning("Declaration of " & "ngtcp2_cid_token" &
-            " exists but with different size")
-    ngtcp2_cid_token
-   else:
-    ngtcp2_cid_token_536871609)
-  struct_st_ptls_buffer_t_536871642 = (when declared(struct_st_ptls_buffer_t):
-    when ownSizeof(struct_st_ptls_buffer_t) !=
-        ownSizeof(struct_st_ptls_buffer_t_536871641):
-      static :
-        warning("Declaration of " & "struct_st_ptls_buffer_t" &
-            " exists but with different size")
-    struct_st_ptls_buffer_t
-   else:
-    struct_st_ptls_buffer_t_536871641)
-  ptls_openssl_signature_scheme_t_536871806 = (when declared(
-      ptls_openssl_signature_scheme_t):
-    when ownSizeof(ptls_openssl_signature_scheme_t) !=
-        ownSizeof(ptls_openssl_signature_scheme_t_536871805):
-      static :
-        warning("Declaration of " & "ptls_openssl_signature_scheme_t" &
-            " exists but with different size")
-    ptls_openssl_signature_scheme_t
-   else:
-    ptls_openssl_signature_scheme_t_536871805)
-  struct_st_ptls_log_state_t_536871786 = (when declared(
-      struct_st_ptls_log_state_t):
-    when ownSizeof(struct_st_ptls_log_state_t) !=
-        ownSizeof(struct_st_ptls_log_state_t_536871785):
-      static :
-        warning("Declaration of " & "struct_st_ptls_log_state_t" &
-            " exists but with different size")
-    struct_st_ptls_log_state_t
-   else:
-    struct_st_ptls_log_state_t_536871785)
-  struct_st_ptls_log_event_t_536871748 = (when declared(
-      struct_st_ptls_log_event_t):
-    when ownSizeof(struct_st_ptls_log_event_t) !=
-        ownSizeof(struct_st_ptls_log_event_t_536871747):
-      static :
-        warning("Declaration of " & "struct_st_ptls_log_event_t" &
-            " exists but with different size")
-    struct_st_ptls_log_event_t
-   else:
-    struct_st_ptls_log_event_t_536871747)
-  ngtcp2_realloc_536871381 = (when declared(ngtcp2_realloc):
-    when ownSizeof(ngtcp2_realloc) != ownSizeof(ngtcp2_realloc_536871380):
-      static :
-        warning("Declaration of " & "ngtcp2_realloc" &
-            " exists but with different size")
-    ngtcp2_realloc
-   else:
-    ngtcp2_realloc_536871380)
-  X509_STORE_536871824 = (when declared(X509_STORE):
-    when ownSizeof(X509_STORE) != ownSizeof(X509_STORE_536871823):
-      static :
-        warning("Declaration of " & "X509_STORE" &
-            " exists but with different size")
-    X509_STORE
-   else:
-    X509_STORE_536871823)
-  HMAC_CTX_536871830 = (when declared(HMAC_CTX):
-    when ownSizeof(HMAC_CTX) != ownSizeof(HMAC_CTX_536871829):
-      static :
-        warning("Declaration of " & "HMAC_CTX" &
-            " exists but with different size")
-    HMAC_CTX
-   else:
-    HMAC_CTX_536871829)
-  ngtcp2_crypto_aead_536871500 = (when declared(ngtcp2_crypto_aead):
-    when ownSizeof(ngtcp2_crypto_aead) != ownSizeof(ngtcp2_crypto_aead_536871499):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_aead" &
-            " exists but with different size")
-    ngtcp2_crypto_aead
-   else:
-    ngtcp2_crypto_aead_536871499)
-  struct_st_ptls_openssl_override_verify_certificate_t_536871818 = (when declared(
-      struct_st_ptls_openssl_override_verify_certificate_t):
-    when ownSizeof(struct_st_ptls_openssl_override_verify_certificate_t) !=
-        ownSizeof(struct_st_ptls_openssl_override_verify_certificate_t_536871817):
-      static :
-        warning("Declaration of " &
-            "struct_st_ptls_openssl_override_verify_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_openssl_override_verify_certificate_t
-   else:
-    struct_st_ptls_openssl_override_verify_certificate_t_536871817)
-  ngtcp2_extend_max_stream_data_536871562 = (when declared(
-      ngtcp2_extend_max_stream_data):
-    when ownSizeof(ngtcp2_extend_max_stream_data) !=
-        ownSizeof(ngtcp2_extend_max_stream_data_536871561):
-      static :
-        warning("Declaration of " & "ngtcp2_extend_max_stream_data" &
-            " exists but with different size")
-    ngtcp2_extend_max_stream_data
-   else:
-    ngtcp2_extend_max_stream_data_536871561)
-  struct_st_ptls_async_job_t_536871728 = (when declared(
+  else:
+    struct_st_ptls_on_client_hello_parameters_t_553648926)
+  struct_st_ptls_async_job_t_553648943 = (when declared(
       struct_st_ptls_async_job_t):
     when ownSizeof(struct_st_ptls_async_job_t) !=
-        ownSizeof(struct_st_ptls_async_job_t_536871727):
+        ownSizeof(struct_st_ptls_async_job_t_553648942):
       static :
         warning("Declaration of " & "struct_st_ptls_async_job_t" &
             " exists but with different size")
     struct_st_ptls_async_job_t
-   else:
-    struct_st_ptls_async_job_t_536871727)
-  ngtcp2_conn_536871522 = (when declared(ngtcp2_conn):
-    when ownSizeof(ngtcp2_conn) != ownSizeof(ngtcp2_conn_536871521):
-      static :
-        warning("Declaration of " & "ngtcp2_conn" &
-            " exists but with different size")
-    ngtcp2_conn
-   else:
-    ngtcp2_conn_536871521)
-  ngtcp2_delete_crypto_cipher_ctx_536871586 = (when declared(
-      ngtcp2_delete_crypto_cipher_ctx):
-    when ownSizeof(ngtcp2_delete_crypto_cipher_ctx) !=
-        ownSizeof(ngtcp2_delete_crypto_cipher_ctx_536871585):
-      static :
-        warning("Declaration of " & "ngtcp2_delete_crypto_cipher_ctx" &
-            " exists but with different size")
-    ngtcp2_delete_crypto_cipher_ctx
-   else:
-    ngtcp2_delete_crypto_cipher_ctx_536871585)
-  ptls_log_conn_state_t_536871794 = (when declared(ptls_log_conn_state_t):
-    when ownSizeof(ptls_log_conn_state_t) != ownSizeof(ptls_log_conn_state_t_536871793):
-      static :
-        warning("Declaration of " & "ptls_log_conn_state_t" &
-            " exists but with different size")
-    ptls_log_conn_state_t
-   else:
-    ptls_log_conn_state_t_536871793)
-  struct_st_ptls_openssl_sign_certificate_t_536871808 = (when declared(
-      struct_st_ptls_openssl_sign_certificate_t):
-    when ownSizeof(struct_st_ptls_openssl_sign_certificate_t) !=
-        ownSizeof(struct_st_ptls_openssl_sign_certificate_t_536871807):
-      static :
-        warning("Declaration of " & "struct_st_ptls_openssl_sign_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_openssl_sign_certificate_t
-   else:
-    struct_st_ptls_openssl_sign_certificate_t_536871807)
-  sa_family_t_536871842 = (when declared(sa_family_t):
-    when ownSizeof(sa_family_t) != ownSizeof(sa_family_t_536871841):
-      static :
-        warning("Declaration of " & "sa_family_t" &
-            " exists but with different size")
-    sa_family_t
-   else:
-    sa_family_t_536871841)
-  struct_ngtcp2_crypto_cipher_ctx_536871510 = (when declared(
-      struct_ngtcp2_crypto_cipher_ctx):
-    when ownSizeof(struct_ngtcp2_crypto_cipher_ctx) !=
-        ownSizeof(struct_ngtcp2_crypto_cipher_ctx_536871509):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_cipher_ctx" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_cipher_ctx
-   else:
-    struct_ngtcp2_crypto_cipher_ctx_536871509)
-  ngtcp2_client_initial_536871524 = (when declared(ngtcp2_client_initial):
-    when ownSizeof(ngtcp2_client_initial) != ownSizeof(ngtcp2_client_initial_536871523):
-      static :
-        warning("Declaration of " & "ngtcp2_client_initial" &
-            " exists but with different size")
-    ngtcp2_client_initial
-   else:
-    ngtcp2_client_initial_536871523)
-  struct_ngtcp2_cid_token_536871608 = (when declared(struct_ngtcp2_cid_token):
-    when ownSizeof(struct_ngtcp2_cid_token) !=
-        ownSizeof(struct_ngtcp2_cid_token_536871607):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_cid_token" &
-            " exists but with different size")
-    struct_ngtcp2_cid_token
-   else:
-    struct_ngtcp2_cid_token_536871607)
-  ngtcp2_delete_crypto_aead_ctx_536871584 = (when declared(
-      ngtcp2_delete_crypto_aead_ctx):
-    when ownSizeof(ngtcp2_delete_crypto_aead_ctx) !=
-        ownSizeof(ngtcp2_delete_crypto_aead_ctx_536871583):
-      static :
-        warning("Declaration of " & "ngtcp2_delete_crypto_aead_ctx" &
-            " exists but with different size")
-    ngtcp2_delete_crypto_aead_ctx
-   else:
-    ngtcp2_delete_crypto_aead_ctx_536871583)
-  struct_st_ptls_hpke_cipher_suite_t_536871704 = (when declared(
-      struct_st_ptls_hpke_cipher_suite_t):
-    when ownSizeof(struct_st_ptls_hpke_cipher_suite_t) !=
-        ownSizeof(struct_st_ptls_hpke_cipher_suite_t_536871703):
-      static :
-        warning("Declaration of " & "struct_st_ptls_hpke_cipher_suite_t" &
-            " exists but with different size")
-    struct_st_ptls_hpke_cipher_suite_t
-   else:
-    struct_st_ptls_hpke_cipher_suite_t_536871703)
-  ngtcp2_tstamp_536871399 = (when declared(ngtcp2_tstamp):
-    when ownSizeof(ngtcp2_tstamp) != ownSizeof(ngtcp2_tstamp_536871398):
-      static :
-        warning("Declaration of " & "ngtcp2_tstamp" &
-            " exists but with different size")
-    ngtcp2_tstamp
-   else:
-    ngtcp2_tstamp_536871398)
-  ngtcp2_select_preferred_addr_536871574 = (when declared(
-      ngtcp2_select_preferred_addr):
-    when ownSizeof(ngtcp2_select_preferred_addr) !=
-        ownSizeof(ngtcp2_select_preferred_addr_536871573):
-      static :
-        warning("Declaration of " & "ngtcp2_select_preferred_addr" &
-            " exists but with different size")
-    ngtcp2_select_preferred_addr
-   else:
-    ngtcp2_select_preferred_addr_536871573)
-  struct_st_ptls_get_time_t_536871716 = (when declared(struct_st_ptls_get_time_t):
-    when ownSizeof(struct_st_ptls_get_time_t) !=
-        ownSizeof(struct_st_ptls_get_time_t_536871715):
-      static :
-        warning("Declaration of " & "struct_st_ptls_get_time_t" &
-            " exists but with different size")
-    struct_st_ptls_get_time_t
-   else:
-    struct_st_ptls_get_time_t_536871715)
-  struct_st_ptls_handshake_properties_t_536871782 = (when declared(
-      struct_st_ptls_handshake_properties_t):
-    when ownSizeof(struct_st_ptls_handshake_properties_t) !=
-        ownSizeof(struct_st_ptls_handshake_properties_t_536871781):
-      static :
-        warning("Declaration of " & "struct_st_ptls_handshake_properties_t" &
-            " exists but with different size")
-    struct_st_ptls_handshake_properties_t
-   else:
-    struct_st_ptls_handshake_properties_t_536871781)
-  ptls_client_hello_psk_identity_t_536871710 = (when declared(
-      ptls_client_hello_psk_identity_t):
-    when ownSizeof(ptls_client_hello_psk_identity_t) !=
-        ownSizeof(ptls_client_hello_psk_identity_t_536871709):
-      static :
-        warning("Declaration of " & "ptls_client_hello_psk_identity_t" &
-            " exists but with different size")
-    ptls_client_hello_psk_identity_t
-   else:
-    ptls_client_hello_psk_identity_t_536871709)
-  struct_ngtcp2_crypto_aead_ctx_536871506 = (when declared(
-      struct_ngtcp2_crypto_aead_ctx):
-    when ownSizeof(struct_ngtcp2_crypto_aead_ctx) !=
-        ownSizeof(struct_ngtcp2_crypto_aead_ctx_536871505):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_aead_ctx" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_aead_ctx
-   else:
-    struct_ngtcp2_crypto_aead_ctx_536871505)
-  ngtcp2_acked_stream_data_offset_536871556 = (when declared(
-      ngtcp2_acked_stream_data_offset):
-    when ownSizeof(ngtcp2_acked_stream_data_offset) !=
-        ownSizeof(ngtcp2_acked_stream_data_offset_536871555):
-      static :
-        warning("Declaration of " & "ngtcp2_acked_stream_data_offset" &
-            " exists but with different size")
-    ngtcp2_acked_stream_data_offset
-   else:
-    ngtcp2_acked_stream_data_offset_536871555)
-  ngtcp2_transport_params_536871449 = (when declared(ngtcp2_transport_params):
-    when ownSizeof(ngtcp2_transport_params) !=
-        ownSizeof(ngtcp2_transport_params_536871448):
-      static :
-        warning("Declaration of " & "ngtcp2_transport_params" &
-            " exists but with different size")
-    ngtcp2_transport_params
-   else:
-    ngtcp2_transport_params_536871448)
-  struct_ngtcp2_pkt_info_536871387 = (when declared(struct_ngtcp2_pkt_info):
-    when ownSizeof(struct_ngtcp2_pkt_info) != ownSizeof(struct_ngtcp2_pkt_info_536871386):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_pkt_info" &
-            " exists but with different size")
-    struct_ngtcp2_pkt_info
-   else:
-    struct_ngtcp2_pkt_info_536871386)
-  ptls_emit_certificate_t_536871726 = (when declared(ptls_emit_certificate_t):
-    when ownSizeof(ptls_emit_certificate_t) !=
-        ownSizeof(ptls_emit_certificate_t_536871725):
-      static :
-        warning("Declaration of " & "ptls_emit_certificate_t" &
-            " exists but with different size")
-    ptls_emit_certificate_t
-   else:
-    ptls_emit_certificate_t_536871725)
-  enum_en_ptls_early_data_acceptance_t_536871778 = (when declared(
-      enum_en_ptls_early_data_acceptance_t):
-    when ownSizeof(enum_en_ptls_early_data_acceptance_t) !=
-        ownSizeof(enum_en_ptls_early_data_acceptance_t_536871777):
-      static :
-        warning("Declaration of " & "enum_en_ptls_early_data_acceptance_t" &
-            " exists but with different size")
-    enum_en_ptls_early_data_acceptance_t
-   else:
-    enum_en_ptls_early_data_acceptance_t_536871777)
-  struct_ngtcp2_transport_params_536871447 = (when declared(
-      struct_ngtcp2_transport_params):
-    when ownSizeof(struct_ngtcp2_transport_params) !=
-        ownSizeof(struct_ngtcp2_transport_params_536871446):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_transport_params" &
-            " exists but with different size")
-    struct_ngtcp2_transport_params
-   else:
-    struct_ngtcp2_transport_params_536871446)
-  struct_in_addr_536871798 = (when declared(struct_in_addr):
-    when ownSizeof(struct_in_addr) != ownSizeof(struct_in_addr_536871797):
-      static :
-        warning("Declaration of " & "struct_in_addr" &
-            " exists but with different size")
-    struct_in_addr
-   else:
-    struct_in_addr_536871797)
-  ngtcp2_crypto_get_conn_536871628 = (when declared(ngtcp2_crypto_get_conn):
-    when ownSizeof(ngtcp2_crypto_get_conn) != ownSizeof(ngtcp2_crypto_get_conn_536871627):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_get_conn" &
-            " exists but with different size")
-    ngtcp2_crypto_get_conn
-   else:
-    ngtcp2_crypto_get_conn_536871627)
-  ptls_aead_context_t_536871672 = (when declared(ptls_aead_context_t):
-    when ownSizeof(ptls_aead_context_t) != ownSizeof(ptls_aead_context_t_536871671):
-      static :
-        warning("Declaration of " & "ptls_aead_context_t" &
-            " exists but with different size")
-    ptls_aead_context_t
-   else:
-    ptls_aead_context_t_536871671)
-  ngtcp2_cc_algo_536871464 = (when declared(ngtcp2_cc_algo):
-    when ownSizeof(ngtcp2_cc_algo) != ownSizeof(ngtcp2_cc_algo_536871463):
-      static :
-        warning("Declaration of " & "ngtcp2_cc_algo" &
-            " exists but with different size")
-    ngtcp2_cc_algo
-   else:
-    ngtcp2_cc_algo_536871463)
-  ngtcp2_sockaddr_536871419 = (when declared(ngtcp2_sockaddr):
-    when ownSizeof(ngtcp2_sockaddr) != ownSizeof(ngtcp2_sockaddr_536871418):
-      static :
-        warning("Declaration of " & "ngtcp2_sockaddr" &
-            " exists but with different size")
-    ngtcp2_sockaddr
-   else:
-    ngtcp2_sockaddr_536871418)
-  ngtcp2_decrypt_536871544 = (when declared(ngtcp2_decrypt):
-    when ownSizeof(ngtcp2_decrypt) != ownSizeof(ngtcp2_decrypt_536871543):
-      static :
-        warning("Declaration of " & "ngtcp2_decrypt" &
-            " exists but with different size")
-    ngtcp2_decrypt
-   else:
-    ngtcp2_decrypt_536871543)
-  struct_st_ptls_aead_context_t_536871668 = (when declared(
-      struct_st_ptls_aead_context_t):
-    when ownSizeof(struct_st_ptls_aead_context_t) !=
-        ownSizeof(struct_st_ptls_aead_context_t_536871667):
-      static :
-        warning("Declaration of " & "struct_st_ptls_aead_context_t" &
-            " exists but with different size")
-    struct_st_ptls_aead_context_t
-   else:
-    struct_st_ptls_aead_context_t_536871667)
-  ptls_openssl_verify_certificate_t_536871826 = (when declared(
-      ptls_openssl_verify_certificate_t):
-    when ownSizeof(ptls_openssl_verify_certificate_t) !=
-        ownSizeof(ptls_openssl_verify_certificate_t_536871825):
-      static :
-        warning("Declaration of " & "ptls_openssl_verify_certificate_t" &
-            " exists but with different size")
-    ptls_openssl_verify_certificate_t
-   else:
-    ptls_openssl_verify_certificate_t_536871825)
-  struct_st_ptls_decompress_certificate_t_536871766 = (when declared(
-      struct_st_ptls_decompress_certificate_t):
-    when ownSizeof(struct_st_ptls_decompress_certificate_t) !=
-        ownSizeof(struct_st_ptls_decompress_certificate_t_536871765):
-      static :
-        warning("Declaration of " & "struct_st_ptls_decompress_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_decompress_certificate_t
-   else:
-    struct_st_ptls_decompress_certificate_t_536871765)
-  ngtcp2_pkt_type_536871393 = (when declared(ngtcp2_pkt_type):
-    when ownSizeof(ngtcp2_pkt_type) != ownSizeof(ngtcp2_pkt_type_536871392):
-      static :
-        warning("Declaration of " & "ngtcp2_pkt_type" &
-            " exists but with different size")
-    ngtcp2_pkt_type
-   else:
-    ngtcp2_pkt_type_536871392)
-  ptls_hpke_cipher_suite_id_t_536871702 = (when declared(
-      ptls_hpke_cipher_suite_id_t):
-    when ownSizeof(ptls_hpke_cipher_suite_id_t) !=
-        ownSizeof(ptls_hpke_cipher_suite_id_t_536871701):
-      static :
-        warning("Declaration of " & "ptls_hpke_cipher_suite_id_t" &
-            " exists but with different size")
-    ptls_hpke_cipher_suite_id_t
-   else:
-    ptls_hpke_cipher_suite_id_t_536871701)
-  struct_ngtcp2_mem_536871383 = (when declared(struct_ngtcp2_mem):
-    when ownSizeof(struct_ngtcp2_mem) != ownSizeof(struct_ngtcp2_mem_536871382):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_mem" &
-            " exists but with different size")
-    struct_ngtcp2_mem
-   else:
-    struct_ngtcp2_mem_536871382)
-  ngtcp2_calloc_536871379 = (when declared(ngtcp2_calloc):
-    when ownSizeof(ngtcp2_calloc) != ownSizeof(ngtcp2_calloc_536871378):
-      static :
-        warning("Declaration of " & "ngtcp2_calloc" &
-            " exists but with different size")
-    ngtcp2_calloc
-   else:
-    ngtcp2_calloc_536871378)
-  struct_ngtcp2_preferred_addr_536871439 = (when declared(
-      struct_ngtcp2_preferred_addr):
-    when ownSizeof(struct_ngtcp2_preferred_addr) !=
-        ownSizeof(struct_ngtcp2_preferred_addr_536871438):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_preferred_addr" &
-            " exists but with different size")
-    struct_ngtcp2_preferred_addr
-   else:
-    struct_ngtcp2_preferred_addr_536871438)
-  ngtcp2_path_storage_536871492 = (when declared(ngtcp2_path_storage):
-    when ownSizeof(ngtcp2_path_storage) != ownSizeof(ngtcp2_path_storage_536871491):
-      static :
-        warning("Declaration of " & "ngtcp2_path_storage" &
-            " exists but with different size")
-    ngtcp2_path_storage
-   else:
-    ngtcp2_path_storage_536871491)
-  ngtcp2_addr_536871484 = (when declared(ngtcp2_addr):
-    when ownSizeof(ngtcp2_addr) != ownSizeof(ngtcp2_addr_536871483):
-      static :
-        warning("Declaration of " & "ngtcp2_addr" &
-            " exists but with different size")
-    ngtcp2_addr
-   else:
-    ngtcp2_addr_536871483)
-  ngtcp2_tls_early_data_rejected_536871602 = (when declared(
-      ngtcp2_tls_early_data_rejected):
-    when ownSizeof(ngtcp2_tls_early_data_rejected) !=
-        ownSizeof(ngtcp2_tls_early_data_rejected_536871601):
-      static :
-        warning("Declaration of " & "ngtcp2_tls_early_data_rejected" &
-            " exists but with different size")
-    ngtcp2_tls_early_data_rejected
-   else:
-    ngtcp2_tls_early_data_rejected_536871601)
-  struct_st_ptls_hpke_cipher_suite_id_t_536871700 = (when declared(
-      struct_st_ptls_hpke_cipher_suite_id_t):
-    when ownSizeof(struct_st_ptls_hpke_cipher_suite_id_t) !=
-        ownSizeof(struct_st_ptls_hpke_cipher_suite_id_t_536871699):
-      static :
-        warning("Declaration of " & "struct_st_ptls_hpke_cipher_suite_id_t" &
-            " exists but with different size")
-    struct_st_ptls_hpke_cipher_suite_id_t
-   else:
-    struct_st_ptls_hpke_cipher_suite_id_t_536871699)
-  EVP_MD_536871804 = (when declared(EVP_MD):
-    when ownSizeof(EVP_MD) != ownSizeof(EVP_MD_536871803):
-      static :
-        warning("Declaration of " & "EVP_MD" & " exists but with different size")
-    EVP_MD
-   else:
-    EVP_MD_536871803)
-  ngtcp2_stream_reset_536871554 = (when declared(ngtcp2_stream_reset):
-    when ownSizeof(ngtcp2_stream_reset) != ownSizeof(ngtcp2_stream_reset_536871553):
-      static :
-        warning("Declaration of " & "ngtcp2_stream_reset" &
-            " exists but with different size")
-    ngtcp2_stream_reset
-   else:
-    ngtcp2_stream_reset_536871553)
-  struct_st_ptls_iovec_t_536871638 = (when declared(struct_st_ptls_iovec_t):
-    when ownSizeof(struct_st_ptls_iovec_t) != ownSizeof(struct_st_ptls_iovec_t_536871637):
-      static :
-        warning("Declaration of " & "struct_st_ptls_iovec_t" &
-            " exists but with different size")
-    struct_st_ptls_iovec_t
-   else:
-    struct_st_ptls_iovec_t_536871637)
-  ngtcp2_recv_stream_data_536871548 = (when declared(ngtcp2_recv_stream_data):
-    when ownSizeof(ngtcp2_recv_stream_data) !=
-        ownSizeof(ngtcp2_recv_stream_data_536871547):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_stream_data" &
-            " exists but with different size")
-    ngtcp2_recv_stream_data
-   else:
-    ngtcp2_recv_stream_data_536871547)
-  struct_ngtcp2_crypto_ctx_536871514 = (when declared(struct_ngtcp2_crypto_ctx):
-    when ownSizeof(struct_ngtcp2_crypto_ctx) !=
-        ownSizeof(struct_ngtcp2_crypto_ctx_536871513):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_ctx" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_ctx
-   else:
-    struct_ngtcp2_crypto_ctx_536871513)
-  ngtcp2_version_info_536871445 = (when declared(ngtcp2_version_info):
-    when ownSizeof(ngtcp2_version_info) != ownSizeof(ngtcp2_version_info_536871444):
-      static :
-        warning("Declaration of " & "ngtcp2_version_info" &
-            " exists but with different size")
-    ngtcp2_version_info
-   else:
-    ngtcp2_version_info_536871444)
-  enum_en_ptls_hash_final_mode_t_536871676 = (when declared(
-      enum_en_ptls_hash_final_mode_t):
-    when ownSizeof(enum_en_ptls_hash_final_mode_t) !=
-        ownSizeof(enum_en_ptls_hash_final_mode_t_536871675):
-      static :
-        warning("Declaration of " & "enum_en_ptls_hash_final_mode_t" &
-            " exists but with different size")
-    enum_en_ptls_hash_final_mode_t
-   else:
-    enum_en_ptls_hash_final_mode_t_536871675)
-  ngtcp2_socklen_536871431 = (when declared(ngtcp2_socklen):
-    when ownSizeof(ngtcp2_socklen) != ownSizeof(ngtcp2_socklen_536871430):
-      static :
-        warning("Declaration of " & "ngtcp2_socklen" &
-            " exists but with different size")
-    ngtcp2_socklen
-   else:
-    ngtcp2_socklen_536871430)
-  struct_st_ptls_cipher_suite_t_536871688 = (when declared(
-      struct_st_ptls_cipher_suite_t):
-    when ownSizeof(struct_st_ptls_cipher_suite_t) !=
-        ownSizeof(struct_st_ptls_cipher_suite_t_536871687):
-      static :
-        warning("Declaration of " & "struct_st_ptls_cipher_suite_t" &
-            " exists but with different size")
-    struct_st_ptls_cipher_suite_t
-   else:
-    struct_st_ptls_cipher_suite_t_536871687)
-  ngtcp2_recv_client_initial_536871526 = (when declared(
-      ngtcp2_recv_client_initial):
-    when ownSizeof(ngtcp2_recv_client_initial) !=
-        ownSizeof(ngtcp2_recv_client_initial_536871525):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_client_initial" &
-            " exists but with different size")
-    ngtcp2_recv_client_initial
-   else:
-    ngtcp2_recv_client_initial_536871525)
-  compiler_ssize_t_536871848 = (when declared(compiler_ssize_t):
-    when ownSizeof(compiler_ssize_t) != ownSizeof(compiler_ssize_t_536871847):
-      static :
-        warning("Declaration of " & "compiler_ssize_t" &
-            " exists but with different size")
-    compiler_ssize_t
-   else:
-    compiler_ssize_t_536871847)
-  ptls_hpke_kem_t_536871698 = (when declared(ptls_hpke_kem_t):
-    when ownSizeof(ptls_hpke_kem_t) != ownSizeof(ptls_hpke_kem_t_536871697):
-      static :
-        warning("Declaration of " & "ptls_hpke_kem_t" &
-            " exists but with different size")
-    ptls_hpke_kem_t
-   else:
-    ptls_hpke_kem_t_536871697)
-  ptls_key_exchange_algorithm_t_536871654 = (when declared(
-      ptls_key_exchange_algorithm_t):
-    when ownSizeof(ptls_key_exchange_algorithm_t) !=
-        ownSizeof(ptls_key_exchange_algorithm_t_536871653):
-      static :
-        warning("Declaration of " & "ptls_key_exchange_algorithm_t" &
-            " exists but with different size")
-    ptls_key_exchange_algorithm_t
-   else:
-    ptls_key_exchange_algorithm_t_536871653)
-  ngtcp2_callbacks_536871606 = (when declared(ngtcp2_callbacks):
-    when ownSizeof(ngtcp2_callbacks) != ownSizeof(ngtcp2_callbacks_536871605):
-      static :
-        warning("Declaration of " & "ngtcp2_callbacks" &
-            " exists but with different size")
-    ngtcp2_callbacks
-   else:
-    ngtcp2_callbacks_536871605)
-  ngtcp2_crypto_cipher_536871504 = (when declared(ngtcp2_crypto_cipher):
-    when ownSizeof(ngtcp2_crypto_cipher) != ownSizeof(ngtcp2_crypto_cipher_536871503):
-      static :
-        warning("Declaration of " & "ngtcp2_crypto_cipher" &
-            " exists but with different size")
-    ngtcp2_crypto_cipher
-   else:
-    ngtcp2_crypto_cipher_536871503)
-  struct_st_ptls_sign_certificate_t_536871732 = (when declared(
-      struct_st_ptls_sign_certificate_t):
-    when ownSizeof(struct_st_ptls_sign_certificate_t) !=
-        ownSizeof(struct_st_ptls_sign_certificate_t_536871731):
-      static :
-        warning("Declaration of " & "struct_st_ptls_sign_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_sign_certificate_t
-   else:
-    struct_st_ptls_sign_certificate_t_536871731)
-  struct_st_ptls_emit_certificate_t_536871724 = (when declared(
-      struct_st_ptls_emit_certificate_t):
-    when ownSizeof(struct_st_ptls_emit_certificate_t) !=
-        ownSizeof(struct_st_ptls_emit_certificate_t_536871723):
-      static :
-        warning("Declaration of " & "struct_st_ptls_emit_certificate_t" &
-            " exists but with different size")
-    struct_st_ptls_emit_certificate_t
-   else:
-    struct_st_ptls_emit_certificate_t_536871723)
-  socklen_t_536871433 = (when declared(socklen_t):
-    when ownSizeof(socklen_t) != ownSizeof(socklen_t_536871432):
-      static :
-        warning("Declaration of " & "socklen_t" &
-            " exists but with different size")
-    socklen_t
-   else:
-    socklen_t_536871432)
-  ptls_raw_extension_t_536871776 = (when declared(ptls_raw_extension_t):
-    when ownSizeof(ptls_raw_extension_t) != ownSizeof(ptls_raw_extension_t_536871775):
-      static :
-        warning("Declaration of " & "ptls_raw_extension_t" &
-            " exists but with different size")
-    ptls_raw_extension_t
-   else:
-    ptls_raw_extension_t_536871775)
-  ngtcp2_lost_datagram_536871592 = (when declared(ngtcp2_lost_datagram):
-    when ownSizeof(ngtcp2_lost_datagram) != ownSizeof(ngtcp2_lost_datagram_536871591):
-      static :
-        warning("Declaration of " & "ngtcp2_lost_datagram" &
-            " exists but with different size")
-    ngtcp2_lost_datagram
-   else:
-    ngtcp2_lost_datagram_536871591)
-  struct_ngtcp2_pkt_hd_536871411 = (when declared(struct_ngtcp2_pkt_hd):
-    when ownSizeof(struct_ngtcp2_pkt_hd) != ownSizeof(struct_ngtcp2_pkt_hd_536871410):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_pkt_hd" &
-            " exists but with different size")
-    struct_ngtcp2_pkt_hd
-   else:
-    struct_ngtcp2_pkt_hd_536871410)
-  ptls_hash_context_t_536871682 = (when declared(ptls_hash_context_t):
-    when ownSizeof(ptls_hash_context_t) != ownSizeof(ptls_hash_context_t_536871681):
-      static :
-        warning("Declaration of " & "ptls_hash_context_t" &
-            " exists but with different size")
-    ptls_hash_context_t
-   else:
-    ptls_hash_context_t_536871681)
-  ptls_verify_certificate_t_536871738 = (when declared(ptls_verify_certificate_t):
-    when ownSizeof(ptls_verify_certificate_t) !=
-        ownSizeof(ptls_verify_certificate_t_536871737):
-      static :
-        warning("Declaration of " & "ptls_verify_certificate_t" &
-            " exists but with different size")
-    ptls_verify_certificate_t
-   else:
-    ptls_verify_certificate_t_536871737)
-  ngtcp2_ccerr_536871618 = (when declared(ngtcp2_ccerr):
-    when ownSizeof(ngtcp2_ccerr) != ownSizeof(ngtcp2_ccerr_536871617):
-      static :
-        warning("Declaration of " & "ngtcp2_ccerr" &
-            " exists but with different size")
-    ngtcp2_ccerr
-   else:
-    ngtcp2_ccerr_536871617)
-  ngtcp2_stream_close_536871552 = (when declared(ngtcp2_stream_close):
-    when ownSizeof(ngtcp2_stream_close) != ownSizeof(ngtcp2_stream_close_536871551):
-      static :
-        warning("Declaration of " & "ngtcp2_stream_close" &
-            " exists but with different size")
-    ngtcp2_stream_close
-   else:
-    ngtcp2_stream_close_536871551)
-  ssize_t_536871754 = (when declared(ssize_t):
-    when ownSizeof(ssize_t) != ownSizeof(ssize_t_536871753):
-      static :
-        warning("Declaration of " & "ssize_t" &
-            " exists but with different size")
-    ssize_t
-   else:
-    ssize_t_536871753)
-  ngtcp2_free_536871377 = (when declared(ngtcp2_free):
-    when ownSizeof(ngtcp2_free) != ownSizeof(ngtcp2_free_536871376):
-      static :
-        warning("Declaration of " & "ngtcp2_free" &
-            " exists but with different size")
-    ngtcp2_free
-   else:
-    ngtcp2_free_536871376)
-  struct_st_ptls_log_t_536871796 = (when declared(struct_st_ptls_log_t):
-    when ownSizeof(struct_st_ptls_log_t) != ownSizeof(struct_st_ptls_log_t_536871795):
-      static :
-        warning("Declaration of " & "struct_st_ptls_log_t" &
-            " exists but with different size")
-    struct_st_ptls_log_t
-   else:
-    struct_st_ptls_log_t_536871795)
-  ngtcp2_conn_info_536871460 = (when declared(ngtcp2_conn_info):
-    when ownSizeof(ngtcp2_conn_info) != ownSizeof(ngtcp2_conn_info_536871459):
-      static :
-        warning("Declaration of " & "ngtcp2_conn_info" &
-            " exists but with different size")
-    ngtcp2_conn_info
-   else:
-    ngtcp2_conn_info_536871459)
-  ngtcp2_handshake_confirmed_536871536 = (when declared(
-      ngtcp2_handshake_confirmed):
-    when ownSizeof(ngtcp2_handshake_confirmed) !=
-        ownSizeof(ngtcp2_handshake_confirmed_536871535):
-      static :
-        warning("Declaration of " & "ngtcp2_handshake_confirmed" &
-            " exists but with different size")
-    ngtcp2_handshake_confirmed
-   else:
-    ngtcp2_handshake_confirmed_536871535)
-  ptls_ech_create_opener_t_536871772 = (when declared(ptls_ech_create_opener_t):
-    when ownSizeof(ptls_ech_create_opener_t) !=
-        ownSizeof(ptls_ech_create_opener_t_536871771):
-      static :
-        warning("Declaration of " & "ptls_ech_create_opener_t" &
-            " exists but with different size")
-    ptls_ech_create_opener_t
-   else:
-    ptls_ech_create_opener_t_536871771)
-  ptls_openssl_raw_pubkey_verify_certificate_t_536871816 = (when declared(
-      ptls_openssl_raw_pubkey_verify_certificate_t):
-    when ownSizeof(ptls_openssl_raw_pubkey_verify_certificate_t) !=
-        ownSizeof(ptls_openssl_raw_pubkey_verify_certificate_t_536871815):
-      static :
-        warning("Declaration of " &
-            "ptls_openssl_raw_pubkey_verify_certificate_t" &
-            " exists but with different size")
-    ptls_openssl_raw_pubkey_verify_certificate_t
-   else:
-    ptls_openssl_raw_pubkey_verify_certificate_t_536871815)
-  ngtcp2_qlog_write_536871472 = (when declared(ngtcp2_qlog_write):
-    when ownSizeof(ngtcp2_qlog_write) != ownSizeof(ngtcp2_qlog_write_536871471):
-      static :
-        warning("Declaration of " & "ngtcp2_qlog_write" &
-            " exists but with different size")
-    ngtcp2_qlog_write
-   else:
-    ngtcp2_qlog_write_536871471)
-  struct_ngtcp2_addr_536871482 = (when declared(struct_ngtcp2_addr):
-    when ownSizeof(struct_ngtcp2_addr) != ownSizeof(struct_ngtcp2_addr_536871481):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_addr" &
-            " exists but with different size")
-    struct_ngtcp2_addr
-   else:
-    struct_ngtcp2_addr_536871481)
-  ngtcp2_update_key_536871570 = (when declared(ngtcp2_update_key):
-    when ownSizeof(ngtcp2_update_key) != ownSizeof(ngtcp2_update_key_536871569):
+  else:
+    struct_st_ptls_async_job_t_553648942)
+  EVP_CIPHER_CTX_553649043 = (when declared(EVP_CIPHER_CTX):
+    when ownSizeof(EVP_CIPHER_CTX) != ownSizeof(EVP_CIPHER_CTX_553649042):
+      static :
+        warning("Declaration of " & "EVP_CIPHER_CTX" &
+            " exists but with different size")
+    EVP_CIPHER_CTX
+  else:
+    EVP_CIPHER_CTX_553649042)
+  ptls_decompress_certificate_t_553648983 = (when declared(
+      ptls_decompress_certificate_t):
+    when ownSizeof(ptls_decompress_certificate_t) !=
+        ownSizeof(ptls_decompress_certificate_t_553648982):
+      static :
+        warning("Declaration of " & "ptls_decompress_certificate_t" &
+            " exists but with different size")
+    ptls_decompress_certificate_t
+  else:
+    ptls_decompress_certificate_t_553648982)
+  ngtcp2_update_key_553648785 = (when declared(ngtcp2_update_key):
+    when ownSizeof(ngtcp2_update_key) != ownSizeof(ngtcp2_update_key_553648784):
       static :
         warning("Declaration of " & "ngtcp2_update_key" &
             " exists but with different size")
     ngtcp2_update_key
-   else:
-    ngtcp2_update_key_536871569)
-  ptls_log_event_t_536871750 = (when declared(ptls_log_event_t):
-    when ownSizeof(ptls_log_event_t) != ownSizeof(ptls_log_event_t_536871749):
+  else:
+    ngtcp2_update_key_553648784)
+  ngtcp2_get_new_connection_id_553648781 = (when declared(
+      ngtcp2_get_new_connection_id):
+    when ownSizeof(ngtcp2_get_new_connection_id) !=
+        ownSizeof(ngtcp2_get_new_connection_id_553648780):
+      static :
+        warning("Declaration of " & "ngtcp2_get_new_connection_id" &
+            " exists but with different size")
+    ngtcp2_get_new_connection_id
+  else:
+    ngtcp2_get_new_connection_id_553648780)
+  ngtcp2_encrypt_553648757 = (when declared(ngtcp2_encrypt):
+    when ownSizeof(ngtcp2_encrypt) != ownSizeof(ngtcp2_encrypt_553648756):
+      static :
+        warning("Declaration of " & "ngtcp2_encrypt" &
+            " exists but with different size")
+    ngtcp2_encrypt
+  else:
+    ngtcp2_encrypt_553648756)
+  compiler_ssize_t_553649063 = (when declared(compiler_ssize_t):
+    when ownSizeof(compiler_ssize_t) != ownSizeof(compiler_ssize_t_553649062):
+      static :
+        warning("Declaration of " & "compiler_ssize_t" &
+            " exists but with different size")
+    compiler_ssize_t
+  else:
+    compiler_ssize_t_553649062)
+  ngtcp2_stream_open_553648765 = (when declared(ngtcp2_stream_open):
+    when ownSizeof(ngtcp2_stream_open) != ownSizeof(ngtcp2_stream_open_553648764):
+      static :
+        warning("Declaration of " & "ngtcp2_stream_open" &
+            " exists but with different size")
+    ngtcp2_stream_open
+  else:
+    ngtcp2_stream_open_553648764)
+  ptls_handshake_properties_t_553648999 = (when declared(
+      ptls_handshake_properties_t):
+    when ownSizeof(ptls_handshake_properties_t) !=
+        ownSizeof(ptls_handshake_properties_t_553648998):
+      static :
+        warning("Declaration of " & "ptls_handshake_properties_t" &
+            " exists but with different size")
+    ptls_handshake_properties_t
+  else:
+    ptls_handshake_properties_t_553648998)
+  struct_sockaddr_553648636 = (when declared(struct_sockaddr):
+    when ownSizeof(struct_sockaddr) != ownSizeof(struct_sockaddr_553648635):
+      static :
+        warning("Declaration of " & "struct_sockaddr" &
+            " exists but with different size")
+    struct_sockaddr
+  else:
+    struct_sockaddr_553648635)
+  ngtcp2_recv_datagram_553648803 = (when declared(ngtcp2_recv_datagram):
+    when ownSizeof(ngtcp2_recv_datagram) != ownSizeof(ngtcp2_recv_datagram_553648802):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_datagram" &
+            " exists but with different size")
+    ngtcp2_recv_datagram
+  else:
+    ngtcp2_recv_datagram_553648802)
+  ptls_log_event_t_553648965 = (when declared(ptls_log_event_t):
+    when ownSizeof(ptls_log_event_t) != ownSizeof(ptls_log_event_t_553648964):
       static :
         warning("Declaration of " & "ptls_log_event_t" &
             " exists but with different size")
     ptls_log_event_t
-   else:
-    ptls_log_event_t_536871749)
-  struct_st_ptls_openssl_signature_scheme_t_536871802 = (when declared(
-      struct_st_ptls_openssl_signature_scheme_t):
-    when ownSizeof(struct_st_ptls_openssl_signature_scheme_t) !=
-        ownSizeof(struct_st_ptls_openssl_signature_scheme_t_536871801):
+  else:
+    ptls_log_event_t_553648964)
+  ngtcp2_extend_max_streams_553648775 = (when declared(ngtcp2_extend_max_streams):
+    when ownSizeof(ngtcp2_extend_max_streams) !=
+        ownSizeof(ngtcp2_extend_max_streams_553648774):
       static :
-        warning("Declaration of " & "struct_st_ptls_openssl_signature_scheme_t" &
+        warning("Declaration of " & "ngtcp2_extend_max_streams" &
             " exists but with different size")
-    struct_st_ptls_openssl_signature_scheme_t
-   else:
-    struct_st_ptls_openssl_signature_scheme_t_536871801)
-  ngtcp2_ack_datagram_536871590 = (when declared(ngtcp2_ack_datagram):
-    when ownSizeof(ngtcp2_ack_datagram) != ownSizeof(ngtcp2_ack_datagram_536871589):
+    ngtcp2_extend_max_streams
+  else:
+    ngtcp2_extend_max_streams_553648774)
+  ngtcp2_recv_stateless_reset_553648773 = (when declared(
+      ngtcp2_recv_stateless_reset):
+    when ownSizeof(ngtcp2_recv_stateless_reset) !=
+        ownSizeof(ngtcp2_recv_stateless_reset_553648772):
       static :
-        warning("Declaration of " & "ngtcp2_ack_datagram" &
+        warning("Declaration of " & "ngtcp2_recv_stateless_reset" &
             " exists but with different size")
-    ngtcp2_ack_datagram
-   else:
-    ngtcp2_ack_datagram_536871589)
-  ngtcp2_ccerr_type_536871614 = (when declared(ngtcp2_ccerr_type):
-    when ownSizeof(ngtcp2_ccerr_type) != ownSizeof(ngtcp2_ccerr_type_536871613):
+    ngtcp2_recv_stateless_reset
+  else:
+    ngtcp2_recv_stateless_reset_553648772)
+  ngtcp2_path_validation_553648787 = (when declared(ngtcp2_path_validation):
+    when ownSizeof(ngtcp2_path_validation) != ownSizeof(ngtcp2_path_validation_553648786):
       static :
-        warning("Declaration of " & "ngtcp2_ccerr_type" &
+        warning("Declaration of " & "ngtcp2_path_validation" &
             " exists but with different size")
-    ngtcp2_ccerr_type
-   else:
-    ngtcp2_ccerr_type_536871613)
-  struct_st_ptls_hpke_kem_t_536871696 = (when declared(struct_st_ptls_hpke_kem_t):
-    when ownSizeof(struct_st_ptls_hpke_kem_t) !=
-        ownSizeof(struct_st_ptls_hpke_kem_t_536871695):
+    ngtcp2_path_validation
+  else:
+    ngtcp2_path_validation_553648786)
+  ptls_iovec_t_553648855 = (when declared(ptls_iovec_t):
+    when ownSizeof(ptls_iovec_t) != ownSizeof(ptls_iovec_t_553648854):
       static :
-        warning("Declaration of " & "struct_st_ptls_hpke_kem_t" &
+        warning("Declaration of " & "ptls_iovec_t" &
             " exists but with different size")
-    struct_st_ptls_hpke_kem_t
-   else:
-    struct_st_ptls_hpke_kem_t_536871695)
-  union_ngtcp2_sockaddr_union_536871435 = (when declared(
-      union_ngtcp2_sockaddr_union):
-    when ownSizeof(union_ngtcp2_sockaddr_union) !=
-        ownSizeof(union_ngtcp2_sockaddr_union_536871434):
-      static :
-        warning("Declaration of " & "union_ngtcp2_sockaddr_union" &
-            " exists but with different size")
-    union_ngtcp2_sockaddr_union
-   else:
-    union_ngtcp2_sockaddr_union_536871434)
-  struct_st_ptls_raw_extension_t_536871774 = (when declared(
-      struct_st_ptls_raw_extension_t):
-    when ownSizeof(struct_st_ptls_raw_extension_t) !=
-        ownSizeof(struct_st_ptls_raw_extension_t_536871773):
-      static :
-        warning("Declaration of " & "struct_st_ptls_raw_extension_t" &
-            " exists but with different size")
-    struct_st_ptls_raw_extension_t
-   else:
-    struct_st_ptls_raw_extension_t_536871773)
-  ngtcp2_path_validation_result_536871397 = (when declared(
-      ngtcp2_path_validation_result):
-    when ownSizeof(ngtcp2_path_validation_result) !=
-        ownSizeof(ngtcp2_path_validation_result_536871396):
-      static :
-        warning("Declaration of " & "ngtcp2_path_validation_result" &
-            " exists but with different size")
-    ngtcp2_path_validation_result
-   else:
-    ngtcp2_path_validation_result_536871396)
-  ngtcp2_cid_536871405 = (when declared(ngtcp2_cid):
-    when ownSizeof(ngtcp2_cid) != ownSizeof(ngtcp2_cid_536871404):
-      static :
-        warning("Declaration of " & "ngtcp2_cid" &
-            " exists but with different size")
-    ngtcp2_cid
-   else:
-    ngtcp2_cid_536871404)
-  struct_st_ptls_key_exchange_context_t_536871646 = (when declared(
-      struct_st_ptls_key_exchange_context_t):
-    when ownSizeof(struct_st_ptls_key_exchange_context_t) !=
-        ownSizeof(struct_st_ptls_key_exchange_context_t_536871645):
-      static :
-        warning("Declaration of " & "struct_st_ptls_key_exchange_context_t" &
-            " exists but with different size")
-    struct_st_ptls_key_exchange_context_t
-   else:
-    struct_st_ptls_key_exchange_context_t_536871645)
-  struct_st_ptls_ech_create_opener_t_536871770 = (when declared(
-      struct_st_ptls_ech_create_opener_t):
-    when ownSizeof(struct_st_ptls_ech_create_opener_t) !=
-        ownSizeof(struct_st_ptls_ech_create_opener_t_536871769):
-      static :
-        warning("Declaration of " & "struct_st_ptls_ech_create_opener_t" &
-            " exists but with different size")
-    struct_st_ptls_ech_create_opener_t
-   else:
-    struct_st_ptls_ech_create_opener_t_536871769)
-  struct_st_ptls_log_point_t_536871788 = (when declared(
-      struct_st_ptls_log_point_t):
-    when ownSizeof(struct_st_ptls_log_point_t) !=
-        ownSizeof(struct_st_ptls_log_point_t_536871787):
-      static :
-        warning("Declaration of " & "struct_st_ptls_log_point_t" &
-            " exists but with different size")
-    struct_st_ptls_log_point_t
-   else:
-    struct_st_ptls_log_point_t_536871787)
-  ptls_cred_buffer_t_536871840 = (when declared(ptls_cred_buffer_t):
-    when ownSizeof(ptls_cred_buffer_t) != ownSizeof(ptls_cred_buffer_t_536871839):
-      static :
-        warning("Declaration of " & "ptls_cred_buffer_t" &
-            " exists but with different size")
-    ptls_cred_buffer_t
-   else:
-    ptls_cred_buffer_t_536871839)
-  ngtcp2_recv_new_token_536871582 = (when declared(ngtcp2_recv_new_token):
-    when ownSizeof(ngtcp2_recv_new_token) != ownSizeof(ngtcp2_recv_new_token_536871581):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_new_token" &
-            " exists but with different size")
-    ngtcp2_recv_new_token
-   else:
-    ngtcp2_recv_new_token_536871581)
-  in_addr_t_536871850 = (when declared(in_addr_t):
-    when ownSizeof(in_addr_t) != ownSizeof(in_addr_t_536871849):
-      static :
-        warning("Declaration of " & "in_addr_t" &
-            " exists but with different size")
-    in_addr_t
-   else:
-    in_addr_t_536871849)
-  ngtcp2_mem_536871385 = (when declared(ngtcp2_mem):
-    when ownSizeof(ngtcp2_mem) != ownSizeof(ngtcp2_mem_536871384):
-      static :
-        warning("Declaration of " & "ngtcp2_mem" &
-            " exists but with different size")
-    ngtcp2_mem
-   else:
-    ngtcp2_mem_536871384)
-  ngtcp2_info_536871622 = (when declared(ngtcp2_info):
-    when ownSizeof(ngtcp2_info) != ownSizeof(ngtcp2_info_536871621):
-      static :
-        warning("Declaration of " & "ngtcp2_info" &
-            " exists but with different size")
-    ngtcp2_info
-   else:
-    ngtcp2_info_536871621)
-  struct_ngtcp2_crypto_md_536871494 = (when declared(struct_ngtcp2_crypto_md):
-    when ownSizeof(struct_ngtcp2_crypto_md) !=
-        ownSizeof(struct_ngtcp2_crypto_md_536871493):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_crypto_md" &
-            " exists but with different size")
-    struct_ngtcp2_crypto_md
-   else:
-    struct_ngtcp2_crypto_md_536871493)
-  ngtcp2_rand_536871564 = (when declared(ngtcp2_rand):
-    when ownSizeof(ngtcp2_rand) != ownSizeof(ngtcp2_rand_536871563):
-      static :
-        warning("Declaration of " & "ngtcp2_rand" &
-            " exists but with different size")
-    ngtcp2_rand
-   else:
-    ngtcp2_rand_536871563)
-  EVP_PKEY_536871800 = (when declared(EVP_PKEY):
-    when ownSizeof(EVP_PKEY) != ownSizeof(EVP_PKEY_536871799):
-      static :
-        warning("Declaration of " & "EVP_PKEY" &
-            " exists but with different size")
-    EVP_PKEY
-   else:
-    EVP_PKEY_536871799)
-  struct_st_ptls_log_conn_state_t_536871790 = (when declared(
-      struct_st_ptls_log_conn_state_t):
-    when ownSizeof(struct_st_ptls_log_conn_state_t) !=
-        ownSizeof(struct_st_ptls_log_conn_state_t_536871789):
-      static :
-        warning("Declaration of " & "struct_st_ptls_log_conn_state_t" &
-            " exists but with different size")
-    struct_st_ptls_log_conn_state_t
-   else:
-    struct_st_ptls_log_conn_state_t_536871789)
-  struct_ngtcp2_pkt_stateless_reset_536871415 = (when declared(
-      struct_ngtcp2_pkt_stateless_reset):
-    when ownSizeof(struct_ngtcp2_pkt_stateless_reset) !=
-        ownSizeof(struct_ngtcp2_pkt_stateless_reset_536871414):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_pkt_stateless_reset" &
-            " exists but with different size")
-    struct_ngtcp2_pkt_stateless_reset
-   else:
-    struct_ngtcp2_pkt_stateless_reset_536871414)
-  ngtcp2_rand_ctx_536871470 = (when declared(ngtcp2_rand_ctx):
-    when ownSizeof(ngtcp2_rand_ctx) != ownSizeof(ngtcp2_rand_ctx_536871469):
-      static :
-        warning("Declaration of " & "ngtcp2_rand_ctx" &
-            " exists but with different size")
-    ngtcp2_rand_ctx
-   else:
-    ngtcp2_rand_ctx_536871469)
-  struct_st_ptls_encrypt_ticket_t_536871740 = (when declared(
-      struct_st_ptls_encrypt_ticket_t):
-    when ownSizeof(struct_st_ptls_encrypt_ticket_t) !=
-        ownSizeof(struct_st_ptls_encrypt_ticket_t_536871739):
-      static :
-        warning("Declaration of " & "struct_st_ptls_encrypt_ticket_t" &
-            " exists but with different size")
-    struct_st_ptls_encrypt_ticket_t
-   else:
-    struct_st_ptls_encrypt_ticket_t_536871739)
-  ngtcp2_recv_version_negotiation_536871538 = (when declared(
-      ngtcp2_recv_version_negotiation):
-    when ownSizeof(ngtcp2_recv_version_negotiation) !=
-        ownSizeof(ngtcp2_recv_version_negotiation_536871537):
-      static :
-        warning("Declaration of " & "ngtcp2_recv_version_negotiation" &
-            " exists but with different size")
-    ngtcp2_recv_version_negotiation
-   else:
-    ngtcp2_recv_version_negotiation_536871537)
-  ptls_on_client_hello_parameters_t_536871714 = (when declared(
-      ptls_on_client_hello_parameters_t):
-    when ownSizeof(ptls_on_client_hello_parameters_t) !=
-        ownSizeof(ptls_on_client_hello_parameters_t_536871713):
-      static :
-        warning("Declaration of " & "ptls_on_client_hello_parameters_t" &
-            " exists but with different size")
-    ptls_on_client_hello_parameters_t
-   else:
-    ptls_on_client_hello_parameters_t_536871713)
-  struct_ngtcp2_conn_info_536871451 = (when declared(struct_ngtcp2_conn_info):
-    when ownSizeof(struct_ngtcp2_conn_info) !=
-        ownSizeof(struct_ngtcp2_conn_info_536871450):
-      static :
-        warning("Declaration of " & "struct_ngtcp2_conn_info" &
-            " exists but with different size")
-    struct_ngtcp2_conn_info
-   else:
-    struct_ngtcp2_conn_info_536871450)
-  struct_st_ptls_save_ticket_t_536871744 = (when declared(
-      struct_st_ptls_save_ticket_t):
-    when ownSizeof(struct_st_ptls_save_ticket_t) !=
-        ownSizeof(struct_st_ptls_save_ticket_t_536871743):
-      static :
-        warning("Declaration of " & "struct_st_ptls_save_ticket_t" &
-            " exists but with different size")
-    struct_st_ptls_save_ticket_t
-   else:
-    struct_st_ptls_save_ticket_t_536871743)
-  ptls_update_open_count_t_536871756 = (when declared(ptls_update_open_count_t):
-    when ownSizeof(ptls_update_open_count_t) !=
-        ownSizeof(ptls_update_open_count_t_536871755):
-      static :
-        warning("Declaration of " & "ptls_update_open_count_t" &
-            " exists but with different size")
-    ptls_update_open_count_t
-   else:
-    ptls_update_open_count_t_536871755)
-  struct_st_ptls_client_hello_psk_identity_t_536871708 = (when declared(
-      struct_st_ptls_client_hello_psk_identity_t):
-    when ownSizeof(struct_st_ptls_client_hello_psk_identity_t) !=
-        ownSizeof(struct_st_ptls_client_hello_psk_identity_t_536871707):
-      static :
-        warning("Declaration of " & "struct_st_ptls_client_hello_psk_identity_t" &
-            " exists but with different size")
-    struct_st_ptls_client_hello_psk_identity_t
-   else:
-    struct_st_ptls_client_hello_psk_identity_t_536871707)
-  ptls_sign_certificate_t_536871734 = (when declared(ptls_sign_certificate_t):
-    when ownSizeof(ptls_sign_certificate_t) !=
-        ownSizeof(ptls_sign_certificate_t_536871733):
-      static :
-        warning("Declaration of " & "ptls_sign_certificate_t" &
-            " exists but with different size")
-    ptls_sign_certificate_t
-   else:
-    ptls_sign_certificate_t_536871733)
-  ptls_context_t_536871632 = (when declared(ptls_context_t):
-    when ownSizeof(ptls_context_t) != ownSizeof(ptls_context_t_536871631):
-      static :
-        warning("Declaration of " & "ptls_context_t" &
-            " exists but with different size")
-    ptls_context_t
-   else:
-    ptls_context_t_536871631)
-  ngtcp2_hp_mask_536871546 = (when declared(ngtcp2_hp_mask):
-    when ownSizeof(ngtcp2_hp_mask) != ownSizeof(ngtcp2_hp_mask_536871545):
-      static :
-        warning("Declaration of " & "ngtcp2_hp_mask" &
-            " exists but with different size")
-    ngtcp2_hp_mask
-   else:
-    ngtcp2_hp_mask_536871545)
-  ngtcp2_connection_id_status_536871580 = (when declared(
-      ngtcp2_connection_id_status):
-    when ownSizeof(ngtcp2_connection_id_status) !=
-        ownSizeof(ngtcp2_connection_id_status_536871579):
-      static :
-        warning("Declaration of " & "ngtcp2_connection_id_status" &
-            " exists but with different size")
-    ngtcp2_connection_id_status
-   else:
-    ngtcp2_connection_id_status_536871579)
-  enum_ngtcp2_encryption_level_536871528 = (when declared(
-      enum_ngtcp2_encryption_level):
-    when ownSizeof(enum_ngtcp2_encryption_level) !=
-        ownSizeof(enum_ngtcp2_encryption_level_536871527):
-      static :
-        warning("Declaration of " & "enum_ngtcp2_encryption_level" &
-            " exists but with different size")
-    enum_ngtcp2_encryption_level
-   else:
-    enum_ngtcp2_encryption_level_536871527)
-  ngtcp2_ssize_536871371 = (when declared(ngtcp2_ssize):
-    when ownSizeof(ngtcp2_ssize) != ownSizeof(ngtcp2_ssize_536871370):
-      static :
-        warning("Declaration of " & "ngtcp2_ssize" &
-            " exists but with different size")
-    ngtcp2_ssize
-   else:
-    ngtcp2_ssize_536871370)
-  struct_st_ptls_openssl_verify_certificate_t_536871822 = (when declared(
+    ptls_iovec_t
+  else:
+    ptls_iovec_t_553648854)
+  struct_st_ptls_openssl_verify_certificate_t_553649037 = (when declared(
       struct_st_ptls_openssl_verify_certificate_t):
     when ownSizeof(struct_st_ptls_openssl_verify_certificate_t) !=
-        ownSizeof(struct_st_ptls_openssl_verify_certificate_t_536871821):
+        ownSizeof(struct_st_ptls_openssl_verify_certificate_t_553649036):
       static :
         warning("Declaration of " &
             "struct_st_ptls_openssl_verify_certificate_t" &
             " exists but with different size")
     struct_st_ptls_openssl_verify_certificate_t
-   else:
-    struct_st_ptls_openssl_verify_certificate_t_536871821)
-  ptrdiff_t_536871373 = (when declared(ptrdiff_t):
-    when ownSizeof(ptrdiff_t) != ownSizeof(ptrdiff_t_536871372):
+  else:
+    struct_st_ptls_openssl_verify_certificate_t_553649036)
+  struct_sockaddr_in6_553648644 = (when declared(struct_sockaddr_in6):
+    when ownSizeof(struct_sockaddr_in6) != ownSizeof(struct_sockaddr_in6_553648643):
       static :
-        warning("Declaration of " & "ptrdiff_t" &
+        warning("Declaration of " & "struct_sockaddr_in6" &
             " exists but with different size")
-    ptrdiff_t
-   else:
-    ptrdiff_t_536871372)
-  struct_ptls_cred_buffer_s_536871838 = (when declared(struct_ptls_cred_buffer_s):
-    when ownSizeof(struct_ptls_cred_buffer_s) !=
-        ownSizeof(struct_ptls_cred_buffer_s_536871837):
+    struct_sockaddr_in6
+  else:
+    struct_sockaddr_in6_553648643)
+  struct_st_ptls_aead_algorithm_t_553648885 = (when declared(
+      struct_st_ptls_aead_algorithm_t):
+    when ownSizeof(struct_st_ptls_aead_algorithm_t) !=
+        ownSizeof(struct_st_ptls_aead_algorithm_t_553648884):
       static :
-        warning("Declaration of " & "struct_ptls_cred_buffer_s" &
+        warning("Declaration of " & "struct_st_ptls_aead_algorithm_t" &
             " exists but with different size")
-    struct_ptls_cred_buffer_s
-   else:
-    struct_ptls_cred_buffer_s_536871837)
-  ngtcp2_sockaddr_union_536871437 = (when declared(ngtcp2_sockaddr_union):
-    when ownSizeof(ngtcp2_sockaddr_union) != ownSizeof(ngtcp2_sockaddr_union_536871436):
+    struct_st_ptls_aead_algorithm_t
+  else:
+    struct_st_ptls_aead_algorithm_t_553648884)
+  struct_ngtcp2_cid_553648618 = (when declared(struct_ngtcp2_cid):
+    when ownSizeof(struct_ngtcp2_cid) != ownSizeof(struct_ngtcp2_cid_553648617):
       static :
-        warning("Declaration of " & "ngtcp2_sockaddr_union" &
+        warning("Declaration of " & "struct_ngtcp2_cid" &
             " exists but with different size")
-    ngtcp2_sockaddr_union
-   else:
-    ngtcp2_sockaddr_union_536871436)
-  struct_ngtcp2_crypto_cipher_536871502 = (when declared(
+    struct_ngtcp2_cid
+  else:
+    struct_ngtcp2_cid_553648617)
+  ssize_t_553648969 = (when declared(ssize_t):
+    when ownSizeof(ssize_t) != ownSizeof(ssize_t_553648968):
+      static :
+        warning("Declaration of " & "ssize_t" &
+            " exists but with different size")
+    ssize_t
+  else:
+    ssize_t_553648968)
+  ngtcp2_pkt_hd_553648628 = (when declared(ngtcp2_pkt_hd):
+    when ownSizeof(ngtcp2_pkt_hd) != ownSizeof(ngtcp2_pkt_hd_553648627):
+      static :
+        warning("Declaration of " & "ngtcp2_pkt_hd" &
+            " exists but with different size")
+    ngtcp2_pkt_hd
+  else:
+    ngtcp2_pkt_hd_553648627)
+  enum_ngtcp2_token_type_553648689 = (when declared(enum_ngtcp2_token_type):
+    when ownSizeof(enum_ngtcp2_token_type) != ownSizeof(enum_ngtcp2_token_type_553648688):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_token_type" &
+            " exists but with different size")
+    enum_ngtcp2_token_type
+  else:
+    enum_ngtcp2_token_type_553648688)
+  ngtcp2_recv_stream_data_553648763 = (when declared(ngtcp2_recv_stream_data):
+    when ownSizeof(ngtcp2_recv_stream_data) !=
+        ownSizeof(ngtcp2_recv_stream_data_553648762):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_stream_data" &
+            " exists but with different size")
+    ngtcp2_recv_stream_data
+  else:
+    ngtcp2_recv_stream_data_553648762)
+  struct_st_ptls_ech_create_opener_t_553648985 = (when declared(
+      struct_st_ptls_ech_create_opener_t):
+    when ownSizeof(struct_st_ptls_ech_create_opener_t) !=
+        ownSizeof(struct_st_ptls_ech_create_opener_t_553648984):
+      static :
+        warning("Declaration of " & "struct_st_ptls_ech_create_opener_t" &
+            " exists but with different size")
+    struct_st_ptls_ech_create_opener_t
+  else:
+    struct_st_ptls_ech_create_opener_t_553648984)
+  ptls_openssl_raw_pubkey_verify_certificate_t_553649031 = (when declared(
+      ptls_openssl_raw_pubkey_verify_certificate_t):
+    when ownSizeof(ptls_openssl_raw_pubkey_verify_certificate_t) !=
+        ownSizeof(ptls_openssl_raw_pubkey_verify_certificate_t_553649030):
+      static :
+        warning("Declaration of " &
+            "ptls_openssl_raw_pubkey_verify_certificate_t" &
+            " exists but with different size")
+    ptls_openssl_raw_pubkey_verify_certificate_t
+  else:
+    ptls_openssl_raw_pubkey_verify_certificate_t_553649030)
+  struct_st_ptls_message_emitter_t_553648907 = (when declared(
+      struct_st_ptls_message_emitter_t):
+    when ownSizeof(struct_st_ptls_message_emitter_t) !=
+        ownSizeof(struct_st_ptls_message_emitter_t_553648906):
+      static :
+        warning("Declaration of " & "struct_st_ptls_message_emitter_t" &
+            " exists but with different size")
+    struct_st_ptls_message_emitter_t
+  else:
+    struct_st_ptls_message_emitter_t_553648906)
+  sa_family_t_553649057 = (when declared(sa_family_t):
+    when ownSizeof(sa_family_t) != ownSizeof(sa_family_t_553649056):
+      static :
+        warning("Declaration of " & "sa_family_t" &
+            " exists but with different size")
+    sa_family_t
+  else:
+    sa_family_t_553649056)
+  ngtcp2_callbacks_553648821 = (when declared(ngtcp2_callbacks):
+    when ownSizeof(ngtcp2_callbacks) != ownSizeof(ngtcp2_callbacks_553648820):
+      static :
+        warning("Declaration of " & "ngtcp2_callbacks" &
+            " exists but with different size")
+    ngtcp2_callbacks
+  else:
+    ngtcp2_callbacks_553648820)
+  struct_st_ptls_log_point_t_553649003 = (when declared(
+      struct_st_ptls_log_point_t):
+    when ownSizeof(struct_st_ptls_log_point_t) !=
+        ownSizeof(struct_st_ptls_log_point_t_553649002):
+      static :
+        warning("Declaration of " & "struct_st_ptls_log_point_t" &
+            " exists but with different size")
+    struct_st_ptls_log_point_t
+  else:
+    struct_st_ptls_log_point_t_553649002)
+  ngtcp2_stream_reset_553648769 = (when declared(ngtcp2_stream_reset):
+    when ownSizeof(ngtcp2_stream_reset) != ownSizeof(ngtcp2_stream_reset_553648768):
+      static :
+        warning("Declaration of " & "ngtcp2_stream_reset" &
+            " exists but with different size")
+    ngtcp2_stream_reset
+  else:
+    ngtcp2_stream_reset_553648768)
+  ptls_aead_context_t_553648887 = (when declared(ptls_aead_context_t):
+    when ownSizeof(ptls_aead_context_t) != ownSizeof(ptls_aead_context_t_553648886):
+      static :
+        warning("Declaration of " & "ptls_aead_context_t" &
+            " exists but with different size")
+    ptls_aead_context_t
+  else:
+    ptls_aead_context_t_553648886)
+  struct_ngtcp2_conn_info_553648666 = (when declared(struct_ngtcp2_conn_info):
+    when ownSizeof(struct_ngtcp2_conn_info) !=
+        ownSizeof(struct_ngtcp2_conn_info_553648665):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_conn_info" &
+            " exists but with different size")
+    struct_ngtcp2_conn_info
+  else:
+    struct_ngtcp2_conn_info_553648665)
+  struct_ngtcp2_pkt_info_553648602 = (when declared(struct_ngtcp2_pkt_info):
+    when ownSizeof(struct_ngtcp2_pkt_info) != ownSizeof(struct_ngtcp2_pkt_info_553648601):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_pkt_info" &
+            " exists but with different size")
+    struct_ngtcp2_pkt_info
+  else:
+    struct_ngtcp2_pkt_info_553648601)
+  ngtcp2_tls_early_data_rejected_553648817 = (when declared(
+      ngtcp2_tls_early_data_rejected):
+    when ownSizeof(ngtcp2_tls_early_data_rejected) !=
+        ownSizeof(ngtcp2_tls_early_data_rejected_553648816):
+      static :
+        warning("Declaration of " & "ngtcp2_tls_early_data_rejected" &
+            " exists but with different size")
+    ngtcp2_tls_early_data_rejected
+  else:
+    ngtcp2_tls_early_data_rejected_553648816)
+  struct_ngtcp2_path_storage_553648705 = (when declared(
+      struct_ngtcp2_path_storage):
+    when ownSizeof(struct_ngtcp2_path_storage) !=
+        ownSizeof(struct_ngtcp2_path_storage_553648704):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_path_storage" &
+            " exists but with different size")
+    struct_ngtcp2_path_storage
+  else:
+    struct_ngtcp2_path_storage_553648704)
+  struct_st_ptls_handshake_properties_t_553648997 = (when declared(
+      struct_st_ptls_handshake_properties_t):
+    when ownSizeof(struct_st_ptls_handshake_properties_t) !=
+        ownSizeof(struct_st_ptls_handshake_properties_t_553648996):
+      static :
+        warning("Declaration of " & "struct_st_ptls_handshake_properties_t" &
+            " exists but with different size")
+    struct_st_ptls_handshake_properties_t
+  else:
+    struct_st_ptls_handshake_properties_t_553648996)
+  ptls_key_exchange_algorithm_t_553648869 = (when declared(
+      ptls_key_exchange_algorithm_t):
+    when ownSizeof(ptls_key_exchange_algorithm_t) !=
+        ownSizeof(ptls_key_exchange_algorithm_t_553648868):
+      static :
+        warning("Declaration of " & "ptls_key_exchange_algorithm_t" &
+            " exists but with different size")
+    ptls_key_exchange_algorithm_t
+  else:
+    ptls_key_exchange_algorithm_t_553648868)
+  ngtcp2_client_initial_553648739 = (when declared(ngtcp2_client_initial):
+    when ownSizeof(ngtcp2_client_initial) != ownSizeof(ngtcp2_client_initial_553648738):
+      static :
+        warning("Declaration of " & "ngtcp2_client_initial" &
+            " exists but with different size")
+    ngtcp2_client_initial
+  else:
+    ngtcp2_client_initial_553648738)
+  ptls_openssl_verify_certificate_t_553649041 = (when declared(
+      ptls_openssl_verify_certificate_t):
+    when ownSizeof(ptls_openssl_verify_certificate_t) !=
+        ownSizeof(ptls_openssl_verify_certificate_t_553649040):
+      static :
+        warning("Declaration of " & "ptls_openssl_verify_certificate_t" &
+            " exists but with different size")
+    ptls_openssl_verify_certificate_t
+  else:
+    ptls_openssl_verify_certificate_t_553649040)
+  ptls_hpke_cipher_suite_id_t_553648917 = (when declared(
+      ptls_hpke_cipher_suite_id_t):
+    when ownSizeof(ptls_hpke_cipher_suite_id_t) !=
+        ownSizeof(ptls_hpke_cipher_suite_id_t_553648916):
+      static :
+        warning("Declaration of " & "ptls_hpke_cipher_suite_id_t" &
+            " exists but with different size")
+    ptls_hpke_cipher_suite_id_t
+  else:
+    ptls_hpke_cipher_suite_id_t_553648916)
+  struct_ngtcp2_crypto_aead_553648713 = (when declared(struct_ngtcp2_crypto_aead):
+    when ownSizeof(struct_ngtcp2_crypto_aead) !=
+        ownSizeof(struct_ngtcp2_crypto_aead_553648712):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_aead" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_aead
+  else:
+    struct_ngtcp2_crypto_aead_553648712)
+  struct_st_ptls_decompress_certificate_t_553648981 = (when declared(
+      struct_st_ptls_decompress_certificate_t):
+    when ownSizeof(struct_st_ptls_decompress_certificate_t) !=
+        ownSizeof(struct_st_ptls_decompress_certificate_t_553648980):
+      static :
+        warning("Declaration of " & "struct_st_ptls_decompress_certificate_t" &
+            " exists but with different size")
+    struct_st_ptls_decompress_certificate_t
+  else:
+    struct_st_ptls_decompress_certificate_t_553648980)
+  ngtcp2_path_storage_553648707 = (when declared(ngtcp2_path_storage):
+    when ownSizeof(ngtcp2_path_storage) != ownSizeof(ngtcp2_path_storage_553648706):
+      static :
+        warning("Declaration of " & "ngtcp2_path_storage" &
+            " exists but with different size")
+    ngtcp2_path_storage
+  else:
+    ngtcp2_path_storage_553648706)
+  ngtcp2_calloc_553648594 = (when declared(ngtcp2_calloc):
+    when ownSizeof(ngtcp2_calloc) != ownSizeof(ngtcp2_calloc_553648593):
+      static :
+        warning("Declaration of " & "ngtcp2_calloc" &
+            " exists but with different size")
+    ngtcp2_calloc
+  else:
+    ngtcp2_calloc_553648593)
+  ptls_cipher_suite_t_553648905 = (when declared(ptls_cipher_suite_t):
+    when ownSizeof(ptls_cipher_suite_t) != ownSizeof(ptls_cipher_suite_t_553648904):
+      static :
+        warning("Declaration of " & "ptls_cipher_suite_t" &
+            " exists but with different size")
+    ptls_cipher_suite_t
+  else:
+    ptls_cipher_suite_t_553648904)
+  ngtcp2_conn_info_553648668 = (when declared(ngtcp2_conn_info):
+    when ownSizeof(ngtcp2_conn_info) != ownSizeof(ngtcp2_conn_info_553648667):
+      static :
+        warning("Declaration of " & "ngtcp2_conn_info" &
+            " exists but with different size")
+    ngtcp2_conn_info
+  else:
+    ngtcp2_conn_info_553648667)
+  ngtcp2_socklen_553648646 = (when declared(ngtcp2_socklen):
+    when ownSizeof(ngtcp2_socklen) != ownSizeof(ngtcp2_socklen_553648645):
+      static :
+        warning("Declaration of " & "ngtcp2_socklen" &
+            " exists but with different size")
+    ngtcp2_socklen
+  else:
+    ngtcp2_socklen_553648645)
+  ptls_context_t_553648847 = (when declared(ptls_context_t):
+    when ownSizeof(ptls_context_t) != ownSizeof(ptls_context_t_553648846):
+      static :
+        warning("Declaration of " & "ptls_context_t" &
+            " exists but with different size")
+    ptls_context_t
+  else:
+    ptls_context_t_553648846)
+  struct_ngtcp2_rand_ctx_553648683 = (when declared(struct_ngtcp2_rand_ctx):
+    when ownSizeof(struct_ngtcp2_rand_ctx) != ownSizeof(struct_ngtcp2_rand_ctx_553648682):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_rand_ctx" &
+            " exists but with different size")
+    struct_ngtcp2_rand_ctx
+  else:
+    struct_ngtcp2_rand_ctx_553648682)
+  ngtcp2_ccerr_553648833 = (when declared(ngtcp2_ccerr):
+    when ownSizeof(ngtcp2_ccerr) != ownSizeof(ngtcp2_ccerr_553648832):
+      static :
+        warning("Declaration of " & "ngtcp2_ccerr" &
+            " exists but with different size")
+    ngtcp2_ccerr
+  else:
+    ngtcp2_ccerr_553648832)
+  struct_st_ptls_context_t_553648849 = (when declared(struct_st_ptls_context_t):
+    when ownSizeof(struct_st_ptls_context_t) !=
+        ownSizeof(struct_st_ptls_context_t_553648848):
+      static :
+        warning("Declaration of " & "struct_st_ptls_context_t" &
+            " exists but with different size")
+    struct_st_ptls_context_t
+  else:
+    struct_st_ptls_context_t_553648848)
+  ngtcp2_handshake_completed_553648749 = (when declared(
+      ngtcp2_handshake_completed):
+    when ownSizeof(ngtcp2_handshake_completed) !=
+        ownSizeof(ngtcp2_handshake_completed_553648748):
+      static :
+        warning("Declaration of " & "ngtcp2_handshake_completed" &
+            " exists but with different size")
+    ngtcp2_handshake_completed
+  else:
+    ngtcp2_handshake_completed_553648748)
+  struct_ngtcp2_pkt_stateless_reset_553648630 = (when declared(
+      struct_ngtcp2_pkt_stateless_reset):
+    when ownSizeof(struct_ngtcp2_pkt_stateless_reset) !=
+        ownSizeof(struct_ngtcp2_pkt_stateless_reset_553648629):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_pkt_stateless_reset" &
+            " exists but with different size")
+    struct_ngtcp2_pkt_stateless_reset
+  else:
+    struct_ngtcp2_pkt_stateless_reset_553648629)
+  HMAC_CTX_553649045 = (when declared(HMAC_CTX):
+    when ownSizeof(HMAC_CTX) != ownSizeof(HMAC_CTX_553649044):
+      static :
+        warning("Declaration of " & "HMAC_CTX" &
+            " exists but with different size")
+    HMAC_CTX
+  else:
+    HMAC_CTX_553649044)
+  ptls_cred_buffer_t_553649055 = (when declared(ptls_cred_buffer_t):
+    when ownSizeof(ptls_cred_buffer_t) != ownSizeof(ptls_cred_buffer_t_553649054):
+      static :
+        warning("Declaration of " & "ptls_cred_buffer_t" &
+            " exists but with different size")
+    ptls_cred_buffer_t
+  else:
+    ptls_cred_buffer_t_553649054)
+  intptr_t_553648867 = (when declared(intptr_t):
+    when ownSizeof(intptr_t) != ownSizeof(intptr_t_553648866):
+      static :
+        warning("Declaration of " & "intptr_t" &
+            " exists but with different size")
+    intptr_t
+  else:
+    intptr_t_553648866)
+  struct_ngtcp2_crypto_cipher_553648717 = (when declared(
       struct_ngtcp2_crypto_cipher):
     when ownSizeof(struct_ngtcp2_crypto_cipher) !=
-        ownSizeof(struct_ngtcp2_crypto_cipher_536871501):
+        ownSizeof(struct_ngtcp2_crypto_cipher_553648716):
       static :
         warning("Declaration of " & "struct_ngtcp2_crypto_cipher" &
             " exists but with different size")
     struct_ngtcp2_crypto_cipher
-   else:
-    struct_ngtcp2_crypto_cipher_536871501)
-  ngtcp2_version_negotiation_536871598 = (when declared(
+  else:
+    struct_ngtcp2_crypto_cipher_553648716)
+  struct_st_ptls_on_extension_t_553648977 = (when declared(
+      struct_st_ptls_on_extension_t):
+    when ownSizeof(struct_st_ptls_on_extension_t) !=
+        ownSizeof(struct_st_ptls_on_extension_t_553648976):
+      static :
+        warning("Declaration of " & "struct_st_ptls_on_extension_t" &
+            " exists but with different size")
+    struct_st_ptls_on_extension_t
+  else:
+    struct_st_ptls_on_extension_t_553648976)
+  struct_st_ptls_openssl_signature_scheme_t_553649017 = (when declared(
+      struct_st_ptls_openssl_signature_scheme_t):
+    when ownSizeof(struct_st_ptls_openssl_signature_scheme_t) !=
+        ownSizeof(struct_st_ptls_openssl_signature_scheme_t_553649016):
+      static :
+        warning("Declaration of " & "struct_st_ptls_openssl_signature_scheme_t" &
+            " exists but with different size")
+    struct_st_ptls_openssl_signature_scheme_t
+  else:
+    struct_st_ptls_openssl_signature_scheme_t_553649016)
+  ngtcp2_pkt_type_553648608 = (when declared(ngtcp2_pkt_type):
+    when ownSizeof(ngtcp2_pkt_type) != ownSizeof(ngtcp2_pkt_type_553648607):
+      static :
+        warning("Declaration of " & "ngtcp2_pkt_type" &
+            " exists but with different size")
+    ngtcp2_pkt_type
+  else:
+    ngtcp2_pkt_type_553648607)
+  struct_ngtcp2_preferred_addr_553648654 = (when declared(
+      struct_ngtcp2_preferred_addr):
+    when ownSizeof(struct_ngtcp2_preferred_addr) !=
+        ownSizeof(struct_ngtcp2_preferred_addr_553648653):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_preferred_addr" &
+            " exists but with different size")
+    struct_ngtcp2_preferred_addr
+  else:
+    struct_ngtcp2_preferred_addr_553648653)
+  enum_ngtcp2_ccerr_type_553648827 = (when declared(enum_ngtcp2_ccerr_type):
+    when ownSizeof(enum_ngtcp2_ccerr_type) != ownSizeof(enum_ngtcp2_ccerr_type_553648826):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_ccerr_type" &
+            " exists but with different size")
+    enum_ngtcp2_ccerr_type
+  else:
+    enum_ngtcp2_ccerr_type_553648826)
+  ngtcp2_delete_crypto_cipher_ctx_553648801 = (when declared(
+      ngtcp2_delete_crypto_cipher_ctx):
+    when ownSizeof(ngtcp2_delete_crypto_cipher_ctx) !=
+        ownSizeof(ngtcp2_delete_crypto_cipher_ctx_553648800):
+      static :
+        warning("Declaration of " & "ngtcp2_delete_crypto_cipher_ctx" &
+            " exists but with different size")
+    ngtcp2_delete_crypto_cipher_ctx
+  else:
+    ngtcp2_delete_crypto_cipher_ctx_553648800)
+  ptls_hash_context_t_553648897 = (when declared(ptls_hash_context_t):
+    when ownSizeof(ptls_hash_context_t) != ownSizeof(ptls_hash_context_t_553648896):
+      static :
+        warning("Declaration of " & "ptls_hash_context_t" &
+            " exists but with different size")
+    ptls_hash_context_t
+  else:
+    ptls_hash_context_t_553648896)
+  ngtcp2_stream_stop_sending_553648811 = (when declared(
+      ngtcp2_stream_stop_sending):
+    when ownSizeof(ngtcp2_stream_stop_sending) !=
+        ownSizeof(ngtcp2_stream_stop_sending_553648810):
+      static :
+        warning("Declaration of " & "ngtcp2_stream_stop_sending" &
+            " exists but with different size")
+    ngtcp2_stream_stop_sending
+  else:
+    ngtcp2_stream_stop_sending_553648810)
+  ngtcp2_pkt_stateless_reset_553648632 = (when declared(
+      ngtcp2_pkt_stateless_reset):
+    when ownSizeof(ngtcp2_pkt_stateless_reset) !=
+        ownSizeof(ngtcp2_pkt_stateless_reset_553648631):
+      static :
+        warning("Declaration of " & "ngtcp2_pkt_stateless_reset" &
+            " exists but with different size")
+    ngtcp2_pkt_stateless_reset
+  else:
+    ngtcp2_pkt_stateless_reset_553648631)
+  ngtcp2_token_type_553648691 = (when declared(ngtcp2_token_type):
+    when ownSizeof(ngtcp2_token_type) != ownSizeof(ngtcp2_token_type_553648690):
+      static :
+        warning("Declaration of " & "ngtcp2_token_type" &
+            " exists but with different size")
+    ngtcp2_token_type
+  else:
+    ngtcp2_token_type_553648690)
+  ptls_hpke_cipher_suite_t_553648921 = (when declared(ptls_hpke_cipher_suite_t):
+    when ownSizeof(ptls_hpke_cipher_suite_t) !=
+        ownSizeof(ptls_hpke_cipher_suite_t_553648920):
+      static :
+        warning("Declaration of " & "ptls_hpke_cipher_suite_t" &
+            " exists but with different size")
+    ptls_hpke_cipher_suite_t
+  else:
+    ptls_hpke_cipher_suite_t_553648920)
+  ngtcp2_crypto_cipher_553648719 = (when declared(ngtcp2_crypto_cipher):
+    when ownSizeof(ngtcp2_crypto_cipher) != ownSizeof(ngtcp2_crypto_cipher_553648718):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_cipher" &
+            " exists but with different size")
+    ngtcp2_crypto_cipher
+  else:
+    ngtcp2_crypto_cipher_553648718)
+  struct_ngtcp2_crypto_cipher_ctx_553648725 = (when declared(
+      struct_ngtcp2_crypto_cipher_ctx):
+    when ownSizeof(struct_ngtcp2_crypto_cipher_ctx) !=
+        ownSizeof(struct_ngtcp2_crypto_cipher_ctx_553648724):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_cipher_ctx" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_cipher_ctx
+  else:
+    struct_ngtcp2_crypto_cipher_ctx_553648724)
+  ptls_cipher_algorithm_t_553648877 = (when declared(ptls_cipher_algorithm_t):
+    when ownSizeof(ptls_cipher_algorithm_t) !=
+        ownSizeof(ptls_cipher_algorithm_t_553648876):
+      static :
+        warning("Declaration of " & "ptls_cipher_algorithm_t" &
+            " exists but with different size")
+    ptls_cipher_algorithm_t
+  else:
+    ptls_cipher_algorithm_t_553648876)
+  ngtcp2_path_553648703 = (when declared(ngtcp2_path):
+    when ownSizeof(ngtcp2_path) != ownSizeof(ngtcp2_path_553648702):
+      static :
+        warning("Declaration of " & "ngtcp2_path" &
+            " exists but with different size")
+    ngtcp2_path
+  else:
+    ngtcp2_path_553648702)
+  ngtcp2_version_negotiation_553648813 = (when declared(
       ngtcp2_version_negotiation):
     when ownSizeof(ngtcp2_version_negotiation) !=
-        ownSizeof(ngtcp2_version_negotiation_536871597):
+        ownSizeof(ngtcp2_version_negotiation_553648812):
       static :
         warning("Declaration of " & "ngtcp2_version_negotiation" &
             " exists but with different size")
     ngtcp2_version_negotiation
-   else:
-    ngtcp2_version_negotiation_536871597)
-  ptls_on_client_hello_t_536871722 = (when declared(ptls_on_client_hello_t):
-    when ownSizeof(ptls_on_client_hello_t) != ownSizeof(ptls_on_client_hello_t_536871721):
+  else:
+    ngtcp2_version_negotiation_553648812)
+  struct_ngtcp2_mem_553648598 = (when declared(struct_ngtcp2_mem):
+    when ownSizeof(struct_ngtcp2_mem) != ownSizeof(struct_ngtcp2_mem_553648597):
       static :
-        warning("Declaration of " & "ptls_on_client_hello_t" &
+        warning("Declaration of " & "struct_ngtcp2_mem" &
             " exists but with different size")
-    ptls_on_client_hello_t
-   else:
-    ptls_on_client_hello_t_536871721)
-  ptls_async_job_t_536871730 = (when declared(ptls_async_job_t):
-    when ownSizeof(ptls_async_job_t) != ownSizeof(ptls_async_job_t_536871729):
+    struct_ngtcp2_mem
+  else:
+    struct_ngtcp2_mem_553648597)
+  ngtcp2_cid_553648620 = (when declared(ngtcp2_cid):
+    when ownSizeof(ngtcp2_cid) != ownSizeof(ngtcp2_cid_553648619):
       static :
-        warning("Declaration of " & "ptls_async_job_t" &
+        warning("Declaration of " & "ngtcp2_cid" &
             " exists but with different size")
-    ptls_async_job_t
-   else:
-    ptls_async_job_t_536871729)
-  ptls_hash_algorithm_t_536871686 = (when declared(ptls_hash_algorithm_t):
-    when ownSizeof(ptls_hash_algorithm_t) != ownSizeof(ptls_hash_algorithm_t_536871685):
+    ngtcp2_cid
+  else:
+    ngtcp2_cid_553648619)
+  ngtcp2_version_info_553648660 = (when declared(ngtcp2_version_info):
+    when ownSizeof(ngtcp2_version_info) != ownSizeof(ngtcp2_version_info_553648659):
       static :
-        warning("Declaration of " & "ptls_hash_algorithm_t" &
+        warning("Declaration of " & "ngtcp2_version_info" &
             " exists but with different size")
-    ptls_hash_algorithm_t
-   else:
-    ptls_hash_algorithm_t_536871685)
-  ptls_cipher_context_t_536871660 = (when declared(ptls_cipher_context_t):
-    when ownSizeof(ptls_cipher_context_t) != ownSizeof(ptls_cipher_context_t_536871659):
+    ngtcp2_version_info
+  else:
+    ngtcp2_version_info_553648659)
+  struct_ngtcp2_addr_553648697 = (when declared(struct_ngtcp2_addr):
+    when ownSizeof(struct_ngtcp2_addr) != ownSizeof(struct_ngtcp2_addr_553648696):
       static :
-        warning("Declaration of " & "ptls_cipher_context_t" &
+        warning("Declaration of " & "struct_ngtcp2_addr" &
             " exists but with different size")
-    ptls_cipher_context_t
-   else:
-    ptls_cipher_context_t_536871659)
-  ngtcp2_malloc_536871375 = (when declared(ngtcp2_malloc):
-    when ownSizeof(ngtcp2_malloc) != ownSizeof(ngtcp2_malloc_536871374):
+    struct_ngtcp2_addr
+  else:
+    struct_ngtcp2_addr_553648696)
+  ngtcp2_addr_553648699 = (when declared(ngtcp2_addr):
+    when ownSizeof(ngtcp2_addr) != ownSizeof(ngtcp2_addr_553648698):
       static :
-        warning("Declaration of " & "ngtcp2_malloc" &
+        warning("Declaration of " & "ngtcp2_addr" &
             " exists but with different size")
-    ngtcp2_malloc
-   else:
-    ngtcp2_malloc_536871374)
-  ptls_openssl_override_verify_certificate_t_536871820 = (when declared(
+    ngtcp2_addr
+  else:
+    ngtcp2_addr_553648698)
+  ngtcp2_qlog_write_553648687 = (when declared(ngtcp2_qlog_write):
+    when ownSizeof(ngtcp2_qlog_write) != ownSizeof(ngtcp2_qlog_write_553648686):
+      static :
+        warning("Declaration of " & "ngtcp2_qlog_write" &
+            " exists but with different size")
+    ngtcp2_qlog_write
+  else:
+    ngtcp2_qlog_write_553648686)
+  ngtcp2_remove_connection_id_553648783 = (when declared(
+      ngtcp2_remove_connection_id):
+    when ownSizeof(ngtcp2_remove_connection_id) !=
+        ownSizeof(ngtcp2_remove_connection_id_553648782):
+      static :
+        warning("Declaration of " & "ngtcp2_remove_connection_id" &
+            " exists but with different size")
+    ngtcp2_remove_connection_id
+  else:
+    ngtcp2_remove_connection_id_553648782)
+  struct_ngtcp2_cid_token_553648823 = (when declared(struct_ngtcp2_cid_token):
+    when ownSizeof(struct_ngtcp2_cid_token) !=
+        ownSizeof(struct_ngtcp2_cid_token_553648822):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_cid_token" &
+            " exists but with different size")
+    struct_ngtcp2_cid_token
+  else:
+    struct_ngtcp2_cid_token_553648822)
+  ngtcp2_rand_ctx_553648685 = (when declared(ngtcp2_rand_ctx):
+    when ownSizeof(ngtcp2_rand_ctx) != ownSizeof(ngtcp2_rand_ctx_553648684):
+      static :
+        warning("Declaration of " & "ngtcp2_rand_ctx" &
+            " exists but with different size")
+    ngtcp2_rand_ctx
+  else:
+    ngtcp2_rand_ctx_553648684)
+  struct_ngtcp2_settings_553648693 = (when declared(struct_ngtcp2_settings):
+    when ownSizeof(struct_ngtcp2_settings) != ownSizeof(struct_ngtcp2_settings_553648692):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_settings" &
+            " exists but with different size")
+    struct_ngtcp2_settings
+  else:
+    struct_ngtcp2_settings_553648692)
+  ngtcp2_get_path_challenge_data_553648809 = (when declared(
+      ngtcp2_get_path_challenge_data):
+    when ownSizeof(ngtcp2_get_path_challenge_data) !=
+        ownSizeof(ngtcp2_get_path_challenge_data_553648808):
+      static :
+        warning("Declaration of " & "ngtcp2_get_path_challenge_data" &
+            " exists but with different size")
+    ngtcp2_get_path_challenge_data
+  else:
+    ngtcp2_get_path_challenge_data_553648808)
+  EVP_PKEY_553649015 = (when declared(EVP_PKEY):
+    when ownSizeof(EVP_PKEY) != ownSizeof(EVP_PKEY_553649014):
+      static :
+        warning("Declaration of " & "EVP_PKEY" &
+            " exists but with different size")
+    EVP_PKEY
+  else:
+    EVP_PKEY_553649014)
+  ptls_save_ticket_t_553648961 = (when declared(ptls_save_ticket_t):
+    when ownSizeof(ptls_save_ticket_t) != ownSizeof(ptls_save_ticket_t_553648960):
+      static :
+        warning("Declaration of " & "ptls_save_ticket_t" &
+            " exists but with different size")
+    ptls_save_ticket_t
+  else:
+    ptls_save_ticket_t_553648960)
+  ptls_openssl_override_verify_certificate_t_553649035 = (when declared(
       ptls_openssl_override_verify_certificate_t):
     when ownSizeof(ptls_openssl_override_verify_certificate_t) !=
-        ownSizeof(ptls_openssl_override_verify_certificate_t_536871819):
+        ownSizeof(ptls_openssl_override_verify_certificate_t_553649034):
       static :
         warning("Declaration of " & "ptls_openssl_override_verify_certificate_t" &
             " exists but with different size")
     ptls_openssl_override_verify_certificate_t
-   else:
-    ptls_openssl_override_verify_certificate_t_536871819)
-  struct_ngtcp2_version_info_536871443 = (when declared(
-      struct_ngtcp2_version_info):
-    when ownSizeof(struct_ngtcp2_version_info) !=
-        ownSizeof(struct_ngtcp2_version_info_536871442):
+  else:
+    ptls_openssl_override_verify_certificate_t_553649034)
+  ptls_sign_certificate_t_553648949 = (when declared(ptls_sign_certificate_t):
+    when ownSizeof(ptls_sign_certificate_t) !=
+        ownSizeof(ptls_sign_certificate_t_553648948):
       static :
-        warning("Declaration of " & "struct_ngtcp2_version_info" &
+        warning("Declaration of " & "ptls_sign_certificate_t" &
             " exists but with different size")
-    struct_ngtcp2_version_info
-   else:
-    struct_ngtcp2_version_info_536871442)
-when not declared(struct_st_ptls_update_open_count_t):
-  type
-    struct_st_ptls_update_open_count_t* = struct_st_ptls_update_open_count_t_536871751
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_update_open_count_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_key_exchange_algorithm_t):
-  type
-    struct_st_ptls_key_exchange_algorithm_t* = struct_st_ptls_key_exchange_algorithm_t_536871647
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_key_exchange_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_preferred_addr):
-  type
-    ngtcp2_preferred_addr* = ngtcp2_preferred_addr_536871440
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_preferred_addr" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_connection_id_status_type):
-  type
-    ngtcp2_connection_id_status_type* = ngtcp2_connection_id_status_type_536871577
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_connection_id_status_type" &
-        " already exists, not redeclaring")
-when not declared(struct_sockaddr):
-  type
-    struct_sockaddr* = struct_sockaddr_536871420
-else:
-  static :
-    hint("Declaration of " & "struct_sockaddr" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_aead_algorithm_t):
-  type
-    struct_st_ptls_aead_algorithm_t* = struct_st_ptls_aead_algorithm_t_536871669
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_aead_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_hash_context_t):
-  type
-    struct_st_ptls_hash_context_t* = struct_st_ptls_hash_context_t_536871679
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_hash_context_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_encrypt):
-  type
-    ngtcp2_encrypt* = ngtcp2_encrypt_536871541
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_encrypt" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_ccerr):
-  type
-    struct_ngtcp2_ccerr* = struct_ngtcp2_ccerr_536871615
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_ccerr" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_message_emitter_t):
-  type
-    struct_st_ptls_message_emitter_t* = struct_st_ptls_message_emitter_t_536871691
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_message_emitter_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_hpke_cipher_suite_t):
-  type
-    ptls_hpke_cipher_suite_t* = ptls_hpke_cipher_suite_t_536871705
-else:
-  static :
-    hint("Declaration of " & "ptls_hpke_cipher_suite_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_pkt_hd):
-  type
-    ngtcp2_pkt_hd* = ngtcp2_pkt_hd_536871412
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_pkt_hd" &
-        " already exists, not redeclaring")
-when not declared(struct_sockaddr_in):
-  type
-    struct_sockaddr_in* = struct_sockaddr_in_536871424
-else:
-  static :
-    hint("Declaration of " & "struct_sockaddr_in" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_token_type):
-  type
-    enum_ngtcp2_token_type* = enum_ngtcp2_token_type_536871473
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_token_type" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_rand_ctx):
-  type
-    struct_ngtcp2_rand_ctx* = struct_ngtcp2_rand_ctx_536871467
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_rand_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_stream_open):
-  type
-    ngtcp2_stream_open* = ngtcp2_stream_open_536871549
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_stream_open" &
-        " already exists, not redeclaring")
-when not declared(struct_sockaddr_in6):
-  type
-    struct_sockaddr_in6* = struct_sockaddr_in6_536871428
-else:
-  static :
-    hint("Declaration of " & "struct_sockaddr_in6" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_ccerr_type):
-  type
-    enum_ngtcp2_ccerr_type* = enum_ngtcp2_ccerr_type_536871611
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_ccerr_type" &
-        " already exists, not redeclaring")
-when not declared(ptls_key_exchange_context_t):
-  type
-    ptls_key_exchange_context_t* = ptls_key_exchange_context_t_536871649
-else:
-  static :
-    hint("Declaration of " & "ptls_key_exchange_context_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_on_client_hello_t):
-  type
-    struct_st_ptls_on_client_hello_t* = struct_st_ptls_on_client_hello_t_536871719
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_on_client_hello_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_on_extension_t):
-  type
-    struct_st_ptls_on_extension_t* = struct_st_ptls_on_extension_t_536871761
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_on_extension_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_stream_stop_sending):
-  type
-    ngtcp2_stream_stop_sending* = ngtcp2_stream_stop_sending_536871595
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_stream_stop_sending" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_sockaddr_in):
-  type
-    ngtcp2_sockaddr_in* = ngtcp2_sockaddr_in_536871422
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_sockaddr_in" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_callbacks):
-  type
-    struct_ngtcp2_callbacks* = struct_ngtcp2_callbacks_536871603
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_callbacks" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_datagram):
-  type
-    ngtcp2_recv_datagram* = ngtcp2_recv_datagram_536871587
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_datagram" &
-        " already exists, not redeclaring")
-when not declared(ptls_cipher_suite_t):
-  type
-    ptls_cipher_suite_t* = ptls_cipher_suite_t_536871689
-else:
-  static :
-    hint("Declaration of " & "ptls_cipher_suite_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_path):
-  type
-    ngtcp2_path* = ngtcp2_path_536871487
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_path" & " already exists, not redeclaring")
-when not declared(ngtcp2_pkt_info):
-  type
-    ngtcp2_pkt_info* = ngtcp2_pkt_info_536871388
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_pkt_info" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_encryption_level):
-  type
-    ngtcp2_encryption_level* = ngtcp2_encryption_level_536871529
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_encryption_level" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_info):
-  type
-    struct_ngtcp2_info* = struct_ngtcp2_info_536871619
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_info" &
-        " already exists, not redeclaring")
-when not declared(ptls_encrypt_ticket_t):
-  type
-    ptls_encrypt_ticket_t* = ptls_encrypt_ticket_t_536871741
-else:
-  static :
-    hint("Declaration of " & "ptls_encrypt_ticket_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_aead):
-  type
-    struct_ngtcp2_crypto_aead* = struct_ngtcp2_crypto_aead_536871497
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_aead" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_path_validation_result):
-  type
-    enum_ngtcp2_path_validation_result* = enum_ngtcp2_path_validation_result_536871394
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_path_validation_result" &
-        " already exists, not redeclaring")
-when not declared(ptls_message_emitter_t):
-  type
-    ptls_message_emitter_t* = ptls_message_emitter_t_536871693
-else:
-  static :
-    hint("Declaration of " & "ptls_message_emitter_t" &
-        " already exists, not redeclaring")
-when not declared(EVP_CIPHER_CTX):
-  type
-    EVP_CIPHER_CTX* = EVP_CIPHER_CTX_536871827
-else:
-  static :
-    hint("Declaration of " & "EVP_CIPHER_CTX" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_path_storage):
-  type
-    struct_ngtcp2_path_storage* = struct_ngtcp2_path_storage_536871489
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_path_storage" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_aead_ctx):
-  type
-    ngtcp2_crypto_aead_ctx* = ngtcp2_crypto_aead_ctx_536871507
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_aead_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_settings):
-  type
-    ngtcp2_settings* = ngtcp2_settings_536871479
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_settings" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_context_t):
-  type
-    struct_st_ptls_context_t* = struct_st_ptls_context_t_536871633
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_context_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_aead_supplementary_encryption_t):
-  type
-    struct_st_ptls_aead_supplementary_encryption_t* = struct_st_ptls_aead_supplementary_encryption_t_536871663
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_aead_supplementary_encryption_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_cipher_algorithm_t):
-  type
-    ptls_cipher_algorithm_t* = ptls_cipher_algorithm_t_536871661
-else:
-  static :
-    hint("Declaration of " & "ptls_cipher_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_openssl_sign_certificate_t):
-  type
-    ptls_openssl_sign_certificate_t* = ptls_openssl_sign_certificate_t_536871809
-else:
-  static :
-    hint("Declaration of " & "ptls_openssl_sign_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_path):
-  type
-    struct_ngtcp2_path* = struct_ngtcp2_path_536871485
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_path" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_get_new_connection_id):
-  type
-    ngtcp2_get_new_connection_id* = ngtcp2_get_new_connection_id_536871565
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_get_new_connection_id" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_get_path_challenge_data):
-  type
-    ngtcp2_get_path_challenge_data* = ngtcp2_get_path_challenge_data_536871593
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_get_path_challenge_data" &
-        " already exists, not redeclaring")
-when not declared(X509):
-  type
-    X509* = X509_536871811
-else:
-  static :
-    hint("Declaration of " & "X509" & " already exists, not redeclaring")
-when not declared(ptls_key_schedule_t):
-  type
-    ptls_key_schedule_t* = ptls_key_schedule_t_536871635
-else:
-  static :
-    hint("Declaration of " & "ptls_key_schedule_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_aead_supplementary_encryption_t):
-  type
-    ptls_aead_supplementary_encryption_t* = ptls_aead_supplementary_encryption_t_536871665
-else:
-  static :
-    hint("Declaration of " & "ptls_aead_supplementary_encryption_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_on_extension_t):
-  type
-    ptls_on_extension_t* = ptls_on_extension_t_536871763
-else:
-  static :
-    hint("Declaration of " & "ptls_on_extension_t" &
-        " already exists, not redeclaring")
-when not declared(EVP_MAC_CTX):
-  type
-    EVP_MAC_CTX* = EVP_MAC_CTX_536871831
-else:
-  static :
-    hint("Declaration of " & "EVP_MAC_CTX" & " already exists, not redeclaring")
-when not declared(ngtcp2_extend_max_streams):
-  type
-    ngtcp2_extend_max_streams* = ngtcp2_extend_max_streams_536871559
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_extend_max_streams" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_sockaddr_in6):
-  type
-    ngtcp2_sockaddr_in6* = ngtcp2_sockaddr_in6_536871426
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_sockaddr_in6" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_version_cid):
-  type
-    struct_ngtcp2_version_cid* = struct_ngtcp2_version_cid_536871517
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_version_cid" &
-        " already exists, not redeclaring")
-when not declared(struct_in6_addr):
-  type
-    struct_in6_addr* = struct_in6_addr_536871791
-else:
-  static :
-    hint("Declaration of " & "struct_in6_addr" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_hash_algorithm_t):
-  type
-    struct_st_ptls_hash_algorithm_t* = struct_st_ptls_hash_algorithm_t_536871683
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_hash_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_iovec_t):
-  type
-    ptls_iovec_t* = ptls_iovec_t_536871639
-else:
-  static :
-    hint("Declaration of " & "ptls_iovec_t" & " already exists, not redeclaring")
-when not declared(enum_ngtcp2_pkt_type):
-  type
-    enum_ngtcp2_pkt_type* = enum_ngtcp2_pkt_type_536871390
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_pkt_type" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_version_cid):
-  type
-    ngtcp2_version_cid* = ngtcp2_version_cid_536871519
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_version_cid" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_conn_ref):
-  type
-    ngtcp2_crypto_conn_ref* = ngtcp2_crypto_conn_ref_536871623
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_conn_ref" &
-        " already exists, not redeclaring")
-when not declared(ptls_buffer_t):
-  type
-    ptls_buffer_t* = ptls_buffer_t_536871643
-else:
-  static :
-    hint("Declaration of " & "ptls_buffer_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_handshake_properties_t):
-  type
-    ptls_handshake_properties_t* = ptls_handshake_properties_t_536871783
-else:
-  static :
-    hint("Declaration of " & "ptls_handshake_properties_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_aead_algorithm_t):
-  type
-    ptls_aead_algorithm_t* = ptls_aead_algorithm_t_536871673
-else:
-  static :
-    hint("Declaration of " & "ptls_aead_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_on_client_hello_parameters_t):
-  type
-    struct_st_ptls_on_client_hello_parameters_t* = struct_st_ptls_on_client_hello_parameters_t_536871711
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_on_client_hello_parameters_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_early_data_acceptance_t):
-  type
-    ptls_early_data_acceptance_t* = ptls_early_data_acceptance_t_536871779
-else:
-  static :
-    hint("Declaration of " & "ptls_early_data_acceptance_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_token_type):
-  type
-    ngtcp2_token_type* = ngtcp2_token_type_536871475
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_token_type" &
-        " already exists, not redeclaring")
-when not declared(ptls_get_time_t):
-  type
-    ptls_get_time_t* = ptls_get_time_t_536871717
-else:
-  static :
-    hint("Declaration of " & "ptls_get_time_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_decompress_certificate_t):
-  type
-    ptls_decompress_certificate_t* = ptls_decompress_certificate_t_536871767
-else:
-  static :
-    hint("Declaration of " & "ptls_decompress_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_pkt_stateless_reset):
-  type
-    ngtcp2_pkt_stateless_reset* = ngtcp2_pkt_stateless_reset_536871416
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_pkt_stateless_reset" &
-        " already exists, not redeclaring")
-when not declared(intptr_t):
-  type
-    intptr_t* = intptr_t_536871651
-else:
-  static :
-    hint("Declaration of " & "intptr_t" & " already exists, not redeclaring")
-when not declared(struct_ngtcp2_settings):
-  type
-    struct_ngtcp2_settings* = struct_ngtcp2_settings_536871477
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_settings" &
-        " already exists, not redeclaring")
-when not declared(compiler_socklen_t):
-  type
-    compiler_socklen_t* = compiler_socklen_t_536871845
-else:
-  static :
-    hint("Declaration of " & "compiler_socklen_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_vec):
-  type
-    struct_ngtcp2_vec* = struct_ngtcp2_vec_536871406
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_vec" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_path_validation):
-  type
-    ngtcp2_path_validation* = ngtcp2_path_validation_536871571
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_path_validation" &
-        " already exists, not redeclaring")
-when not declared(ptls_update_traffic_key_t):
-  type
-    ptls_update_traffic_key_t* = ptls_update_traffic_key_t_536871759
-else:
-  static :
-    hint("Declaration of " & "ptls_update_traffic_key_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_picotls_ctx):
-  type
-    ngtcp2_crypto_picotls_ctx* = ngtcp2_crypto_picotls_ctx_536871835
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_picotls_ctx" &
-        " already exists, not redeclaring")
-when not declared(ptls_t):
-  type
-    ptls_t* = ptls_t_536871629
-else:
-  static :
-    hint("Declaration of " & "ptls_t" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_cipher_algorithm_t):
-  type
-    struct_st_ptls_cipher_algorithm_t* = struct_st_ptls_cipher_algorithm_t_536871657
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_cipher_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_ctx):
-  type
-    ngtcp2_crypto_ctx* = ngtcp2_crypto_ctx_536871515
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_ctx" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_conn_ref):
-  type
-    struct_ngtcp2_crypto_conn_ref* = struct_ngtcp2_crypto_conn_ref_536871625
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_conn_ref" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t):
-  type
-    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t* = struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_536871813
-else:
-  static :
-    hint("Declaration of " &
-        "struct_st_ptls_openssl_raw_pubkey_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_cipher_ctx):
-  type
-    ngtcp2_crypto_cipher_ctx* = ngtcp2_crypto_cipher_ctx_536871511
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_cipher_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_printf):
-  type
-    ngtcp2_printf* = ngtcp2_printf_536871465
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_printf" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_verify_certificate_t):
-  type
-    struct_st_ptls_verify_certificate_t* = struct_st_ptls_verify_certificate_t_536871735
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_picotls_ctx):
-  type
-    struct_ngtcp2_crypto_picotls_ctx* = struct_ngtcp2_crypto_picotls_ctx_536871833
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_picotls_ctx" &
-        " already exists, not redeclaring")
-when not declared(ptls_hash_final_mode_t):
-  type
-    ptls_hash_final_mode_t* = ptls_hash_final_mode_t_536871677
-else:
-  static :
-    hint("Declaration of " & "ptls_hash_final_mode_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_handshake_completed):
-  type
-    ngtcp2_handshake_completed* = ngtcp2_handshake_completed_536871533
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_handshake_completed" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_cipher_context_t):
-  type
-    struct_st_ptls_cipher_context_t* = struct_st_ptls_cipher_context_t_536871655
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_cipher_context_t" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_cc_algo):
-  type
-    enum_ngtcp2_cc_algo* = enum_ngtcp2_cc_algo_536871461
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_cc_algo" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_duration):
-  type
-    ngtcp2_duration* = ngtcp2_duration_536871400
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_duration" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_cid):
-  type
-    struct_ngtcp2_cid* = struct_ngtcp2_cid_536871402
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_cid" &
-        " already exists, not redeclaring")
-when not declared(in_port_t):
-  type
-    in_port_t* = in_port_t_536871843
-else:
-  static :
-    hint("Declaration of " & "in_port_t" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_update_traffic_key_t):
-  type
-    struct_st_ptls_update_traffic_key_t* = struct_st_ptls_update_traffic_key_t_536871757
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_update_traffic_key_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_vec):
-  type
-    ngtcp2_vec* = ngtcp2_vec_536871408
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_vec" & " already exists, not redeclaring")
-when not declared(ptls_save_ticket_t):
-  type
-    ptls_save_ticket_t* = ptls_save_ticket_t_536871745
-else:
-  static :
-    hint("Declaration of " & "ptls_save_ticket_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_stateless_reset):
-  type
-    ngtcp2_recv_stateless_reset* = ngtcp2_recv_stateless_reset_536871557
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_stateless_reset" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_md):
-  type
-    ngtcp2_crypto_md* = ngtcp2_crypto_md_536871495
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_md" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_connection_id_status_type):
-  type
-    enum_ngtcp2_connection_id_status_type* = enum_ngtcp2_connection_id_status_type_536871575
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_connection_id_status_type" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_key):
-  type
-    ngtcp2_recv_key* = ngtcp2_recv_key_536871599
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_key" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_remove_connection_id):
-  type
-    ngtcp2_remove_connection_id* = ngtcp2_remove_connection_id_536871567
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_remove_connection_id" &
+    ptls_sign_certificate_t
+  else:
+    ptls_sign_certificate_t_553648948)
+  struct_ngtcp2_version_cid_553648733 = (when declared(struct_ngtcp2_version_cid):
+    when ownSizeof(struct_ngtcp2_version_cid) !=
+        ownSizeof(struct_ngtcp2_version_cid_553648732):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_version_cid" &
+            " exists but with different size")
+    struct_ngtcp2_version_cid
+  else:
+    struct_ngtcp2_version_cid_553648732)
+  ptls_log_conn_state_t_553649009 = (when declared(ptls_log_conn_state_t):
+    when ownSizeof(ptls_log_conn_state_t) != ownSizeof(ptls_log_conn_state_t_553649008):
+      static :
+        warning("Declaration of " & "ptls_log_conn_state_t" &
+            " exists but with different size")
+    ptls_log_conn_state_t
+  else:
+    ptls_log_conn_state_t_553649008)
+  struct_st_ptls_hpke_cipher_suite_t_553648919 = (when declared(
+      struct_st_ptls_hpke_cipher_suite_t):
+    when ownSizeof(struct_st_ptls_hpke_cipher_suite_t) !=
+        ownSizeof(struct_st_ptls_hpke_cipher_suite_t_553648918):
+      static :
+        warning("Declaration of " & "struct_st_ptls_hpke_cipher_suite_t" &
+            " exists but with different size")
+    struct_st_ptls_hpke_cipher_suite_t
+  else:
+    struct_st_ptls_hpke_cipher_suite_t_553648918)
+  in_addr_t_553649065 = (when declared(in_addr_t):
+    when ownSizeof(in_addr_t) != ownSizeof(in_addr_t_553649064):
+      static :
+        warning("Declaration of " & "in_addr_t" &
+            " exists but with different size")
+    in_addr_t
+  else:
+    in_addr_t_553649064)
+  struct_st_ptls_openssl_override_verify_certificate_t_553649033 = (when declared(
+      struct_st_ptls_openssl_override_verify_certificate_t):
+    when ownSizeof(struct_st_ptls_openssl_override_verify_certificate_t) !=
+        ownSizeof(struct_st_ptls_openssl_override_verify_certificate_t_553649032):
+      static :
+        warning("Declaration of " &
+            "struct_st_ptls_openssl_override_verify_certificate_t" &
+            " exists but with different size")
+    struct_st_ptls_openssl_override_verify_certificate_t
+  else:
+    struct_st_ptls_openssl_override_verify_certificate_t_553649032)
+  ngtcp2_connection_id_status_type_553648793 = (when declared(
+      ngtcp2_connection_id_status_type):
+    when ownSizeof(ngtcp2_connection_id_status_type) !=
+        ownSizeof(ngtcp2_connection_id_status_type_553648792):
+      static :
+        warning("Declaration of " & "ngtcp2_connection_id_status_type" &
+            " exists but with different size")
+    ngtcp2_connection_id_status_type
+  else:
+    ngtcp2_connection_id_status_type_553648792)
+  ngtcp2_sockaddr_union_553648652 = (when declared(ngtcp2_sockaddr_union):
+    when ownSizeof(ngtcp2_sockaddr_union) != ownSizeof(ngtcp2_sockaddr_union_553648651):
+      static :
+        warning("Declaration of " & "ngtcp2_sockaddr_union" &
+            " exists but with different size")
+    ngtcp2_sockaddr_union
+  else:
+    ngtcp2_sockaddr_union_553648651)
+  ngtcp2_cid_token_553648825 = (when declared(ngtcp2_cid_token):
+    when ownSizeof(ngtcp2_cid_token) != ownSizeof(ngtcp2_cid_token_553648824):
+      static :
+        warning("Declaration of " & "ngtcp2_cid_token" &
+            " exists but with different size")
+    ngtcp2_cid_token
+  else:
+    ngtcp2_cid_token_553648824)
+  ptls_buffer_t_553648859 = (when declared(ptls_buffer_t):
+    when ownSizeof(ptls_buffer_t) != ownSizeof(ptls_buffer_t_553648858):
+      static :
+        warning("Declaration of " & "ptls_buffer_t" &
+            " exists but with different size")
+    ptls_buffer_t
+  else:
+    ptls_buffer_t_553648858)
+  struct_st_ptls_buffer_t_553648857 = (when declared(struct_st_ptls_buffer_t):
+    when ownSizeof(struct_st_ptls_buffer_t) !=
+        ownSizeof(struct_st_ptls_buffer_t_553648856):
+      static :
+        warning("Declaration of " & "struct_st_ptls_buffer_t" &
+            " exists but with different size")
+    struct_st_ptls_buffer_t
+  else:
+    struct_st_ptls_buffer_t_553648856)
+  ptls_aead_algorithm_t_553648889 = (when declared(ptls_aead_algorithm_t):
+    when ownSizeof(ptls_aead_algorithm_t) != ownSizeof(ptls_aead_algorithm_t_553648888):
+      static :
+        warning("Declaration of " & "ptls_aead_algorithm_t" &
+            " exists but with different size")
+    ptls_aead_algorithm_t
+  else:
+    ptls_aead_algorithm_t_553648888)
+  ngtcp2_ssize_553648586 = (when declared(ngtcp2_ssize):
+    when ownSizeof(ngtcp2_ssize) != ownSizeof(ngtcp2_ssize_553648585):
+      static :
+        warning("Declaration of " & "ngtcp2_ssize" &
+            " exists but with different size")
+    ngtcp2_ssize
+  else:
+    ngtcp2_ssize_553648585)
+  ngtcp2_sockaddr_in6_553648642 = (when declared(ngtcp2_sockaddr_in6):
+    when ownSizeof(ngtcp2_sockaddr_in6) != ownSizeof(ngtcp2_sockaddr_in6_553648641):
+      static :
+        warning("Declaration of " & "ngtcp2_sockaddr_in6" &
+            " exists but with different size")
+    ngtcp2_sockaddr_in6
+  else:
+    ngtcp2_sockaddr_in6_553648641)
+  ngtcp2_mem_553648600 = (when declared(ngtcp2_mem):
+    when ownSizeof(ngtcp2_mem) != ownSizeof(ngtcp2_mem_553648599):
+      static :
+        warning("Declaration of " & "ngtcp2_mem" &
+            " exists but with different size")
+    ngtcp2_mem
+  else:
+    ngtcp2_mem_553648599)
+  ptls_hash_final_mode_t_553648893 = (when declared(ptls_hash_final_mode_t):
+    when ownSizeof(ptls_hash_final_mode_t) != ownSizeof(ptls_hash_final_mode_t_553648892):
+      static :
+        warning("Declaration of " & "ptls_hash_final_mode_t" &
+            " exists but with different size")
+    ptls_hash_final_mode_t
+  else:
+    ptls_hash_final_mode_t_553648892)
+  ngtcp2_pkt_info_553648604 = (when declared(ngtcp2_pkt_info):
+    when ownSizeof(ngtcp2_pkt_info) != ownSizeof(ngtcp2_pkt_info_553648603):
+      static :
+        warning("Declaration of " & "ngtcp2_pkt_info" &
+            " exists but with different size")
+    ngtcp2_pkt_info
+  else:
+    ngtcp2_pkt_info_553648603)
+  ptrdiff_t_553648588 = (when declared(ptrdiff_t):
+    when ownSizeof(ptrdiff_t) != ownSizeof(ptrdiff_t_553648587):
+      static :
+        warning("Declaration of " & "ptrdiff_t" &
+            " exists but with different size")
+    ptrdiff_t
+  else:
+    ptrdiff_t_553648587)
+  struct_st_ptls_aead_context_t_553648883 = (when declared(
+      struct_st_ptls_aead_context_t):
+    when ownSizeof(struct_st_ptls_aead_context_t) !=
+        ownSizeof(struct_st_ptls_aead_context_t_553648882):
+      static :
+        warning("Declaration of " & "struct_st_ptls_aead_context_t" &
+            " exists but with different size")
+    struct_st_ptls_aead_context_t
+  else:
+    struct_st_ptls_aead_context_t_553648882)
+  ngtcp2_preferred_addr_553648656 = (when declared(ngtcp2_preferred_addr):
+    when ownSizeof(ngtcp2_preferred_addr) != ownSizeof(ngtcp2_preferred_addr_553648655):
+      static :
+        warning("Declaration of " & "ngtcp2_preferred_addr" &
+            " exists but with different size")
+    ngtcp2_preferred_addr
+  else:
+    ngtcp2_preferred_addr_553648655)
+  struct_st_ptls_hpke_kem_t_553648911 = (when declared(struct_st_ptls_hpke_kem_t):
+    when ownSizeof(struct_st_ptls_hpke_kem_t) !=
+        ownSizeof(struct_st_ptls_hpke_kem_t_553648910):
+      static :
+        warning("Declaration of " & "struct_st_ptls_hpke_kem_t" &
+            " exists but with different size")
+    struct_st_ptls_hpke_kem_t
+  else:
+    struct_st_ptls_hpke_kem_t_553648910)
+  ngtcp2_realloc_553648596 = (when declared(ngtcp2_realloc):
+    when ownSizeof(ngtcp2_realloc) != ownSizeof(ngtcp2_realloc_553648595):
+      static :
+        warning("Declaration of " & "ngtcp2_realloc" &
+            " exists but with different size")
+    ngtcp2_realloc
+  else:
+    ngtcp2_realloc_553648595)
+  ngtcp2_crypto_cipher_ctx_553648727 = (when declared(ngtcp2_crypto_cipher_ctx):
+    when ownSizeof(ngtcp2_crypto_cipher_ctx) !=
+        ownSizeof(ngtcp2_crypto_cipher_ctx_553648726):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_cipher_ctx" &
+            " exists but with different size")
+    ngtcp2_crypto_cipher_ctx
+  else:
+    ngtcp2_crypto_cipher_ctx_553648726)
+  ngtcp2_version_cid_553648735 = (when declared(ngtcp2_version_cid):
+    when ownSizeof(ngtcp2_version_cid) != ownSizeof(ngtcp2_version_cid_553648734):
+      static :
+        warning("Declaration of " & "ngtcp2_version_cid" &
+            " exists but with different size")
+    ngtcp2_version_cid
+  else:
+    ngtcp2_version_cid_553648734)
+  ptls_on_client_hello_parameters_t_553648929 = (when declared(
+      ptls_on_client_hello_parameters_t):
+    when ownSizeof(ptls_on_client_hello_parameters_t) !=
+        ownSizeof(ptls_on_client_hello_parameters_t_553648928):
+      static :
+        warning("Declaration of " & "ptls_on_client_hello_parameters_t" &
+            " exists but with different size")
+    ptls_on_client_hello_parameters_t
+  else:
+    ptls_on_client_hello_parameters_t_553648928)
+  ngtcp2_recv_client_initial_553648741 = (when declared(
+      ngtcp2_recv_client_initial):
+    when ownSizeof(ngtcp2_recv_client_initial) !=
+        ownSizeof(ngtcp2_recv_client_initial_553648740):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_client_initial" &
+            " exists but with different size")
+    ngtcp2_recv_client_initial
+  else:
+    ngtcp2_recv_client_initial_553648740)
+  ptls_on_client_hello_t_553648937 = (when declared(ptls_on_client_hello_t):
+    when ownSizeof(ptls_on_client_hello_t) != ownSizeof(ptls_on_client_hello_t_553648936):
+      static :
+        warning("Declaration of " & "ptls_on_client_hello_t" &
+            " exists but with different size")
+    ptls_on_client_hello_t
+  else:
+    ptls_on_client_hello_t_553648936)
+  ngtcp2_vec_553648624 = (when declared(ngtcp2_vec):
+    when ownSizeof(ngtcp2_vec) != ownSizeof(ngtcp2_vec_553648623):
+      static :
+        warning("Declaration of " & "ngtcp2_vec" &
+            " exists but with different size")
+    ngtcp2_vec
+  else:
+    ngtcp2_vec_553648623)
+  struct_st_ptls_encrypt_ticket_t_553648955 = (when declared(
+      struct_st_ptls_encrypt_ticket_t):
+    when ownSizeof(struct_st_ptls_encrypt_ticket_t) !=
+        ownSizeof(struct_st_ptls_encrypt_ticket_t_553648954):
+      static :
+        warning("Declaration of " & "struct_st_ptls_encrypt_ticket_t" &
+            " exists but with different size")
+    struct_st_ptls_encrypt_ticket_t
+  else:
+    struct_st_ptls_encrypt_ticket_t_553648954)
+  union_ngtcp2_sockaddr_union_553648650 = (when declared(
+      union_ngtcp2_sockaddr_union):
+    when ownSizeof(union_ngtcp2_sockaddr_union) !=
+        ownSizeof(union_ngtcp2_sockaddr_union_553648649):
+      static :
+        warning("Declaration of " & "union_ngtcp2_sockaddr_union" &
+            " exists but with different size")
+    union_ngtcp2_sockaddr_union
+  else:
+    union_ngtcp2_sockaddr_union_553648649)
+  struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649029 = (when declared(
+      struct_st_ptls_openssl_raw_pubkey_verify_certificate_t):
+    when ownSizeof(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t) !=
+        ownSizeof(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649028):
+      static :
+        warning("Declaration of " &
+            "struct_st_ptls_openssl_raw_pubkey_verify_certificate_t" &
+            " exists but with different size")
+    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t
+  else:
+    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649028)
+  ngtcp2_rand_553648779 = (when declared(ngtcp2_rand):
+    when ownSizeof(ngtcp2_rand) != ownSizeof(ngtcp2_rand_553648778):
+      static :
+        warning("Declaration of " & "ngtcp2_rand" &
+            " exists but with different size")
+    ngtcp2_rand
+  else:
+    ngtcp2_rand_553648778)
+  enum_ngtcp2_pkt_type_553648606 = (when declared(enum_ngtcp2_pkt_type):
+    when ownSizeof(enum_ngtcp2_pkt_type) != ownSizeof(enum_ngtcp2_pkt_type_553648605):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_pkt_type" &
+            " exists but with different size")
+    enum_ngtcp2_pkt_type
+  else:
+    enum_ngtcp2_pkt_type_553648605)
+  struct_in_addr_553649013 = (when declared(struct_in_addr):
+    when ownSizeof(struct_in_addr) != ownSizeof(struct_in_addr_553649012):
+      static :
+        warning("Declaration of " & "struct_in_addr" &
+            " exists but with different size")
+    struct_in_addr
+  else:
+    struct_in_addr_553649012)
+  struct_st_ptls_cipher_algorithm_t_553648873 = (when declared(
+      struct_st_ptls_cipher_algorithm_t):
+    when ownSizeof(struct_st_ptls_cipher_algorithm_t) !=
+        ownSizeof(struct_st_ptls_cipher_algorithm_t_553648872):
+      static :
+        warning("Declaration of " & "struct_st_ptls_cipher_algorithm_t" &
+            " exists but with different size")
+    struct_st_ptls_cipher_algorithm_t
+  else:
+    struct_st_ptls_cipher_algorithm_t_553648872)
+  ptls_cipher_context_t_553648875 = (when declared(ptls_cipher_context_t):
+    when ownSizeof(ptls_cipher_context_t) != ownSizeof(ptls_cipher_context_t_553648874):
+      static :
+        warning("Declaration of " & "ptls_cipher_context_t" &
+            " exists but with different size")
+    ptls_cipher_context_t
+  else:
+    ptls_cipher_context_t_553648874)
+  enum_ngtcp2_cc_algo_553648677 = (when declared(enum_ngtcp2_cc_algo):
+    when ownSizeof(enum_ngtcp2_cc_algo) != ownSizeof(enum_ngtcp2_cc_algo_553648676):
+      static :
+        warning("Declaration of " & "enum_ngtcp2_cc_algo" &
+            " exists but with different size")
+    enum_ngtcp2_cc_algo
+  else:
+    enum_ngtcp2_cc_algo_553648676)
+  ptls_update_open_count_t_553648971 = (when declared(ptls_update_open_count_t):
+    when ownSizeof(ptls_update_open_count_t) !=
+        ownSizeof(ptls_update_open_count_t_553648970):
+      static :
+        warning("Declaration of " & "ptls_update_open_count_t" &
+            " exists but with different size")
+    ptls_update_open_count_t
+  else:
+    ptls_update_open_count_t_553648970)
+  struct_ngtcp2_crypto_ctx_553648729 = (when declared(struct_ngtcp2_crypto_ctx):
+    when ownSizeof(struct_ngtcp2_crypto_ctx) !=
+        ownSizeof(struct_ngtcp2_crypto_ctx_553648728):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_ctx" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_ctx
+  else:
+    struct_ngtcp2_crypto_ctx_553648728)
+  ngtcp2_extend_max_stream_data_553648777 = (when declared(
+      ngtcp2_extend_max_stream_data):
+    when ownSizeof(ngtcp2_extend_max_stream_data) !=
+        ownSizeof(ngtcp2_extend_max_stream_data_553648776):
+      static :
+        warning("Declaration of " & "ngtcp2_extend_max_stream_data" &
+            " exists but with different size")
+    ngtcp2_extend_max_stream_data
+  else:
+    ngtcp2_extend_max_stream_data_553648776)
+  ngtcp2_lost_datagram_553648807 = (when declared(ngtcp2_lost_datagram):
+    when ownSizeof(ngtcp2_lost_datagram) != ownSizeof(ngtcp2_lost_datagram_553648806):
+      static :
+        warning("Declaration of " & "ngtcp2_lost_datagram" &
+            " exists but with different size")
+    ngtcp2_lost_datagram
+  else:
+    ngtcp2_lost_datagram_553648806)
+  ptls_openssl_signature_scheme_t_553649021 = (when declared(
+      ptls_openssl_signature_scheme_t):
+    when ownSizeof(ptls_openssl_signature_scheme_t) !=
+        ownSizeof(ptls_openssl_signature_scheme_t_553649020):
+      static :
+        warning("Declaration of " & "ptls_openssl_signature_scheme_t" &
+            " exists but with different size")
+    ptls_openssl_signature_scheme_t
+  else:
+    ptls_openssl_signature_scheme_t_553649020)
+  ngtcp2_recv_crypto_data_553648747 = (when declared(ngtcp2_recv_crypto_data):
+    when ownSizeof(ngtcp2_recv_crypto_data) !=
+        ownSizeof(ngtcp2_recv_crypto_data_553648746):
+      static :
+        warning("Declaration of " & "ngtcp2_recv_crypto_data" &
+            " exists but with different size")
+    ngtcp2_recv_crypto_data
+  else:
+    ngtcp2_recv_crypto_data_553648746)
+  ngtcp2_handshake_confirmed_553648751 = (when declared(
+      ngtcp2_handshake_confirmed):
+    when ownSizeof(ngtcp2_handshake_confirmed) !=
+        ownSizeof(ngtcp2_handshake_confirmed_553648750):
+      static :
+        warning("Declaration of " & "ngtcp2_handshake_confirmed" &
+            " exists but with different size")
+    ngtcp2_handshake_confirmed
+  else:
+    ngtcp2_handshake_confirmed_553648750)
+  struct_st_ptls_hash_algorithm_t_553648899 = (when declared(
+      struct_st_ptls_hash_algorithm_t):
+    when ownSizeof(struct_st_ptls_hash_algorithm_t) !=
+        ownSizeof(struct_st_ptls_hash_algorithm_t_553648898):
+      static :
+        warning("Declaration of " & "struct_st_ptls_hash_algorithm_t" &
+            " exists but with different size")
+    struct_st_ptls_hash_algorithm_t
+  else:
+    struct_st_ptls_hash_algorithm_t_553648898)
+  ngtcp2_printf_553648681 = (when declared(ngtcp2_printf):
+    when ownSizeof(ngtcp2_printf) != ownSizeof(ngtcp2_printf_553648680):
+      static :
+        warning("Declaration of " & "ngtcp2_printf" &
+            " exists but with different size")
+    ngtcp2_printf
+  else:
+    ngtcp2_printf_553648680)
+  struct_ngtcp2_crypto_md_553648709 = (when declared(struct_ngtcp2_crypto_md):
+    when ownSizeof(struct_ngtcp2_crypto_md) !=
+        ownSizeof(struct_ngtcp2_crypto_md_553648708):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_md" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_md
+  else:
+    struct_ngtcp2_crypto_md_553648708)
+  struct_st_ptls_save_ticket_t_553648959 = (when declared(
+      struct_st_ptls_save_ticket_t):
+    when ownSizeof(struct_st_ptls_save_ticket_t) !=
+        ownSizeof(struct_st_ptls_save_ticket_t_553648958):
+      static :
+        warning("Declaration of " & "struct_st_ptls_save_ticket_t" &
+            " exists but with different size")
+    struct_st_ptls_save_ticket_t
+  else:
+    struct_st_ptls_save_ticket_t_553648958)
+  struct_in6_addr_553649007 = (when declared(struct_in6_addr):
+    when ownSizeof(struct_in6_addr) != ownSizeof(struct_in6_addr_553649006):
+      static :
+        warning("Declaration of " & "struct_in6_addr" &
+            " exists but with different size")
+    struct_in6_addr
+  else:
+    struct_in6_addr_553649006)
+  struct_ngtcp2_crypto_conn_ref_553648841 = (when declared(
+      struct_ngtcp2_crypto_conn_ref):
+    when ownSizeof(struct_ngtcp2_crypto_conn_ref) !=
+        ownSizeof(struct_ngtcp2_crypto_conn_ref_553648840):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_crypto_conn_ref" &
+            " exists but with different size")
+    struct_ngtcp2_crypto_conn_ref
+  else:
+    struct_ngtcp2_crypto_conn_ref_553648840)
+  struct_st_ptls_update_traffic_key_t_553648973 = (when declared(
+      struct_st_ptls_update_traffic_key_t):
+    when ownSizeof(struct_st_ptls_update_traffic_key_t) !=
+        ownSizeof(struct_st_ptls_update_traffic_key_t_553648972):
+      static :
+        warning("Declaration of " & "struct_st_ptls_update_traffic_key_t" &
+            " exists but with different size")
+    struct_st_ptls_update_traffic_key_t
+  else:
+    struct_st_ptls_update_traffic_key_t_553648972)
+  ngtcp2_crypto_picotls_ctx_553649051 = (when declared(ngtcp2_crypto_picotls_ctx):
+    when ownSizeof(ngtcp2_crypto_picotls_ctx) !=
+        ownSizeof(ngtcp2_crypto_picotls_ctx_553649050):
+      static :
+        warning("Declaration of " & "ngtcp2_crypto_picotls_ctx" &
+            " exists but with different size")
+    ngtcp2_crypto_picotls_ctx
+  else:
+    ngtcp2_crypto_picotls_ctx_553649050)
+  struct_ngtcp2_ccerr_553648831 = (when declared(struct_ngtcp2_ccerr):
+    when ownSizeof(struct_ngtcp2_ccerr) != ownSizeof(struct_ngtcp2_ccerr_553648830):
+      static :
+        warning("Declaration of " & "struct_ngtcp2_ccerr" &
+            " exists but with different size")
+    struct_ngtcp2_ccerr
+  else:
+    struct_ngtcp2_ccerr_553648830)
+when not declared(ptls_hpke_kem_t):
+  type
+    ptls_hpke_kem_t* = ptls_hpke_kem_t_553648912
+else:
+  static :
+    hint("Declaration of " & "ptls_hpke_kem_t" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_recv_retry):
   type
-    ngtcp2_recv_retry* = ngtcp2_recv_retry_536871539
+    ngtcp2_recv_retry* = ngtcp2_recv_retry_553648754
 else:
   static :
     hint("Declaration of " & "ngtcp2_recv_retry" &
         " already exists, not redeclaring")
-when not declared(ngtcp2_recv_crypto_data):
+when not declared(X509):
   type
-    ngtcp2_recv_crypto_data* = ngtcp2_recv_crypto_data_536871531
+    X509* = X509_553649026
 else:
   static :
-    hint("Declaration of " & "ngtcp2_recv_crypto_data" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_cid_token):
+    hint("Declaration of " & "X509" & " already exists, not redeclaring")
+when not declared(ngtcp2_sockaddr_in):
   type
-    ngtcp2_cid_token* = ngtcp2_cid_token_536871609
+    ngtcp2_sockaddr_in* = ngtcp2_sockaddr_in_553648637
 else:
   static :
-    hint("Declaration of " & "ngtcp2_cid_token" &
+    hint("Declaration of " & "ngtcp2_sockaddr_in" &
         " already exists, not redeclaring")
-when not declared(struct_st_ptls_buffer_t):
+when not declared(ptls_message_emitter_t):
   type
-    struct_st_ptls_buffer_t* = struct_st_ptls_buffer_t_536871641
+    ptls_message_emitter_t* = ptls_message_emitter_t_553648908
 else:
   static :
-    hint("Declaration of " & "struct_st_ptls_buffer_t" &
+    hint("Declaration of " & "ptls_message_emitter_t" &
         " already exists, not redeclaring")
-when not declared(ptls_openssl_signature_scheme_t):
+when not declared(struct_st_ptls_verify_certificate_t):
   type
-    ptls_openssl_signature_scheme_t* = ptls_openssl_signature_scheme_t_536871805
+    struct_st_ptls_verify_certificate_t* = struct_st_ptls_verify_certificate_t_553648950
 else:
   static :
-    hint("Declaration of " & "ptls_openssl_signature_scheme_t" &
+    hint("Declaration of " & "struct_st_ptls_verify_certificate_t" &
         " already exists, not redeclaring")
+when not declared(struct_ngtcp2_transport_params):
+  type
+    struct_ngtcp2_transport_params* = struct_ngtcp2_transport_params_553648661
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_transport_params" &
+        " already exists, not redeclaring")
+when not declared(EVP_MAC_CTX):
+  type
+    EVP_MAC_CTX* = EVP_MAC_CTX_553649046
+else:
+  static :
+    hint("Declaration of " & "EVP_MAC_CTX" & " already exists, not redeclaring")
 when not declared(struct_st_ptls_log_state_t):
   type
-    struct_st_ptls_log_state_t* = struct_st_ptls_log_state_t_536871785
+    struct_st_ptls_log_state_t* = struct_st_ptls_log_state_t_553649000
 else:
   static :
     hint("Declaration of " & "struct_st_ptls_log_state_t" &
         " already exists, not redeclaring")
-when not declared(struct_st_ptls_log_event_t):
+when not declared(struct_st_ptls_client_hello_psk_identity_t):
   type
-    struct_st_ptls_log_event_t* = struct_st_ptls_log_event_t_536871747
+    struct_st_ptls_client_hello_psk_identity_t* = struct_st_ptls_client_hello_psk_identity_t_553648922
 else:
   static :
-    hint("Declaration of " & "struct_st_ptls_log_event_t" &
+    hint("Declaration of " & "struct_st_ptls_client_hello_psk_identity_t" &
         " already exists, not redeclaring")
-when not declared(ngtcp2_realloc):
+when not declared(ptls_emit_certificate_t):
   type
-    ngtcp2_realloc* = ngtcp2_realloc_536871380
+    ptls_emit_certificate_t* = ptls_emit_certificate_t_553648940
 else:
   static :
-    hint("Declaration of " & "ngtcp2_realloc" &
+    hint("Declaration of " & "ptls_emit_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_path_validation_result):
+  type
+    ngtcp2_path_validation_result* = ngtcp2_path_validation_result_553648611
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_path_validation_result" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_ack_datagram):
+  type
+    ngtcp2_ack_datagram* = ngtcp2_ack_datagram_553648804
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_ack_datagram" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_info):
+  type
+    ngtcp2_info* = ngtcp2_info_553648836
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_info" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_cipher_suite_t):
+  type
+    struct_st_ptls_cipher_suite_t* = struct_st_ptls_cipher_suite_t_553648902
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_cipher_suite_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_picotls_ctx):
+  type
+    struct_ngtcp2_crypto_picotls_ctx* = struct_ngtcp2_crypto_picotls_ctx_553649048
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_picotls_ctx" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_on_client_hello_t):
+  type
+    struct_st_ptls_on_client_hello_t* = struct_st_ptls_on_client_hello_t_553648934
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_on_client_hello_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_stream_close):
+  type
+    ngtcp2_stream_close* = ngtcp2_stream_close_553648766
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_stream_close" &
         " already exists, not redeclaring")
 when not declared(X509_STORE):
   type
-    X509_STORE* = X509_STORE_536871823
+    X509_STORE* = X509_STORE_553649038
 else:
   static :
     hint("Declaration of " & "X509_STORE" & " already exists, not redeclaring")
-when not declared(HMAC_CTX):
+when not declared(struct_ngtcp2_callbacks):
   type
-    HMAC_CTX* = HMAC_CTX_536871829
+    struct_ngtcp2_callbacks* = struct_ngtcp2_callbacks_553648818
 else:
   static :
-    hint("Declaration of " & "HMAC_CTX" & " already exists, not redeclaring")
+    hint("Declaration of " & "struct_ngtcp2_callbacks" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_info):
+  type
+    struct_ngtcp2_info* = struct_ngtcp2_info_553648834
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_info" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_delete_crypto_aead_ctx):
+  type
+    ngtcp2_delete_crypto_aead_ctx* = ngtcp2_delete_crypto_aead_ctx_553648798
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_delete_crypto_aead_ctx" &
+        " already exists, not redeclaring")
+when not declared(ptls_get_time_t):
+  type
+    ptls_get_time_t* = ptls_get_time_t_553648932
+else:
+  static :
+    hint("Declaration of " & "ptls_get_time_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_select_preferred_addr):
+  type
+    ngtcp2_select_preferred_addr* = ngtcp2_select_preferred_addr_553648788
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_select_preferred_addr" &
+        " already exists, not redeclaring")
+when not declared(ptls_update_traffic_key_t):
+  type
+    ptls_update_traffic_key_t* = ptls_update_traffic_key_t_553648974
+else:
+  static :
+    hint("Declaration of " & "ptls_update_traffic_key_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_log_t):
+  type
+    struct_st_ptls_log_t* = struct_st_ptls_log_t_553649010
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_log_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_version_info):
+  type
+    struct_ngtcp2_version_info* = struct_ngtcp2_version_info_553648657
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_version_info" &
+        " already exists, not redeclaring")
+when not declared(enum_en_ptls_hash_final_mode_t):
+  type
+    enum_en_ptls_hash_final_mode_t* = enum_en_ptls_hash_final_mode_t_553648890
+else:
+  static :
+    hint("Declaration of " & "enum_en_ptls_hash_final_mode_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_encryption_level):
+  type
+    ngtcp2_encryption_level* = ngtcp2_encryption_level_553648744
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_encryption_level" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_update_open_count_t):
+  type
+    struct_st_ptls_update_open_count_t* = struct_st_ptls_update_open_count_t_553648966
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_update_open_count_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_malloc):
+  type
+    ngtcp2_malloc* = ngtcp2_malloc_553648589
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_malloc" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_pkt_hd):
+  type
+    struct_ngtcp2_pkt_hd* = struct_ngtcp2_pkt_hd_553648625
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_pkt_hd" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_conn):
+  type
+    ngtcp2_conn* = ngtcp2_conn_553648736
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_conn" & " already exists, not redeclaring")
+when not declared(ngtcp2_connection_id_status):
+  type
+    ngtcp2_connection_id_status* = ngtcp2_connection_id_status_553648794
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_connection_id_status" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_key):
+  type
+    ngtcp2_recv_key* = ngtcp2_recv_key_553648814
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_key" &
+        " already exists, not redeclaring")
+when not declared(ptls_key_exchange_context_t):
+  type
+    ptls_key_exchange_context_t* = ptls_key_exchange_context_t_553648864
+else:
+  static :
+    hint("Declaration of " & "ptls_key_exchange_context_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_aead_ctx):
+  type
+    struct_ngtcp2_crypto_aead_ctx* = struct_ngtcp2_crypto_aead_ctx_553648720
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_aead_ctx" &
+        " already exists, not redeclaring")
+when not declared(ptls_ech_create_opener_t):
+  type
+    ptls_ech_create_opener_t* = ptls_ech_create_opener_t_553648986
+else:
+  static :
+    hint("Declaration of " & "ptls_ech_create_opener_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_sign_certificate_t):
+  type
+    struct_st_ptls_sign_certificate_t* = struct_st_ptls_sign_certificate_t_553648946
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_sign_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_duration):
+  type
+    ngtcp2_duration* = ngtcp2_duration_553648615
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_duration" &
+        " already exists, not redeclaring")
+when not declared(struct_sockaddr_in):
+  type
+    struct_sockaddr_in* = struct_sockaddr_in_553648639
+else:
+  static :
+    hint("Declaration of " & "struct_sockaddr_in" &
+        " already exists, not redeclaring")
+when not declared(compiler_socklen_t):
+  type
+    compiler_socklen_t* = compiler_socklen_t_553649060
+else:
+  static :
+    hint("Declaration of " & "compiler_socklen_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_cc_algo):
+  type
+    ngtcp2_cc_algo* = ngtcp2_cc_algo_553648678
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_cc_algo" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_md):
+  type
+    ngtcp2_crypto_md* = ngtcp2_crypto_md_553648710
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_md" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_raw_extension_t):
+  type
+    struct_st_ptls_raw_extension_t* = struct_st_ptls_raw_extension_t_553648988
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_raw_extension_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_path):
+  type
+    struct_ngtcp2_path* = struct_ngtcp2_path_553648700
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_path" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_decrypt):
+  type
+    ngtcp2_decrypt* = ngtcp2_decrypt_553648758
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_decrypt" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_tstamp):
+  type
+    ngtcp2_tstamp* = ngtcp2_tstamp_553648613
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_tstamp" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_key_exchange_context_t):
+  type
+    struct_st_ptls_key_exchange_context_t* = struct_st_ptls_key_exchange_context_t_553648860
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_key_exchange_context_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_conn_ref):
+  type
+    ngtcp2_crypto_conn_ref* = ngtcp2_crypto_conn_ref_553648838
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_conn_ref" &
+        " already exists, not redeclaring")
+when not declared(ptls_raw_extension_t):
+  type
+    ptls_raw_extension_t* = ptls_raw_extension_t_553648990
+else:
+  static :
+    hint("Declaration of " & "ptls_raw_extension_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_version_negotiation):
+  type
+    ngtcp2_recv_version_negotiation* = ngtcp2_recv_version_negotiation_553648752
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_version_negotiation" &
+        " already exists, not redeclaring")
+when not declared(ptls_on_extension_t):
+  type
+    ptls_on_extension_t* = ptls_on_extension_t_553648978
+else:
+  static :
+    hint("Declaration of " & "ptls_on_extension_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_openssl_sign_certificate_t):
+  type
+    ptls_openssl_sign_certificate_t* = ptls_openssl_sign_certificate_t_553649024
+else:
+  static :
+    hint("Declaration of " & "ptls_openssl_sign_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_hpke_cipher_suite_id_t):
+  type
+    struct_st_ptls_hpke_cipher_suite_id_t* = struct_st_ptls_hpke_cipher_suite_id_t_553648914
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_hpke_cipher_suite_id_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_aead_supplementary_encryption_t):
+  type
+    struct_st_ptls_aead_supplementary_encryption_t* = struct_st_ptls_aead_supplementary_encryption_t_553648878
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_aead_supplementary_encryption_t" &
+        " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead):
   type
-    ngtcp2_crypto_aead* = ngtcp2_crypto_aead_536871499
+    ngtcp2_crypto_aead* = ngtcp2_crypto_aead_553648714
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_aead" &
         " already exists, not redeclaring")
+when not declared(struct_ptls_cred_buffer_s):
+  type
+    struct_ptls_cred_buffer_s* = struct_ptls_cred_buffer_s_553649052
+else:
+  static :
+    hint("Declaration of " & "struct_ptls_cred_buffer_s" &
+        " already exists, not redeclaring")
+when not declared(ptls_key_schedule_t):
+  type
+    ptls_key_schedule_t* = ptls_key_schedule_t_553648850
+else:
+  static :
+    hint("Declaration of " & "ptls_key_schedule_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_verify_certificate_t):
+  type
+    ptls_verify_certificate_t* = ptls_verify_certificate_t_553648952
+else:
+  static :
+    hint("Declaration of " & "ptls_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_encrypt_ticket_t):
+  type
+    ptls_encrypt_ticket_t* = ptls_encrypt_ticket_t_553648956
+else:
+  static :
+    hint("Declaration of " & "ptls_encrypt_ticket_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_settings):
+  type
+    ngtcp2_settings* = ngtcp2_settings_553648694
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_settings" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_get_time_t):
+  type
+    struct_st_ptls_get_time_t* = struct_st_ptls_get_time_t_553648930
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_get_time_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_async_job_t):
+  type
+    ptls_async_job_t* = ptls_async_job_t_553648944
+else:
+  static :
+    hint("Declaration of " & "ptls_async_job_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_log_conn_state_t):
+  type
+    struct_st_ptls_log_conn_state_t* = struct_st_ptls_log_conn_state_t_553649004
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_log_conn_state_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_key_exchange_algorithm_t):
+  type
+    struct_st_ptls_key_exchange_algorithm_t* = struct_st_ptls_key_exchange_algorithm_t_553648862
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_key_exchange_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_hp_mask):
+  type
+    ngtcp2_hp_mask* = ngtcp2_hp_mask_553648760
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_hp_mask" &
+        " already exists, not redeclaring")
+when not declared(EVP_MD):
+  type
+    EVP_MD* = EVP_MD_553649018
+else:
+  static :
+    hint("Declaration of " & "EVP_MD" & " already exists, not redeclaring")
+when not declared(ptls_client_hello_psk_identity_t):
+  type
+    ptls_client_hello_psk_identity_t* = ptls_client_hello_psk_identity_t_553648924
+else:
+  static :
+    hint("Declaration of " & "ptls_client_hello_psk_identity_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_log_event_t):
+  type
+    struct_st_ptls_log_event_t* = struct_st_ptls_log_event_t_553648962
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_log_event_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_new_token):
+  type
+    ngtcp2_recv_new_token* = ngtcp2_recv_new_token_553648796
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_new_token" &
+        " already exists, not redeclaring")
+when not declared(enum_en_ptls_early_data_acceptance_t):
+  type
+    enum_en_ptls_early_data_acceptance_t* = enum_en_ptls_early_data_acceptance_t_553648992
+else:
+  static :
+    hint("Declaration of " & "enum_en_ptls_early_data_acceptance_t" &
+        " already exists, not redeclaring")
+when not declared(enum_ngtcp2_path_validation_result):
+  type
+    enum_ngtcp2_path_validation_result* = enum_ngtcp2_path_validation_result_553648609
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_path_validation_result" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_hash_context_t):
+  type
+    struct_st_ptls_hash_context_t* = struct_st_ptls_hash_context_t_553648894
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_hash_context_t" &
+        " already exists, not redeclaring")
+when not declared(socklen_t):
+  type
+    socklen_t* = socklen_t_553648647
+else:
+  static :
+    hint("Declaration of " & "socklen_t" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_openssl_sign_certificate_t):
+  type
+    struct_st_ptls_openssl_sign_certificate_t* = struct_st_ptls_openssl_sign_certificate_t_553649022
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_openssl_sign_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(in_port_t):
+  type
+    in_port_t* = in_port_t_553649058
+else:
+  static :
+    hint("Declaration of " & "in_port_t" & " already exists, not redeclaring")
+when not declared(struct_ngtcp2_vec):
+  type
+    struct_ngtcp2_vec* = struct_ngtcp2_vec_553648621
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_vec" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_ccerr_type):
+  type
+    ngtcp2_ccerr_type* = ngtcp2_ccerr_type_553648828
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_ccerr_type" &
+        " already exists, not redeclaring")
+when not declared(ptls_early_data_acceptance_t):
+  type
+    ptls_early_data_acceptance_t* = ptls_early_data_acceptance_t_553648994
+else:
+  static :
+    hint("Declaration of " & "ptls_early_data_acceptance_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_transport_params):
+  type
+    ngtcp2_transport_params* = ngtcp2_transport_params_553648663
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_transport_params" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_acked_stream_data_offset):
+  type
+    ngtcp2_acked_stream_data_offset* = ngtcp2_acked_stream_data_offset_553648770
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_acked_stream_data_offset" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_iovec_t):
+  type
+    struct_st_ptls_iovec_t* = struct_st_ptls_iovec_t_553648852
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_iovec_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_t):
+  type
+    ptls_t* = ptls_t_553648844
+else:
+  static :
+    hint("Declaration of " & "ptls_t" & " already exists, not redeclaring")
+when not declared(ngtcp2_free):
+  type
+    ngtcp2_free* = ngtcp2_free_553648591
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_free" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_cipher_context_t):
+  type
+    struct_st_ptls_cipher_context_t* = struct_st_ptls_cipher_context_t_553648870
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_cipher_context_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_aead_ctx):
+  type
+    ngtcp2_crypto_aead_ctx* = ngtcp2_crypto_aead_ctx_553648722
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_aead_ctx" &
+        " already exists, not redeclaring")
+when not declared(enum_ngtcp2_encryption_level):
+  type
+    enum_ngtcp2_encryption_level* = enum_ngtcp2_encryption_level_553648742
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_encryption_level" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_get_conn):
+  type
+    ngtcp2_crypto_get_conn* = ngtcp2_crypto_get_conn_553648842
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_get_conn" &
+        " already exists, not redeclaring")
+when not declared(ptls_aead_supplementary_encryption_t):
+  type
+    ptls_aead_supplementary_encryption_t* = ptls_aead_supplementary_encryption_t_553648880
+else:
+  static :
+    hint("Declaration of " & "ptls_aead_supplementary_encryption_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_sockaddr):
+  type
+    ngtcp2_sockaddr* = ngtcp2_sockaddr_553648633
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_sockaddr" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_ctx):
+  type
+    ngtcp2_crypto_ctx* = ngtcp2_crypto_ctx_553648730
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_ctx" &
+        " already exists, not redeclaring")
+when not declared(enum_ngtcp2_connection_id_status_type):
+  type
+    enum_ngtcp2_connection_id_status_type* = enum_ngtcp2_connection_id_status_type_553648790
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_connection_id_status_type" &
+        " already exists, not redeclaring")
+when not declared(ptls_hash_algorithm_t):
+  type
+    ptls_hash_algorithm_t* = ptls_hash_algorithm_t_553648900
+else:
+  static :
+    hint("Declaration of " & "ptls_hash_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_emit_certificate_t):
+  type
+    struct_st_ptls_emit_certificate_t* = struct_st_ptls_emit_certificate_t_553648938
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_emit_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_on_client_hello_parameters_t):
+  type
+    struct_st_ptls_on_client_hello_parameters_t* = struct_st_ptls_on_client_hello_parameters_t_553648926
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_on_client_hello_parameters_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_async_job_t):
+  type
+    struct_st_ptls_async_job_t* = struct_st_ptls_async_job_t_553648942
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_async_job_t" &
+        " already exists, not redeclaring")
+when not declared(EVP_CIPHER_CTX):
+  type
+    EVP_CIPHER_CTX* = EVP_CIPHER_CTX_553649042
+else:
+  static :
+    hint("Declaration of " & "EVP_CIPHER_CTX" &
+        " already exists, not redeclaring")
+when not declared(ptls_decompress_certificate_t):
+  type
+    ptls_decompress_certificate_t* = ptls_decompress_certificate_t_553648982
+else:
+  static :
+    hint("Declaration of " & "ptls_decompress_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_update_key):
+  type
+    ngtcp2_update_key* = ngtcp2_update_key_553648784
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_update_key" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_get_new_connection_id):
+  type
+    ngtcp2_get_new_connection_id* = ngtcp2_get_new_connection_id_553648780
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_get_new_connection_id" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_encrypt):
+  type
+    ngtcp2_encrypt* = ngtcp2_encrypt_553648756
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_encrypt" &
+        " already exists, not redeclaring")
+when not declared(compiler_ssize_t):
+  type
+    compiler_ssize_t* = compiler_ssize_t_553649062
+else:
+  static :
+    hint("Declaration of " & "compiler_ssize_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_stream_open):
+  type
+    ngtcp2_stream_open* = ngtcp2_stream_open_553648764
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_stream_open" &
+        " already exists, not redeclaring")
+when not declared(ptls_handshake_properties_t):
+  type
+    ptls_handshake_properties_t* = ptls_handshake_properties_t_553648998
+else:
+  static :
+    hint("Declaration of " & "ptls_handshake_properties_t" &
+        " already exists, not redeclaring")
+when not declared(struct_sockaddr):
+  type
+    struct_sockaddr* = struct_sockaddr_553648635
+else:
+  static :
+    hint("Declaration of " & "struct_sockaddr" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_datagram):
+  type
+    ngtcp2_recv_datagram* = ngtcp2_recv_datagram_553648802
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_datagram" &
+        " already exists, not redeclaring")
+when not declared(ptls_log_event_t):
+  type
+    ptls_log_event_t* = ptls_log_event_t_553648964
+else:
+  static :
+    hint("Declaration of " & "ptls_log_event_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_extend_max_streams):
+  type
+    ngtcp2_extend_max_streams* = ngtcp2_extend_max_streams_553648774
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_extend_max_streams" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_stateless_reset):
+  type
+    ngtcp2_recv_stateless_reset* = ngtcp2_recv_stateless_reset_553648772
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_stateless_reset" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_path_validation):
+  type
+    ngtcp2_path_validation* = ngtcp2_path_validation_553648786
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_path_validation" &
+        " already exists, not redeclaring")
+when not declared(ptls_iovec_t):
+  type
+    ptls_iovec_t* = ptls_iovec_t_553648854
+else:
+  static :
+    hint("Declaration of " & "ptls_iovec_t" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_openssl_verify_certificate_t):
+  type
+    struct_st_ptls_openssl_verify_certificate_t* = struct_st_ptls_openssl_verify_certificate_t_553649036
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_openssl_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(struct_sockaddr_in6):
+  type
+    struct_sockaddr_in6* = struct_sockaddr_in6_553648643
+else:
+  static :
+    hint("Declaration of " & "struct_sockaddr_in6" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_aead_algorithm_t):
+  type
+    struct_st_ptls_aead_algorithm_t* = struct_st_ptls_aead_algorithm_t_553648884
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_aead_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_cid):
+  type
+    struct_ngtcp2_cid* = struct_ngtcp2_cid_553648617
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_cid" &
+        " already exists, not redeclaring")
+when not declared(ssize_t):
+  type
+    ssize_t* = ssize_t_553648968
+else:
+  static :
+    hint("Declaration of " & "ssize_t" & " already exists, not redeclaring")
+when not declared(ngtcp2_pkt_hd):
+  type
+    ngtcp2_pkt_hd* = ngtcp2_pkt_hd_553648627
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_pkt_hd" &
+        " already exists, not redeclaring")
+when not declared(enum_ngtcp2_token_type):
+  type
+    enum_ngtcp2_token_type* = enum_ngtcp2_token_type_553648688
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_token_type" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_stream_data):
+  type
+    ngtcp2_recv_stream_data* = ngtcp2_recv_stream_data_553648762
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_stream_data" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_ech_create_opener_t):
+  type
+    struct_st_ptls_ech_create_opener_t* = struct_st_ptls_ech_create_opener_t_553648984
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_ech_create_opener_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_openssl_raw_pubkey_verify_certificate_t):
+  type
+    ptls_openssl_raw_pubkey_verify_certificate_t* = ptls_openssl_raw_pubkey_verify_certificate_t_553649030
+else:
+  static :
+    hint("Declaration of " & "ptls_openssl_raw_pubkey_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_message_emitter_t):
+  type
+    struct_st_ptls_message_emitter_t* = struct_st_ptls_message_emitter_t_553648906
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_message_emitter_t" &
+        " already exists, not redeclaring")
+when not declared(sa_family_t):
+  type
+    sa_family_t* = sa_family_t_553649056
+else:
+  static :
+    hint("Declaration of " & "sa_family_t" & " already exists, not redeclaring")
+when not declared(ngtcp2_callbacks):
+  type
+    ngtcp2_callbacks* = ngtcp2_callbacks_553648820
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_callbacks" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_log_point_t):
+  type
+    struct_st_ptls_log_point_t* = struct_st_ptls_log_point_t_553649002
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_log_point_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_stream_reset):
+  type
+    ngtcp2_stream_reset* = ngtcp2_stream_reset_553648768
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_stream_reset" &
+        " already exists, not redeclaring")
+when not declared(ptls_aead_context_t):
+  type
+    ptls_aead_context_t* = ptls_aead_context_t_553648886
+else:
+  static :
+    hint("Declaration of " & "ptls_aead_context_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_conn_info):
+  type
+    struct_ngtcp2_conn_info* = struct_ngtcp2_conn_info_553648665
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_conn_info" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_pkt_info):
+  type
+    struct_ngtcp2_pkt_info* = struct_ngtcp2_pkt_info_553648601
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_pkt_info" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_tls_early_data_rejected):
+  type
+    ngtcp2_tls_early_data_rejected* = ngtcp2_tls_early_data_rejected_553648816
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_tls_early_data_rejected" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_path_storage):
+  type
+    struct_ngtcp2_path_storage* = struct_ngtcp2_path_storage_553648704
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_path_storage" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_handshake_properties_t):
+  type
+    struct_st_ptls_handshake_properties_t* = struct_st_ptls_handshake_properties_t_553648996
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_handshake_properties_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_key_exchange_algorithm_t):
+  type
+    ptls_key_exchange_algorithm_t* = ptls_key_exchange_algorithm_t_553648868
+else:
+  static :
+    hint("Declaration of " & "ptls_key_exchange_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_client_initial):
+  type
+    ngtcp2_client_initial* = ngtcp2_client_initial_553648738
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_client_initial" &
+        " already exists, not redeclaring")
+when not declared(ptls_openssl_verify_certificate_t):
+  type
+    ptls_openssl_verify_certificate_t* = ptls_openssl_verify_certificate_t_553649040
+else:
+  static :
+    hint("Declaration of " & "ptls_openssl_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_hpke_cipher_suite_id_t):
+  type
+    ptls_hpke_cipher_suite_id_t* = ptls_hpke_cipher_suite_id_t_553648916
+else:
+  static :
+    hint("Declaration of " & "ptls_hpke_cipher_suite_id_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_aead):
+  type
+    struct_ngtcp2_crypto_aead* = struct_ngtcp2_crypto_aead_553648712
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_aead" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_decompress_certificate_t):
+  type
+    struct_st_ptls_decompress_certificate_t* = struct_st_ptls_decompress_certificate_t_553648980
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_decompress_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_path_storage):
+  type
+    ngtcp2_path_storage* = ngtcp2_path_storage_553648706
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_path_storage" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_calloc):
+  type
+    ngtcp2_calloc* = ngtcp2_calloc_553648593
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_calloc" &
+        " already exists, not redeclaring")
+when not declared(ptls_cipher_suite_t):
+  type
+    ptls_cipher_suite_t* = ptls_cipher_suite_t_553648904
+else:
+  static :
+    hint("Declaration of " & "ptls_cipher_suite_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_conn_info):
+  type
+    ngtcp2_conn_info* = ngtcp2_conn_info_553648667
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_conn_info" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_socklen):
+  type
+    ngtcp2_socklen* = ngtcp2_socklen_553648645
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_socklen" &
+        " already exists, not redeclaring")
+when not declared(ptls_context_t):
+  type
+    ptls_context_t* = ptls_context_t_553648846
+else:
+  static :
+    hint("Declaration of " & "ptls_context_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_rand_ctx):
+  type
+    struct_ngtcp2_rand_ctx* = struct_ngtcp2_rand_ctx_553648682
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_rand_ctx" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_ccerr):
+  type
+    ngtcp2_ccerr* = ngtcp2_ccerr_553648832
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_ccerr" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_context_t):
+  type
+    struct_st_ptls_context_t* = struct_st_ptls_context_t_553648848
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_context_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_handshake_completed):
+  type
+    ngtcp2_handshake_completed* = ngtcp2_handshake_completed_553648748
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_handshake_completed" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_pkt_stateless_reset):
+  type
+    struct_ngtcp2_pkt_stateless_reset* = struct_ngtcp2_pkt_stateless_reset_553648629
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_pkt_stateless_reset" &
+        " already exists, not redeclaring")
+when not declared(HMAC_CTX):
+  type
+    HMAC_CTX* = HMAC_CTX_553649044
+else:
+  static :
+    hint("Declaration of " & "HMAC_CTX" & " already exists, not redeclaring")
+when not declared(ptls_cred_buffer_t):
+  type
+    ptls_cred_buffer_t* = ptls_cred_buffer_t_553649054
+else:
+  static :
+    hint("Declaration of " & "ptls_cred_buffer_t" &
+        " already exists, not redeclaring")
+when not declared(intptr_t):
+  type
+    intptr_t* = intptr_t_553648866
+else:
+  static :
+    hint("Declaration of " & "intptr_t" & " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_cipher):
+  type
+    struct_ngtcp2_crypto_cipher* = struct_ngtcp2_crypto_cipher_553648716
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_cipher" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_on_extension_t):
+  type
+    struct_st_ptls_on_extension_t* = struct_st_ptls_on_extension_t_553648976
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_on_extension_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_openssl_signature_scheme_t):
+  type
+    struct_st_ptls_openssl_signature_scheme_t* = struct_st_ptls_openssl_signature_scheme_t_553649016
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_openssl_signature_scheme_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_pkt_type):
+  type
+    ngtcp2_pkt_type* = ngtcp2_pkt_type_553648607
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_pkt_type" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_preferred_addr):
+  type
+    struct_ngtcp2_preferred_addr* = struct_ngtcp2_preferred_addr_553648653
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_preferred_addr" &
+        " already exists, not redeclaring")
+when not declared(enum_ngtcp2_ccerr_type):
+  type
+    enum_ngtcp2_ccerr_type* = enum_ngtcp2_ccerr_type_553648826
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_ccerr_type" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_delete_crypto_cipher_ctx):
+  type
+    ngtcp2_delete_crypto_cipher_ctx* = ngtcp2_delete_crypto_cipher_ctx_553648800
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_delete_crypto_cipher_ctx" &
+        " already exists, not redeclaring")
+when not declared(ptls_hash_context_t):
+  type
+    ptls_hash_context_t* = ptls_hash_context_t_553648896
+else:
+  static :
+    hint("Declaration of " & "ptls_hash_context_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_stream_stop_sending):
+  type
+    ngtcp2_stream_stop_sending* = ngtcp2_stream_stop_sending_553648810
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_stream_stop_sending" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_pkt_stateless_reset):
+  type
+    ngtcp2_pkt_stateless_reset* = ngtcp2_pkt_stateless_reset_553648631
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_pkt_stateless_reset" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_token_type):
+  type
+    ngtcp2_token_type* = ngtcp2_token_type_553648690
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_token_type" &
+        " already exists, not redeclaring")
+when not declared(ptls_hpke_cipher_suite_t):
+  type
+    ptls_hpke_cipher_suite_t* = ptls_hpke_cipher_suite_t_553648920
+else:
+  static :
+    hint("Declaration of " & "ptls_hpke_cipher_suite_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_cipher):
+  type
+    ngtcp2_crypto_cipher* = ngtcp2_crypto_cipher_553648718
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_cipher" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_cipher_ctx):
+  type
+    struct_ngtcp2_crypto_cipher_ctx* = struct_ngtcp2_crypto_cipher_ctx_553648724
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_cipher_ctx" &
+        " already exists, not redeclaring")
+when not declared(ptls_cipher_algorithm_t):
+  type
+    ptls_cipher_algorithm_t* = ptls_cipher_algorithm_t_553648876
+else:
+  static :
+    hint("Declaration of " & "ptls_cipher_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_path):
+  type
+    ngtcp2_path* = ngtcp2_path_553648702
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_path" & " already exists, not redeclaring")
+when not declared(ngtcp2_version_negotiation):
+  type
+    ngtcp2_version_negotiation* = ngtcp2_version_negotiation_553648812
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_version_negotiation" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_mem):
+  type
+    struct_ngtcp2_mem* = struct_ngtcp2_mem_553648597
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_mem" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_cid):
+  type
+    ngtcp2_cid* = ngtcp2_cid_553648619
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_cid" & " already exists, not redeclaring")
+when not declared(ngtcp2_version_info):
+  type
+    ngtcp2_version_info* = ngtcp2_version_info_553648659
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_version_info" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_addr):
+  type
+    struct_ngtcp2_addr* = struct_ngtcp2_addr_553648696
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_addr" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_addr):
+  type
+    ngtcp2_addr* = ngtcp2_addr_553648698
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_addr" & " already exists, not redeclaring")
+when not declared(ngtcp2_qlog_write):
+  type
+    ngtcp2_qlog_write* = ngtcp2_qlog_write_553648686
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_qlog_write" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_remove_connection_id):
+  type
+    ngtcp2_remove_connection_id* = ngtcp2_remove_connection_id_553648782
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_remove_connection_id" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_cid_token):
+  type
+    struct_ngtcp2_cid_token* = struct_ngtcp2_cid_token_553648822
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_cid_token" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_rand_ctx):
+  type
+    ngtcp2_rand_ctx* = ngtcp2_rand_ctx_553648684
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_rand_ctx" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_settings):
+  type
+    struct_ngtcp2_settings* = struct_ngtcp2_settings_553648692
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_settings" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_get_path_challenge_data):
+  type
+    ngtcp2_get_path_challenge_data* = ngtcp2_get_path_challenge_data_553648808
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_get_path_challenge_data" &
+        " already exists, not redeclaring")
+when not declared(EVP_PKEY):
+  type
+    EVP_PKEY* = EVP_PKEY_553649014
+else:
+  static :
+    hint("Declaration of " & "EVP_PKEY" & " already exists, not redeclaring")
+when not declared(ptls_save_ticket_t):
+  type
+    ptls_save_ticket_t* = ptls_save_ticket_t_553648960
+else:
+  static :
+    hint("Declaration of " & "ptls_save_ticket_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_openssl_override_verify_certificate_t):
+  type
+    ptls_openssl_override_verify_certificate_t* = ptls_openssl_override_verify_certificate_t_553649034
+else:
+  static :
+    hint("Declaration of " & "ptls_openssl_override_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_sign_certificate_t):
+  type
+    ptls_sign_certificate_t* = ptls_sign_certificate_t_553648948
+else:
+  static :
+    hint("Declaration of " & "ptls_sign_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_version_cid):
+  type
+    struct_ngtcp2_version_cid* = struct_ngtcp2_version_cid_553648732
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_version_cid" &
+        " already exists, not redeclaring")
+when not declared(ptls_log_conn_state_t):
+  type
+    ptls_log_conn_state_t* = ptls_log_conn_state_t_553649008
+else:
+  static :
+    hint("Declaration of " & "ptls_log_conn_state_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_hpke_cipher_suite_t):
+  type
+    struct_st_ptls_hpke_cipher_suite_t* = struct_st_ptls_hpke_cipher_suite_t_553648918
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_hpke_cipher_suite_t" &
+        " already exists, not redeclaring")
+when not declared(in_addr_t):
+  type
+    in_addr_t* = in_addr_t_553649064
+else:
+  static :
+    hint("Declaration of " & "in_addr_t" & " already exists, not redeclaring")
 when not declared(struct_st_ptls_openssl_override_verify_certificate_t):
   type
-    struct_st_ptls_openssl_override_verify_certificate_t* = struct_st_ptls_openssl_override_verify_certificate_t_536871817
+    struct_st_ptls_openssl_override_verify_certificate_t* = struct_st_ptls_openssl_override_verify_certificate_t_553649032
 else:
   static :
     hint("Declaration of " &
         "struct_st_ptls_openssl_override_verify_certificate_t" &
         " already exists, not redeclaring")
-when not declared(ngtcp2_extend_max_stream_data):
+when not declared(ngtcp2_connection_id_status_type):
   type
-    ngtcp2_extend_max_stream_data* = ngtcp2_extend_max_stream_data_536871561
+    ngtcp2_connection_id_status_type* = ngtcp2_connection_id_status_type_553648792
 else:
   static :
-    hint("Declaration of " & "ngtcp2_extend_max_stream_data" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_async_job_t):
-  type
-    struct_st_ptls_async_job_t* = struct_st_ptls_async_job_t_536871727
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_async_job_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_conn):
-  type
-    ngtcp2_conn* = ngtcp2_conn_536871521
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_conn" & " already exists, not redeclaring")
-when not declared(ngtcp2_delete_crypto_cipher_ctx):
-  type
-    ngtcp2_delete_crypto_cipher_ctx* = ngtcp2_delete_crypto_cipher_ctx_536871585
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_delete_crypto_cipher_ctx" &
-        " already exists, not redeclaring")
-when not declared(ptls_log_conn_state_t):
-  type
-    ptls_log_conn_state_t* = ptls_log_conn_state_t_536871793
-else:
-  static :
-    hint("Declaration of " & "ptls_log_conn_state_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_openssl_sign_certificate_t):
-  type
-    struct_st_ptls_openssl_sign_certificate_t* = struct_st_ptls_openssl_sign_certificate_t_536871807
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_openssl_sign_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(sa_family_t):
-  type
-    sa_family_t* = sa_family_t_536871841
-else:
-  static :
-    hint("Declaration of " & "sa_family_t" & " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_cipher_ctx):
-  type
-    struct_ngtcp2_crypto_cipher_ctx* = struct_ngtcp2_crypto_cipher_ctx_536871509
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_cipher_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_client_initial):
-  type
-    ngtcp2_client_initial* = ngtcp2_client_initial_536871523
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_client_initial" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_cid_token):
-  type
-    struct_ngtcp2_cid_token* = struct_ngtcp2_cid_token_536871607
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_cid_token" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_delete_crypto_aead_ctx):
-  type
-    ngtcp2_delete_crypto_aead_ctx* = ngtcp2_delete_crypto_aead_ctx_536871583
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_delete_crypto_aead_ctx" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_hpke_cipher_suite_t):
-  type
-    struct_st_ptls_hpke_cipher_suite_t* = struct_st_ptls_hpke_cipher_suite_t_536871703
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_hpke_cipher_suite_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_tstamp):
-  type
-    ngtcp2_tstamp* = ngtcp2_tstamp_536871398
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_tstamp" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_select_preferred_addr):
-  type
-    ngtcp2_select_preferred_addr* = ngtcp2_select_preferred_addr_536871573
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_select_preferred_addr" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_get_time_t):
-  type
-    struct_st_ptls_get_time_t* = struct_st_ptls_get_time_t_536871715
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_get_time_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_handshake_properties_t):
-  type
-    struct_st_ptls_handshake_properties_t* = struct_st_ptls_handshake_properties_t_536871781
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_handshake_properties_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_client_hello_psk_identity_t):
-  type
-    ptls_client_hello_psk_identity_t* = ptls_client_hello_psk_identity_t_536871709
-else:
-  static :
-    hint("Declaration of " & "ptls_client_hello_psk_identity_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_aead_ctx):
-  type
-    struct_ngtcp2_crypto_aead_ctx* = struct_ngtcp2_crypto_aead_ctx_536871505
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_aead_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_acked_stream_data_offset):
-  type
-    ngtcp2_acked_stream_data_offset* = ngtcp2_acked_stream_data_offset_536871555
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_acked_stream_data_offset" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_transport_params):
-  type
-    ngtcp2_transport_params* = ngtcp2_transport_params_536871448
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_transport_params" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_pkt_info):
-  type
-    struct_ngtcp2_pkt_info* = struct_ngtcp2_pkt_info_536871386
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_pkt_info" &
-        " already exists, not redeclaring")
-when not declared(ptls_emit_certificate_t):
-  type
-    ptls_emit_certificate_t* = ptls_emit_certificate_t_536871725
-else:
-  static :
-    hint("Declaration of " & "ptls_emit_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(enum_en_ptls_early_data_acceptance_t):
-  type
-    enum_en_ptls_early_data_acceptance_t* = enum_en_ptls_early_data_acceptance_t_536871777
-else:
-  static :
-    hint("Declaration of " & "enum_en_ptls_early_data_acceptance_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_transport_params):
-  type
-    struct_ngtcp2_transport_params* = struct_ngtcp2_transport_params_536871446
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_transport_params" &
-        " already exists, not redeclaring")
-when not declared(struct_in_addr):
-  type
-    struct_in_addr* = struct_in_addr_536871797
-else:
-  static :
-    hint("Declaration of " & "struct_in_addr" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_get_conn):
-  type
-    ngtcp2_crypto_get_conn* = ngtcp2_crypto_get_conn_536871627
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_get_conn" &
-        " already exists, not redeclaring")
-when not declared(ptls_aead_context_t):
-  type
-    ptls_aead_context_t* = ptls_aead_context_t_536871671
-else:
-  static :
-    hint("Declaration of " & "ptls_aead_context_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_cc_algo):
-  type
-    ngtcp2_cc_algo* = ngtcp2_cc_algo_536871463
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_cc_algo" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_sockaddr):
-  type
-    ngtcp2_sockaddr* = ngtcp2_sockaddr_536871418
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_sockaddr" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_decrypt):
-  type
-    ngtcp2_decrypt* = ngtcp2_decrypt_536871543
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_decrypt" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_aead_context_t):
-  type
-    struct_st_ptls_aead_context_t* = struct_st_ptls_aead_context_t_536871667
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_aead_context_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_openssl_verify_certificate_t):
-  type
-    ptls_openssl_verify_certificate_t* = ptls_openssl_verify_certificate_t_536871825
-else:
-  static :
-    hint("Declaration of " & "ptls_openssl_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_decompress_certificate_t):
-  type
-    struct_st_ptls_decompress_certificate_t* = struct_st_ptls_decompress_certificate_t_536871765
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_decompress_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_pkt_type):
-  type
-    ngtcp2_pkt_type* = ngtcp2_pkt_type_536871392
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_pkt_type" &
-        " already exists, not redeclaring")
-when not declared(ptls_hpke_cipher_suite_id_t):
-  type
-    ptls_hpke_cipher_suite_id_t* = ptls_hpke_cipher_suite_id_t_536871701
-else:
-  static :
-    hint("Declaration of " & "ptls_hpke_cipher_suite_id_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_mem):
-  type
-    struct_ngtcp2_mem* = struct_ngtcp2_mem_536871382
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_mem" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_calloc):
-  type
-    ngtcp2_calloc* = ngtcp2_calloc_536871378
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_calloc" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_preferred_addr):
-  type
-    struct_ngtcp2_preferred_addr* = struct_ngtcp2_preferred_addr_536871438
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_preferred_addr" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_path_storage):
-  type
-    ngtcp2_path_storage* = ngtcp2_path_storage_536871491
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_path_storage" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_addr):
-  type
-    ngtcp2_addr* = ngtcp2_addr_536871483
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_addr" & " already exists, not redeclaring")
-when not declared(ngtcp2_tls_early_data_rejected):
-  type
-    ngtcp2_tls_early_data_rejected* = ngtcp2_tls_early_data_rejected_536871601
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_tls_early_data_rejected" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_hpke_cipher_suite_id_t):
-  type
-    struct_st_ptls_hpke_cipher_suite_id_t* = struct_st_ptls_hpke_cipher_suite_id_t_536871699
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_hpke_cipher_suite_id_t" &
-        " already exists, not redeclaring")
-when not declared(EVP_MD):
-  type
-    EVP_MD* = EVP_MD_536871803
-else:
-  static :
-    hint("Declaration of " & "EVP_MD" & " already exists, not redeclaring")
-when not declared(ngtcp2_stream_reset):
-  type
-    ngtcp2_stream_reset* = ngtcp2_stream_reset_536871553
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_stream_reset" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_iovec_t):
-  type
-    struct_st_ptls_iovec_t* = struct_st_ptls_iovec_t_536871637
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_iovec_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_stream_data):
-  type
-    ngtcp2_recv_stream_data* = ngtcp2_recv_stream_data_536871547
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_stream_data" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_ctx):
-  type
-    struct_ngtcp2_crypto_ctx* = struct_ngtcp2_crypto_ctx_536871513
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_ctx" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_version_info):
-  type
-    ngtcp2_version_info* = ngtcp2_version_info_536871444
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_version_info" &
-        " already exists, not redeclaring")
-when not declared(enum_en_ptls_hash_final_mode_t):
-  type
-    enum_en_ptls_hash_final_mode_t* = enum_en_ptls_hash_final_mode_t_536871675
-else:
-  static :
-    hint("Declaration of " & "enum_en_ptls_hash_final_mode_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_socklen):
-  type
-    ngtcp2_socklen* = ngtcp2_socklen_536871430
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_socklen" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_cipher_suite_t):
-  type
-    struct_st_ptls_cipher_suite_t* = struct_st_ptls_cipher_suite_t_536871687
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_cipher_suite_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_client_initial):
-  type
-    ngtcp2_recv_client_initial* = ngtcp2_recv_client_initial_536871525
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_client_initial" &
-        " already exists, not redeclaring")
-when not declared(compiler_ssize_t):
-  type
-    compiler_ssize_t* = compiler_ssize_t_536871847
-else:
-  static :
-    hint("Declaration of " & "compiler_ssize_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_hpke_kem_t):
-  type
-    ptls_hpke_kem_t* = ptls_hpke_kem_t_536871697
-else:
-  static :
-    hint("Declaration of " & "ptls_hpke_kem_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_key_exchange_algorithm_t):
-  type
-    ptls_key_exchange_algorithm_t* = ptls_key_exchange_algorithm_t_536871653
-else:
-  static :
-    hint("Declaration of " & "ptls_key_exchange_algorithm_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_callbacks):
-  type
-    ngtcp2_callbacks* = ngtcp2_callbacks_536871605
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_callbacks" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_crypto_cipher):
-  type
-    ngtcp2_crypto_cipher* = ngtcp2_crypto_cipher_536871503
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_crypto_cipher" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_sign_certificate_t):
-  type
-    struct_st_ptls_sign_certificate_t* = struct_st_ptls_sign_certificate_t_536871731
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_sign_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_emit_certificate_t):
-  type
-    struct_st_ptls_emit_certificate_t* = struct_st_ptls_emit_certificate_t_536871723
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_emit_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(socklen_t):
-  type
-    socklen_t* = socklen_t_536871432
-else:
-  static :
-    hint("Declaration of " & "socklen_t" & " already exists, not redeclaring")
-when not declared(ptls_raw_extension_t):
-  type
-    ptls_raw_extension_t* = ptls_raw_extension_t_536871775
-else:
-  static :
-    hint("Declaration of " & "ptls_raw_extension_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_lost_datagram):
-  type
-    ngtcp2_lost_datagram* = ngtcp2_lost_datagram_536871591
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_lost_datagram" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_pkt_hd):
-  type
-    struct_ngtcp2_pkt_hd* = struct_ngtcp2_pkt_hd_536871410
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_pkt_hd" &
-        " already exists, not redeclaring")
-when not declared(ptls_hash_context_t):
-  type
-    ptls_hash_context_t* = ptls_hash_context_t_536871681
-else:
-  static :
-    hint("Declaration of " & "ptls_hash_context_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_verify_certificate_t):
-  type
-    ptls_verify_certificate_t* = ptls_verify_certificate_t_536871737
-else:
-  static :
-    hint("Declaration of " & "ptls_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_ccerr):
-  type
-    ngtcp2_ccerr* = ngtcp2_ccerr_536871617
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_ccerr" & " already exists, not redeclaring")
-when not declared(ngtcp2_stream_close):
-  type
-    ngtcp2_stream_close* = ngtcp2_stream_close_536871551
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_stream_close" &
-        " already exists, not redeclaring")
-when not declared(ssize_t):
-  type
-    ssize_t* = ssize_t_536871753
-else:
-  static :
-    hint("Declaration of " & "ssize_t" & " already exists, not redeclaring")
-when not declared(ngtcp2_free):
-  type
-    ngtcp2_free* = ngtcp2_free_536871376
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_free" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_log_t):
-  type
-    struct_st_ptls_log_t* = struct_st_ptls_log_t_536871795
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_log_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_conn_info):
-  type
-    ngtcp2_conn_info* = ngtcp2_conn_info_536871459
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_conn_info" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_handshake_confirmed):
-  type
-    ngtcp2_handshake_confirmed* = ngtcp2_handshake_confirmed_536871535
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_handshake_confirmed" &
-        " already exists, not redeclaring")
-when not declared(ptls_ech_create_opener_t):
-  type
-    ptls_ech_create_opener_t* = ptls_ech_create_opener_t_536871771
-else:
-  static :
-    hint("Declaration of " & "ptls_ech_create_opener_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_openssl_raw_pubkey_verify_certificate_t):
-  type
-    ptls_openssl_raw_pubkey_verify_certificate_t* = ptls_openssl_raw_pubkey_verify_certificate_t_536871815
-else:
-  static :
-    hint("Declaration of " & "ptls_openssl_raw_pubkey_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_qlog_write):
-  type
-    ngtcp2_qlog_write* = ngtcp2_qlog_write_536871471
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_qlog_write" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_addr):
-  type
-    struct_ngtcp2_addr* = struct_ngtcp2_addr_536871481
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_addr" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_update_key):
-  type
-    ngtcp2_update_key* = ngtcp2_update_key_536871569
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_update_key" &
-        " already exists, not redeclaring")
-when not declared(ptls_log_event_t):
-  type
-    ptls_log_event_t* = ptls_log_event_t_536871749
-else:
-  static :
-    hint("Declaration of " & "ptls_log_event_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_openssl_signature_scheme_t):
-  type
-    struct_st_ptls_openssl_signature_scheme_t* = struct_st_ptls_openssl_signature_scheme_t_536871801
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_openssl_signature_scheme_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_ack_datagram):
-  type
-    ngtcp2_ack_datagram* = ngtcp2_ack_datagram_536871589
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_ack_datagram" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_ccerr_type):
-  type
-    ngtcp2_ccerr_type* = ngtcp2_ccerr_type_536871613
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_ccerr_type" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_hpke_kem_t):
-  type
-    struct_st_ptls_hpke_kem_t* = struct_st_ptls_hpke_kem_t_536871695
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_hpke_kem_t" &
-        " already exists, not redeclaring")
-when not declared(union_ngtcp2_sockaddr_union):
-  type
-    union_ngtcp2_sockaddr_union* = union_ngtcp2_sockaddr_union_536871434
-else:
-  static :
-    hint("Declaration of " & "union_ngtcp2_sockaddr_union" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_raw_extension_t):
-  type
-    struct_st_ptls_raw_extension_t* = struct_st_ptls_raw_extension_t_536871773
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_raw_extension_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_path_validation_result):
-  type
-    ngtcp2_path_validation_result* = ngtcp2_path_validation_result_536871396
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_path_validation_result" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_cid):
-  type
-    ngtcp2_cid* = ngtcp2_cid_536871404
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_cid" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_key_exchange_context_t):
-  type
-    struct_st_ptls_key_exchange_context_t* = struct_st_ptls_key_exchange_context_t_536871645
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_key_exchange_context_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_ech_create_opener_t):
-  type
-    struct_st_ptls_ech_create_opener_t* = struct_st_ptls_ech_create_opener_t_536871769
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_ech_create_opener_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_log_point_t):
-  type
-    struct_st_ptls_log_point_t* = struct_st_ptls_log_point_t_536871787
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_log_point_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_cred_buffer_t):
-  type
-    ptls_cred_buffer_t* = ptls_cred_buffer_t_536871839
-else:
-  static :
-    hint("Declaration of " & "ptls_cred_buffer_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_new_token):
-  type
-    ngtcp2_recv_new_token* = ngtcp2_recv_new_token_536871581
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_new_token" &
-        " already exists, not redeclaring")
-when not declared(in_addr_t):
-  type
-    in_addr_t* = in_addr_t_536871849
-else:
-  static :
-    hint("Declaration of " & "in_addr_t" & " already exists, not redeclaring")
-when not declared(ngtcp2_mem):
-  type
-    ngtcp2_mem* = ngtcp2_mem_536871384
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_mem" & " already exists, not redeclaring")
-when not declared(ngtcp2_info):
-  type
-    ngtcp2_info* = ngtcp2_info_536871621
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_info" & " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_md):
-  type
-    struct_ngtcp2_crypto_md* = struct_ngtcp2_crypto_md_536871493
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_md" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_rand):
-  type
-    ngtcp2_rand* = ngtcp2_rand_536871563
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_rand" & " already exists, not redeclaring")
-when not declared(EVP_PKEY):
-  type
-    EVP_PKEY* = EVP_PKEY_536871799
-else:
-  static :
-    hint("Declaration of " & "EVP_PKEY" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_log_conn_state_t):
-  type
-    struct_st_ptls_log_conn_state_t* = struct_st_ptls_log_conn_state_t_536871789
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_log_conn_state_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_pkt_stateless_reset):
-  type
-    struct_ngtcp2_pkt_stateless_reset* = struct_ngtcp2_pkt_stateless_reset_536871414
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_pkt_stateless_reset" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_rand_ctx):
-  type
-    ngtcp2_rand_ctx* = ngtcp2_rand_ctx_536871469
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_rand_ctx" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_encrypt_ticket_t):
-  type
-    struct_st_ptls_encrypt_ticket_t* = struct_st_ptls_encrypt_ticket_t_536871739
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_encrypt_ticket_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_recv_version_negotiation):
-  type
-    ngtcp2_recv_version_negotiation* = ngtcp2_recv_version_negotiation_536871537
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_recv_version_negotiation" &
-        " already exists, not redeclaring")
-when not declared(ptls_on_client_hello_parameters_t):
-  type
-    ptls_on_client_hello_parameters_t* = ptls_on_client_hello_parameters_t_536871713
-else:
-  static :
-    hint("Declaration of " & "ptls_on_client_hello_parameters_t" &
-        " already exists, not redeclaring")
-when not declared(struct_ngtcp2_conn_info):
-  type
-    struct_ngtcp2_conn_info* = struct_ngtcp2_conn_info_536871450
-else:
-  static :
-    hint("Declaration of " & "struct_ngtcp2_conn_info" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_save_ticket_t):
-  type
-    struct_st_ptls_save_ticket_t* = struct_st_ptls_save_ticket_t_536871743
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_save_ticket_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_update_open_count_t):
-  type
-    ptls_update_open_count_t* = ptls_update_open_count_t_536871755
-else:
-  static :
-    hint("Declaration of " & "ptls_update_open_count_t" &
-        " already exists, not redeclaring")
-when not declared(struct_st_ptls_client_hello_psk_identity_t):
-  type
-    struct_st_ptls_client_hello_psk_identity_t* = struct_st_ptls_client_hello_psk_identity_t_536871707
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_client_hello_psk_identity_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_sign_certificate_t):
-  type
-    ptls_sign_certificate_t* = ptls_sign_certificate_t_536871733
-else:
-  static :
-    hint("Declaration of " & "ptls_sign_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ptls_context_t):
-  type
-    ptls_context_t* = ptls_context_t_536871631
-else:
-  static :
-    hint("Declaration of " & "ptls_context_t" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_hp_mask):
-  type
-    ngtcp2_hp_mask* = ngtcp2_hp_mask_536871545
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_hp_mask" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_connection_id_status):
-  type
-    ngtcp2_connection_id_status* = ngtcp2_connection_id_status_536871579
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_connection_id_status" &
-        " already exists, not redeclaring")
-when not declared(enum_ngtcp2_encryption_level):
-  type
-    enum_ngtcp2_encryption_level* = enum_ngtcp2_encryption_level_536871527
-else:
-  static :
-    hint("Declaration of " & "enum_ngtcp2_encryption_level" &
-        " already exists, not redeclaring")
-when not declared(ngtcp2_ssize):
-  type
-    ngtcp2_ssize* = ngtcp2_ssize_536871370
-else:
-  static :
-    hint("Declaration of " & "ngtcp2_ssize" & " already exists, not redeclaring")
-when not declared(struct_st_ptls_openssl_verify_certificate_t):
-  type
-    struct_st_ptls_openssl_verify_certificate_t* = struct_st_ptls_openssl_verify_certificate_t_536871821
-else:
-  static :
-    hint("Declaration of " & "struct_st_ptls_openssl_verify_certificate_t" &
-        " already exists, not redeclaring")
-when not declared(ptrdiff_t):
-  type
-    ptrdiff_t* = ptrdiff_t_536871372
-else:
-  static :
-    hint("Declaration of " & "ptrdiff_t" & " already exists, not redeclaring")
-when not declared(struct_ptls_cred_buffer_s):
-  type
-    struct_ptls_cred_buffer_s* = struct_ptls_cred_buffer_s_536871837
-else:
-  static :
-    hint("Declaration of " & "struct_ptls_cred_buffer_s" &
+    hint("Declaration of " & "ngtcp2_connection_id_status_type" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_sockaddr_union):
   type
-    ngtcp2_sockaddr_union* = ngtcp2_sockaddr_union_536871436
+    ngtcp2_sockaddr_union* = ngtcp2_sockaddr_union_553648651
 else:
   static :
     hint("Declaration of " & "ngtcp2_sockaddr_union" &
         " already exists, not redeclaring")
-when not declared(struct_ngtcp2_crypto_cipher):
+when not declared(ngtcp2_cid_token):
   type
-    struct_ngtcp2_crypto_cipher* = struct_ngtcp2_crypto_cipher_536871501
+    ngtcp2_cid_token* = ngtcp2_cid_token_553648824
 else:
   static :
-    hint("Declaration of " & "struct_ngtcp2_crypto_cipher" &
+    hint("Declaration of " & "ngtcp2_cid_token" &
         " already exists, not redeclaring")
-when not declared(ngtcp2_version_negotiation):
+when not declared(ptls_buffer_t):
   type
-    ngtcp2_version_negotiation* = ngtcp2_version_negotiation_536871597
+    ptls_buffer_t* = ptls_buffer_t_553648858
 else:
   static :
-    hint("Declaration of " & "ngtcp2_version_negotiation" &
+    hint("Declaration of " & "ptls_buffer_t" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_buffer_t):
+  type
+    struct_st_ptls_buffer_t* = struct_st_ptls_buffer_t_553648856
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_buffer_t" &
+        " already exists, not redeclaring")
+when not declared(ptls_aead_algorithm_t):
+  type
+    ptls_aead_algorithm_t* = ptls_aead_algorithm_t_553648888
+else:
+  static :
+    hint("Declaration of " & "ptls_aead_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_ssize):
+  type
+    ngtcp2_ssize* = ngtcp2_ssize_553648585
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_ssize" & " already exists, not redeclaring")
+when not declared(ngtcp2_sockaddr_in6):
+  type
+    ngtcp2_sockaddr_in6* = ngtcp2_sockaddr_in6_553648641
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_sockaddr_in6" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_mem):
+  type
+    ngtcp2_mem* = ngtcp2_mem_553648599
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_mem" & " already exists, not redeclaring")
+when not declared(ptls_hash_final_mode_t):
+  type
+    ptls_hash_final_mode_t* = ptls_hash_final_mode_t_553648892
+else:
+  static :
+    hint("Declaration of " & "ptls_hash_final_mode_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_pkt_info):
+  type
+    ngtcp2_pkt_info* = ngtcp2_pkt_info_553648603
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_pkt_info" &
+        " already exists, not redeclaring")
+when not declared(ptrdiff_t):
+  type
+    ptrdiff_t* = ptrdiff_t_553648587
+else:
+  static :
+    hint("Declaration of " & "ptrdiff_t" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_aead_context_t):
+  type
+    struct_st_ptls_aead_context_t* = struct_st_ptls_aead_context_t_553648882
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_aead_context_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_preferred_addr):
+  type
+    ngtcp2_preferred_addr* = ngtcp2_preferred_addr_553648655
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_preferred_addr" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_hpke_kem_t):
+  type
+    struct_st_ptls_hpke_kem_t* = struct_st_ptls_hpke_kem_t_553648910
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_hpke_kem_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_realloc):
+  type
+    ngtcp2_realloc* = ngtcp2_realloc_553648595
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_realloc" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_cipher_ctx):
+  type
+    ngtcp2_crypto_cipher_ctx* = ngtcp2_crypto_cipher_ctx_553648726
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_cipher_ctx" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_version_cid):
+  type
+    ngtcp2_version_cid* = ngtcp2_version_cid_553648734
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_version_cid" &
+        " already exists, not redeclaring")
+when not declared(ptls_on_client_hello_parameters_t):
+  type
+    ptls_on_client_hello_parameters_t* = ptls_on_client_hello_parameters_t_553648928
+else:
+  static :
+    hint("Declaration of " & "ptls_on_client_hello_parameters_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_client_initial):
+  type
+    ngtcp2_recv_client_initial* = ngtcp2_recv_client_initial_553648740
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_client_initial" &
         " already exists, not redeclaring")
 when not declared(ptls_on_client_hello_t):
   type
-    ptls_on_client_hello_t* = ptls_on_client_hello_t_536871721
+    ptls_on_client_hello_t* = ptls_on_client_hello_t_553648936
 else:
   static :
     hint("Declaration of " & "ptls_on_client_hello_t" &
         " already exists, not redeclaring")
-when not declared(ptls_async_job_t):
+when not declared(ngtcp2_vec):
   type
-    ptls_async_job_t* = ptls_async_job_t_536871729
+    ngtcp2_vec* = ngtcp2_vec_553648623
 else:
   static :
-    hint("Declaration of " & "ptls_async_job_t" &
+    hint("Declaration of " & "ngtcp2_vec" & " already exists, not redeclaring")
+when not declared(struct_st_ptls_encrypt_ticket_t):
+  type
+    struct_st_ptls_encrypt_ticket_t* = struct_st_ptls_encrypt_ticket_t_553648954
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_encrypt_ticket_t" &
         " already exists, not redeclaring")
-when not declared(ptls_hash_algorithm_t):
+when not declared(union_ngtcp2_sockaddr_union):
   type
-    ptls_hash_algorithm_t* = ptls_hash_algorithm_t_536871685
+    union_ngtcp2_sockaddr_union* = union_ngtcp2_sockaddr_union_553648649
 else:
   static :
-    hint("Declaration of " & "ptls_hash_algorithm_t" &
+    hint("Declaration of " & "union_ngtcp2_sockaddr_union" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_openssl_raw_pubkey_verify_certificate_t):
+  type
+    struct_st_ptls_openssl_raw_pubkey_verify_certificate_t* = struct_st_ptls_openssl_raw_pubkey_verify_certificate_t_553649028
+else:
+  static :
+    hint("Declaration of " &
+        "struct_st_ptls_openssl_raw_pubkey_verify_certificate_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_rand):
+  type
+    ngtcp2_rand* = ngtcp2_rand_553648778
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_rand" & " already exists, not redeclaring")
+when not declared(enum_ngtcp2_pkt_type):
+  type
+    enum_ngtcp2_pkt_type* = enum_ngtcp2_pkt_type_553648605
+else:
+  static :
+    hint("Declaration of " & "enum_ngtcp2_pkt_type" &
+        " already exists, not redeclaring")
+when not declared(struct_in_addr):
+  type
+    struct_in_addr* = struct_in_addr_553649012
+else:
+  static :
+    hint("Declaration of " & "struct_in_addr" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_cipher_algorithm_t):
+  type
+    struct_st_ptls_cipher_algorithm_t* = struct_st_ptls_cipher_algorithm_t_553648872
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_cipher_algorithm_t" &
         " already exists, not redeclaring")
 when not declared(ptls_cipher_context_t):
   type
-    ptls_cipher_context_t* = ptls_cipher_context_t_536871659
+    ptls_cipher_context_t* = ptls_cipher_context_t_553648874
 else:
   static :
     hint("Declaration of " & "ptls_cipher_context_t" &
         " already exists, not redeclaring")
-when not declared(ngtcp2_malloc):
+when not declared(enum_ngtcp2_cc_algo):
   type
-    ngtcp2_malloc* = ngtcp2_malloc_536871374
+    enum_ngtcp2_cc_algo* = enum_ngtcp2_cc_algo_553648676
 else:
   static :
-    hint("Declaration of " & "ngtcp2_malloc" &
+    hint("Declaration of " & "enum_ngtcp2_cc_algo" &
         " already exists, not redeclaring")
-when not declared(ptls_openssl_override_verify_certificate_t):
+when not declared(ptls_update_open_count_t):
   type
-    ptls_openssl_override_verify_certificate_t* = ptls_openssl_override_verify_certificate_t_536871819
+    ptls_update_open_count_t* = ptls_update_open_count_t_553648970
 else:
   static :
-    hint("Declaration of " & "ptls_openssl_override_verify_certificate_t" &
+    hint("Declaration of " & "ptls_update_open_count_t" &
         " already exists, not redeclaring")
-when not declared(struct_ngtcp2_version_info):
+when not declared(struct_ngtcp2_crypto_ctx):
   type
-    struct_ngtcp2_version_info* = struct_ngtcp2_version_info_536871442
+    struct_ngtcp2_crypto_ctx* = struct_ngtcp2_crypto_ctx_553648728
 else:
   static :
-    hint("Declaration of " & "struct_ngtcp2_version_info" &
+    hint("Declaration of " & "struct_ngtcp2_crypto_ctx" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_extend_max_stream_data):
+  type
+    ngtcp2_extend_max_stream_data* = ngtcp2_extend_max_stream_data_553648776
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_extend_max_stream_data" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_lost_datagram):
+  type
+    ngtcp2_lost_datagram* = ngtcp2_lost_datagram_553648806
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_lost_datagram" &
+        " already exists, not redeclaring")
+when not declared(ptls_openssl_signature_scheme_t):
+  type
+    ptls_openssl_signature_scheme_t* = ptls_openssl_signature_scheme_t_553649020
+else:
+  static :
+    hint("Declaration of " & "ptls_openssl_signature_scheme_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_recv_crypto_data):
+  type
+    ngtcp2_recv_crypto_data* = ngtcp2_recv_crypto_data_553648746
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_recv_crypto_data" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_handshake_confirmed):
+  type
+    ngtcp2_handshake_confirmed* = ngtcp2_handshake_confirmed_553648750
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_handshake_confirmed" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_hash_algorithm_t):
+  type
+    struct_st_ptls_hash_algorithm_t* = struct_st_ptls_hash_algorithm_t_553648898
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_hash_algorithm_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_printf):
+  type
+    ngtcp2_printf* = ngtcp2_printf_553648680
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_printf" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_md):
+  type
+    struct_ngtcp2_crypto_md* = struct_ngtcp2_crypto_md_553648708
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_md" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_save_ticket_t):
+  type
+    struct_st_ptls_save_ticket_t* = struct_st_ptls_save_ticket_t_553648958
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_save_ticket_t" &
+        " already exists, not redeclaring")
+when not declared(struct_in6_addr):
+  type
+    struct_in6_addr* = struct_in6_addr_553649006
+else:
+  static :
+    hint("Declaration of " & "struct_in6_addr" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_crypto_conn_ref):
+  type
+    struct_ngtcp2_crypto_conn_ref* = struct_ngtcp2_crypto_conn_ref_553648840
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_crypto_conn_ref" &
+        " already exists, not redeclaring")
+when not declared(struct_st_ptls_update_traffic_key_t):
+  type
+    struct_st_ptls_update_traffic_key_t* = struct_st_ptls_update_traffic_key_t_553648972
+else:
+  static :
+    hint("Declaration of " & "struct_st_ptls_update_traffic_key_t" &
+        " already exists, not redeclaring")
+when not declared(ngtcp2_crypto_picotls_ctx):
+  type
+    ngtcp2_crypto_picotls_ctx* = ngtcp2_crypto_picotls_ctx_553649050
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_picotls_ctx" &
+        " already exists, not redeclaring")
+when not declared(struct_ngtcp2_ccerr):
+  type
+    struct_ngtcp2_ccerr* = struct_ngtcp2_ccerr_553648830
+else:
+  static :
+    hint("Declaration of " & "struct_ngtcp2_ccerr" &
         " already exists, not redeclaring")
 when not declared(NGTCP2_VERSION):
-  when "1.11.0-DEV" is static:
+  when "1.6.0" is static:
     const
-      NGTCP2_VERSION* = "1.11.0-DEV" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/version.h:39:9
+      NGTCP2_VERSION* = "1.6.0" ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/ngtcp2/version.h:39:9
   else:
-    let NGTCP2_VERSION* = "1.11.0-DEV" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/version.h:39:9
+    let NGTCP2_VERSION* = "1.6.0" ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/ngtcp2/version.h:39:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_VERSION" &
         " already exists, not redeclaring")
 when not declared(NGTCP2_VERSION_NUM):
-  when 68352 is static:
+  when 67072 is static:
     const
-      NGTCP2_VERSION_NUM* = 68352 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/version.h:49:9
+      NGTCP2_VERSION_NUM* = 67072 ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/ngtcp2/version.h:49:9
   else:
-    let NGTCP2_VERSION_NUM* = 68352 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/version.h:49:9
+    let NGTCP2_VERSION_NUM* = 67072 ## Generated based on /home/andrew/opensource/Vac/nim-ngtcp2/build/lib/includes/ngtcp2/version.h:49:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_VERSION_NUM" &
@@ -4822,13 +4826,13 @@ else:
 when not declared(NGTCP2_PROTO_VER_MAX):
   when NGTCP2_PROTO_VER_V1 is typedesc:
     type
-      NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
+      NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
   else:
     when NGTCP2_PROTO_VER_V1 is static:
       const
-        NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
+        NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
     else:
-      let NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
+      let NGTCP2_PROTO_VER_MAX* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:273:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PROTO_VER_MAX" &
@@ -4836,13 +4840,13 @@ else:
 when not declared(NGTCP2_PROTO_VER_MIN):
   when NGTCP2_PROTO_VER_V1 is typedesc:
     type
-      NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
+      NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
   else:
     when NGTCP2_PROTO_VER_V1 is static:
       const
-        NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
+        NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
     else:
-      let NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
+      let NGTCP2_PROTO_VER_MIN* = NGTCP2_PROTO_VER_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:281:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PROTO_VER_MIN" &
@@ -4850,9 +4854,9 @@ else:
 when not declared(NGTCP2_RESERVED_VERSION_MASK):
   when cast[cuint](168430090'i64) is static:
     const
-      NGTCP2_RESERVED_VERSION_MASK* = cast[cuint](168430090'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:289:9
+      NGTCP2_RESERVED_VERSION_MASK* = cast[cuint](168430090'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:289:9
   else:
-    let NGTCP2_RESERVED_VERSION_MASK* = cast[cuint](168430090'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:289:9
+    let NGTCP2_RESERVED_VERSION_MASK* = cast[cuint](168430090'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:289:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_RESERVED_VERSION_MASK" &
@@ -4860,9 +4864,9 @@ else:
 when not declared(NGTCP2_MAX_UDP_PAYLOAD_SIZE):
   when 1200 is static:
     const
-      NGTCP2_MAX_UDP_PAYLOAD_SIZE* = 1200 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:303:9
+      NGTCP2_MAX_UDP_PAYLOAD_SIZE* = 1200 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:303:9
   else:
-    let NGTCP2_MAX_UDP_PAYLOAD_SIZE* = 1200 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:303:9
+    let NGTCP2_MAX_UDP_PAYLOAD_SIZE* = 1200 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:303:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MAX_UDP_PAYLOAD_SIZE" &
@@ -4870,9 +4874,9 @@ else:
 when not declared(NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE):
   when 1452 is static:
     const
-      NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE* = 1452 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:311:9
+      NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE* = 1452 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:311:9
   else:
-    let NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE* = 1452 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:311:9
+    let NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE* = 1452 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:311:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE" &
@@ -4880,9 +4884,9 @@ else:
 when not declared(NGTCP2_STATELESS_RESET_TOKENLEN):
   when 16 is static:
     const
-      NGTCP2_STATELESS_RESET_TOKENLEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:333:9
+      NGTCP2_STATELESS_RESET_TOKENLEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:333:9
   else:
-    let NGTCP2_STATELESS_RESET_TOKENLEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:333:9
+    let NGTCP2_STATELESS_RESET_TOKENLEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:333:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STATELESS_RESET_TOKENLEN" &
@@ -4890,9 +4894,9 @@ else:
 when not declared(NGTCP2_MIN_STATELESS_RESET_RANDLEN):
   when 5 is static:
     const
-      NGTCP2_MIN_STATELESS_RESET_RANDLEN* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:341:9
+      NGTCP2_MIN_STATELESS_RESET_RANDLEN* = 5 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:341:9
   else:
-    let NGTCP2_MIN_STATELESS_RESET_RANDLEN* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:341:9
+    let NGTCP2_MIN_STATELESS_RESET_RANDLEN* = 5 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:341:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MIN_STATELESS_RESET_RANDLEN" &
@@ -4900,9 +4904,9 @@ else:
 when not declared(NGTCP2_PATH_CHALLENGE_DATALEN):
   when 8 is static:
     const
-      NGTCP2_PATH_CHALLENGE_DATALEN* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:349:9
+      NGTCP2_PATH_CHALLENGE_DATALEN* = 8 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:349:9
   else:
-    let NGTCP2_PATH_CHALLENGE_DATALEN* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:349:9
+    let NGTCP2_PATH_CHALLENGE_DATALEN* = 8 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:349:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PATH_CHALLENGE_DATALEN" &
@@ -4910,9 +4914,9 @@ else:
 when not declared(NGTCP2_RETRY_NONCE_V1):
   when "\\x46\\x15\\x99\\xd3\\x5d\\x63\\x2b\\xf2\\x23\\x98\\x25\\xbb" is static:
     const
-      NGTCP2_RETRY_NONCE_V1* = "\\x46\\x15\\x99\\xd3\\x5d\\x63\\x2b\\xf2\\x23\\x98\\x25\\xbb" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:366:9
+      NGTCP2_RETRY_NONCE_V1* = "\\x46\\x15\\x99\\xd3\\x5d\\x63\\x2b\\xf2\\x23\\x98\\x25\\xbb" ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:366:9
   else:
-    let NGTCP2_RETRY_NONCE_V1* = "\\x46\\x15\\x99\\xd3\\x5d\\x63\\x2b\\xf2\\x23\\x98\\x25\\xbb" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:366:9
+    let NGTCP2_RETRY_NONCE_V1* = "\\x46\\x15\\x99\\xd3\\x5d\\x63\\x2b\\xf2\\x23\\x98\\x25\\xbb" ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:366:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_RETRY_NONCE_V1" &
@@ -4920,9 +4924,9 @@ else:
 when not declared(NGTCP2_RETRY_NONCE_V2):
   when "\\xd8\\x69\\x69\\xbc\\x2d\\x7c\\x6d\\x99\\x90\\xef\\xb0\\x4a" is static:
     const
-      NGTCP2_RETRY_NONCE_V2* = "\\xd8\\x69\\x69\\xbc\\x2d\\x7c\\x6d\\x99\\x90\\xef\\xb0\\x4a" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:385:9
+      NGTCP2_RETRY_NONCE_V2* = "\\xd8\\x69\\x69\\xbc\\x2d\\x7c\\x6d\\x99\\x90\\xef\\xb0\\x4a" ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:385:9
   else:
-    let NGTCP2_RETRY_NONCE_V2* = "\\xd8\\x69\\x69\\xbc\\x2d\\x7c\\x6d\\x99\\x90\\xef\\xb0\\x4a" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:385:9
+    let NGTCP2_RETRY_NONCE_V2* = "\\xd8\\x69\\x69\\xbc\\x2d\\x7c\\x6d\\x99\\x90\\xef\\xb0\\x4a" ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:385:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_RETRY_NONCE_V2" &
@@ -4930,9 +4934,9 @@ else:
 when not declared(NGTCP2_HP_MASKLEN):
   when 5 is static:
     const
-      NGTCP2_HP_MASKLEN* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:392:9
+      NGTCP2_HP_MASKLEN* = 5 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:392:9
   else:
-    let NGTCP2_HP_MASKLEN* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:392:9
+    let NGTCP2_HP_MASKLEN* = 5 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:392:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_HP_MASKLEN" &
@@ -4940,9 +4944,9 @@ else:
 when not declared(NGTCP2_HP_SAMPLELEN):
   when 16 is static:
     const
-      NGTCP2_HP_SAMPLELEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:400:9
+      NGTCP2_HP_SAMPLELEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:400:9
   else:
-    let NGTCP2_HP_SAMPLELEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:400:9
+    let NGTCP2_HP_SAMPLELEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:400:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_HP_SAMPLELEN" &
@@ -4950,9 +4954,9 @@ else:
 when not declared(NGTCP2_MAX_CIDLEN):
   when 20 is static:
     const
-      NGTCP2_MAX_CIDLEN* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:414:9
+      NGTCP2_MAX_CIDLEN* = 20 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:414:9
   else:
-    let NGTCP2_MAX_CIDLEN* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:414:9
+    let NGTCP2_MAX_CIDLEN* = 20 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:414:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MAX_CIDLEN" &
@@ -4960,9 +4964,9 @@ else:
 when not declared(NGTCP2_MIN_CIDLEN):
   when 1 is static:
     const
-      NGTCP2_MIN_CIDLEN* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:421:9
+      NGTCP2_MIN_CIDLEN* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:421:9
   else:
-    let NGTCP2_MIN_CIDLEN* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:421:9
+    let NGTCP2_MIN_CIDLEN* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:421:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MIN_CIDLEN" &
@@ -4970,9 +4974,9 @@ else:
 when not declared(NGTCP2_MIN_INITIAL_DCIDLEN):
   when 8 is static:
     const
-      NGTCP2_MIN_INITIAL_DCIDLEN* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:430:9
+      NGTCP2_MIN_INITIAL_DCIDLEN* = 8 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:430:9
   else:
-    let NGTCP2_MIN_INITIAL_DCIDLEN* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:430:9
+    let NGTCP2_MIN_INITIAL_DCIDLEN* = 8 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:430:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_MIN_INITIAL_DCIDLEN" &
@@ -4980,9 +4984,9 @@ else:
 when not declared(NGTCP2_ECN_NOT_ECT):
   when 0 is static:
     const
-      NGTCP2_ECN_NOT_ECT* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:443:9
+      NGTCP2_ECN_NOT_ECT* = 0 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:443:9
   else:
-    let NGTCP2_ECN_NOT_ECT* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:443:9
+    let NGTCP2_ECN_NOT_ECT* = 0 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:443:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ECN_NOT_ECT" &
@@ -4990,9 +4994,9 @@ else:
 when not declared(NGTCP2_ECN_ECT_1):
   when 1 is static:
     const
-      NGTCP2_ECN_ECT_1* = 1  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:450:9
+      NGTCP2_ECN_ECT_1* = 1  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:450:9
   else:
-    let NGTCP2_ECN_ECT_1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:450:9
+    let NGTCP2_ECN_ECT_1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:450:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ECN_ECT_1" &
@@ -5000,9 +5004,9 @@ else:
 when not declared(NGTCP2_ECN_ECT_0):
   when 2 is static:
     const
-      NGTCP2_ECN_ECT_0* = 2  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:457:9
+      NGTCP2_ECN_ECT_0* = 2  ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:457:9
   else:
-    let NGTCP2_ECN_ECT_0* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:457:9
+    let NGTCP2_ECN_ECT_0* = 2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:457:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ECN_ECT_0" &
@@ -5010,9 +5014,9 @@ else:
 when not declared(NGTCP2_ECN_CE):
   when 3 is static:
     const
-      NGTCP2_ECN_CE* = 3     ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:464:9
+      NGTCP2_ECN_CE* = 3     ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:464:9
   else:
-    let NGTCP2_ECN_CE* = 3   ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:464:9
+    let NGTCP2_ECN_CE* = 3   ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:464:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ECN_CE" &
@@ -5020,9 +5024,9 @@ else:
 when not declared(NGTCP2_ECN_MASK):
   when 3 is static:
     const
-      NGTCP2_ECN_MASK* = 3   ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:471:9
+      NGTCP2_ECN_MASK* = 3   ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:471:9
   else:
-    let NGTCP2_ECN_MASK* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:471:9
+    let NGTCP2_ECN_MASK* = 3 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:471:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ECN_MASK" &
@@ -5030,9 +5034,9 @@ else:
 when not declared(NGTCP2_PKT_INFO_V1):
   when 1 is static:
     const
-      NGTCP2_PKT_INFO_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:473:9
+      NGTCP2_PKT_INFO_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:473:9
   else:
-    let NGTCP2_PKT_INFO_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:473:9
+    let NGTCP2_PKT_INFO_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:473:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_INFO_V1" &
@@ -5040,13 +5044,13 @@ else:
 when not declared(NGTCP2_PKT_INFO_VERSION):
   when NGTCP2_PKT_INFO_V1 is typedesc:
     type
-      NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
+      NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
   else:
     when NGTCP2_PKT_INFO_V1 is static:
       const
-        NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
+        NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
     else:
-      let NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
+      let NGTCP2_PKT_INFO_VERSION* = NGTCP2_PKT_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:474:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_INFO_VERSION" &
@@ -5054,9 +5058,9 @@ else:
 when not declared(NGTCP2_ERR_INVALID_ARGUMENT):
   when -201 is static:
     const
-      NGTCP2_ERR_INVALID_ARGUMENT* = -201 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:503:9
+      NGTCP2_ERR_INVALID_ARGUMENT* = -201 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:503:9
   else:
-    let NGTCP2_ERR_INVALID_ARGUMENT* = -201 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:503:9
+    let NGTCP2_ERR_INVALID_ARGUMENT* = -201 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:503:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_INVALID_ARGUMENT" &
@@ -5064,9 +5068,9 @@ else:
 when not declared(NGTCP2_ERR_NOBUF):
   when -202 is static:
     const
-      NGTCP2_ERR_NOBUF* = -202 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:510:9
+      NGTCP2_ERR_NOBUF* = -202 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:510:9
   else:
-    let NGTCP2_ERR_NOBUF* = -202 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:510:9
+    let NGTCP2_ERR_NOBUF* = -202 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:510:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_NOBUF" &
@@ -5074,9 +5078,9 @@ else:
 when not declared(NGTCP2_ERR_PROTO):
   when -203 is static:
     const
-      NGTCP2_ERR_PROTO* = -203 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:516:9
+      NGTCP2_ERR_PROTO* = -203 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:516:9
   else:
-    let NGTCP2_ERR_PROTO* = -203 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:516:9
+    let NGTCP2_ERR_PROTO* = -203 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:516:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_PROTO" &
@@ -5084,9 +5088,9 @@ else:
 when not declared(NGTCP2_ERR_INVALID_STATE):
   when -204 is static:
     const
-      NGTCP2_ERR_INVALID_STATE* = -204 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:523:9
+      NGTCP2_ERR_INVALID_STATE* = -204 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:523:9
   else:
-    let NGTCP2_ERR_INVALID_STATE* = -204 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:523:9
+    let NGTCP2_ERR_INVALID_STATE* = -204 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:523:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_INVALID_STATE" &
@@ -5094,9 +5098,9 @@ else:
 when not declared(NGTCP2_ERR_ACK_FRAME):
   when -205 is static:
     const
-      NGTCP2_ERR_ACK_FRAME* = -205 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:530:9
+      NGTCP2_ERR_ACK_FRAME* = -205 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:530:9
   else:
-    let NGTCP2_ERR_ACK_FRAME* = -205 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:530:9
+    let NGTCP2_ERR_ACK_FRAME* = -205 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:530:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_ACK_FRAME" &
@@ -5104,9 +5108,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_ID_BLOCKED):
   when -206 is static:
     const
-      NGTCP2_ERR_STREAM_ID_BLOCKED* = -206 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:537:9
+      NGTCP2_ERR_STREAM_ID_BLOCKED* = -206 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:537:9
   else:
-    let NGTCP2_ERR_STREAM_ID_BLOCKED* = -206 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:537:9
+    let NGTCP2_ERR_STREAM_ID_BLOCKED* = -206 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:537:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_ID_BLOCKED" &
@@ -5114,9 +5118,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_IN_USE):
   when -207 is static:
     const
-      NGTCP2_ERR_STREAM_IN_USE* = -207 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:544:9
+      NGTCP2_ERR_STREAM_IN_USE* = -207 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:544:9
   else:
-    let NGTCP2_ERR_STREAM_IN_USE* = -207 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:544:9
+    let NGTCP2_ERR_STREAM_IN_USE* = -207 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:544:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_IN_USE" &
@@ -5124,9 +5128,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_DATA_BLOCKED):
   when -208 is static:
     const
-      NGTCP2_ERR_STREAM_DATA_BLOCKED* = -208 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:551:9
+      NGTCP2_ERR_STREAM_DATA_BLOCKED* = -208 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:551:9
   else:
-    let NGTCP2_ERR_STREAM_DATA_BLOCKED* = -208 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:551:9
+    let NGTCP2_ERR_STREAM_DATA_BLOCKED* = -208 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:551:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_DATA_BLOCKED" &
@@ -5134,9 +5138,9 @@ else:
 when not declared(NGTCP2_ERR_FLOW_CONTROL):
   when -209 is static:
     const
-      NGTCP2_ERR_FLOW_CONTROL* = -209 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:557:9
+      NGTCP2_ERR_FLOW_CONTROL* = -209 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:557:9
   else:
-    let NGTCP2_ERR_FLOW_CONTROL* = -209 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:557:9
+    let NGTCP2_ERR_FLOW_CONTROL* = -209 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:557:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_FLOW_CONTROL" &
@@ -5144,9 +5148,9 @@ else:
 when not declared(NGTCP2_ERR_CONNECTION_ID_LIMIT):
   when -210 is static:
     const
-      NGTCP2_ERR_CONNECTION_ID_LIMIT* = -210 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:564:9
+      NGTCP2_ERR_CONNECTION_ID_LIMIT* = -210 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:564:9
   else:
-    let NGTCP2_ERR_CONNECTION_ID_LIMIT* = -210 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:564:9
+    let NGTCP2_ERR_CONNECTION_ID_LIMIT* = -210 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:564:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CONNECTION_ID_LIMIT" &
@@ -5154,9 +5158,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_LIMIT):
   when -211 is static:
     const
-      NGTCP2_ERR_STREAM_LIMIT* = -211 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:571:9
+      NGTCP2_ERR_STREAM_LIMIT* = -211 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:571:9
   else:
-    let NGTCP2_ERR_STREAM_LIMIT* = -211 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:571:9
+    let NGTCP2_ERR_STREAM_LIMIT* = -211 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:571:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_LIMIT" &
@@ -5164,9 +5168,9 @@ else:
 when not declared(NGTCP2_ERR_FINAL_SIZE):
   when -212 is static:
     const
-      NGTCP2_ERR_FINAL_SIZE* = -212 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:578:9
+      NGTCP2_ERR_FINAL_SIZE* = -212 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:578:9
   else:
-    let NGTCP2_ERR_FINAL_SIZE* = -212 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:578:9
+    let NGTCP2_ERR_FINAL_SIZE* = -212 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:578:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_FINAL_SIZE" &
@@ -5174,9 +5178,9 @@ else:
 when not declared(NGTCP2_ERR_CRYPTO):
   when -213 is static:
     const
-      NGTCP2_ERR_CRYPTO* = -213 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:584:9
+      NGTCP2_ERR_CRYPTO* = -213 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:584:9
   else:
-    let NGTCP2_ERR_CRYPTO* = -213 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:584:9
+    let NGTCP2_ERR_CRYPTO* = -213 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:584:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CRYPTO" &
@@ -5184,9 +5188,9 @@ else:
 when not declared(NGTCP2_ERR_PKT_NUM_EXHAUSTED):
   when -214 is static:
     const
-      NGTCP2_ERR_PKT_NUM_EXHAUSTED* = -214 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:591:9
+      NGTCP2_ERR_PKT_NUM_EXHAUSTED* = -214 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:591:9
   else:
-    let NGTCP2_ERR_PKT_NUM_EXHAUSTED* = -214 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:591:9
+    let NGTCP2_ERR_PKT_NUM_EXHAUSTED* = -214 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:591:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_PKT_NUM_EXHAUSTED" &
@@ -5194,9 +5198,9 @@ else:
 when not declared(NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM):
   when -215 is static:
     const
-      NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM* = -215 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:598:9
+      NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM* = -215 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:598:9
   else:
-    let NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM* = -215 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:598:9
+    let NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM* = -215 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:598:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM" &
@@ -5204,9 +5208,9 @@ else:
 when not declared(NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM):
   when -216 is static:
     const
-      NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM* = -216 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:605:9
+      NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM* = -216 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:605:9
   else:
-    let NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM* = -216 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:605:9
+    let NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM* = -216 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:605:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM" &
@@ -5214,9 +5218,9 @@ else:
 when not declared(NGTCP2_ERR_FRAME_ENCODING):
   when -217 is static:
     const
-      NGTCP2_ERR_FRAME_ENCODING* = -217 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:612:9
+      NGTCP2_ERR_FRAME_ENCODING* = -217 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:612:9
   else:
-    let NGTCP2_ERR_FRAME_ENCODING* = -217 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:612:9
+    let NGTCP2_ERR_FRAME_ENCODING* = -217 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:612:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_FRAME_ENCODING" &
@@ -5224,9 +5228,9 @@ else:
 when not declared(NGTCP2_ERR_DECRYPT):
   when -218 is static:
     const
-      NGTCP2_ERR_DECRYPT* = -218 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:618:9
+      NGTCP2_ERR_DECRYPT* = -218 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:618:9
   else:
-    let NGTCP2_ERR_DECRYPT* = -218 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:618:9
+    let NGTCP2_ERR_DECRYPT* = -218 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:618:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_DECRYPT" &
@@ -5234,9 +5238,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_SHUT_WR):
   when -219 is static:
     const
-      NGTCP2_ERR_STREAM_SHUT_WR* = -219 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:625:9
+      NGTCP2_ERR_STREAM_SHUT_WR* = -219 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:625:9
   else:
-    let NGTCP2_ERR_STREAM_SHUT_WR* = -219 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:625:9
+    let NGTCP2_ERR_STREAM_SHUT_WR* = -219 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:625:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_SHUT_WR" &
@@ -5244,9 +5248,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_NOT_FOUND):
   when -220 is static:
     const
-      NGTCP2_ERR_STREAM_NOT_FOUND* = -220 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:632:9
+      NGTCP2_ERR_STREAM_NOT_FOUND* = -220 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:632:9
   else:
-    let NGTCP2_ERR_STREAM_NOT_FOUND* = -220 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:632:9
+    let NGTCP2_ERR_STREAM_NOT_FOUND* = -220 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:632:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_NOT_FOUND" &
@@ -5254,9 +5258,9 @@ else:
 when not declared(NGTCP2_ERR_STREAM_STATE):
   when -221 is static:
     const
-      NGTCP2_ERR_STREAM_STATE* = -221 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:639:9
+      NGTCP2_ERR_STREAM_STATE* = -221 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:639:9
   else:
-    let NGTCP2_ERR_STREAM_STATE* = -221 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:639:9
+    let NGTCP2_ERR_STREAM_STATE* = -221 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:639:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_STREAM_STATE" &
@@ -5264,9 +5268,9 @@ else:
 when not declared(NGTCP2_ERR_RECV_VERSION_NEGOTIATION):
   when -222 is static:
     const
-      NGTCP2_ERR_RECV_VERSION_NEGOTIATION* = -222 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:646:9
+      NGTCP2_ERR_RECV_VERSION_NEGOTIATION* = -222 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:646:9
   else:
-    let NGTCP2_ERR_RECV_VERSION_NEGOTIATION* = -222 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:646:9
+    let NGTCP2_ERR_RECV_VERSION_NEGOTIATION* = -222 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:646:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_RECV_VERSION_NEGOTIATION" &
@@ -5274,9 +5278,9 @@ else:
 when not declared(NGTCP2_ERR_CLOSING):
   when -223 is static:
     const
-      NGTCP2_ERR_CLOSING* = -223 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:653:9
+      NGTCP2_ERR_CLOSING* = -223 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:653:9
   else:
-    let NGTCP2_ERR_CLOSING* = -223 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:653:9
+    let NGTCP2_ERR_CLOSING* = -223 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:653:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CLOSING" &
@@ -5284,9 +5288,9 @@ else:
 when not declared(NGTCP2_ERR_DRAINING):
   when -224 is static:
     const
-      NGTCP2_ERR_DRAINING* = -224 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:660:9
+      NGTCP2_ERR_DRAINING* = -224 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:660:9
   else:
-    let NGTCP2_ERR_DRAINING* = -224 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:660:9
+    let NGTCP2_ERR_DRAINING* = -224 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:660:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_DRAINING" &
@@ -5294,9 +5298,9 @@ else:
 when not declared(NGTCP2_ERR_TRANSPORT_PARAM):
   when -225 is static:
     const
-      NGTCP2_ERR_TRANSPORT_PARAM* = -225 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:667:9
+      NGTCP2_ERR_TRANSPORT_PARAM* = -225 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:667:9
   else:
-    let NGTCP2_ERR_TRANSPORT_PARAM* = -225 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:667:9
+    let NGTCP2_ERR_TRANSPORT_PARAM* = -225 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:667:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_TRANSPORT_PARAM" &
@@ -5304,9 +5308,9 @@ else:
 when not declared(NGTCP2_ERR_DISCARD_PKT):
   when -226 is static:
     const
-      NGTCP2_ERR_DISCARD_PKT* = -226 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:673:9
+      NGTCP2_ERR_DISCARD_PKT* = -226 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:673:9
   else:
-    let NGTCP2_ERR_DISCARD_PKT* = -226 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:673:9
+    let NGTCP2_ERR_DISCARD_PKT* = -226 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:673:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_DISCARD_PKT" &
@@ -5314,9 +5318,9 @@ else:
 when not declared(NGTCP2_ERR_CONN_ID_BLOCKED):
   when -227 is static:
     const
-      NGTCP2_ERR_CONN_ID_BLOCKED* = -227 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:680:9
+      NGTCP2_ERR_CONN_ID_BLOCKED* = -227 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:680:9
   else:
-    let NGTCP2_ERR_CONN_ID_BLOCKED* = -227 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:680:9
+    let NGTCP2_ERR_CONN_ID_BLOCKED* = -227 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:680:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CONN_ID_BLOCKED" &
@@ -5324,9 +5328,9 @@ else:
 when not declared(NGTCP2_ERR_INTERNAL):
   when -228 is static:
     const
-      NGTCP2_ERR_INTERNAL* = -228 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:686:9
+      NGTCP2_ERR_INTERNAL* = -228 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:686:9
   else:
-    let NGTCP2_ERR_INTERNAL* = -228 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:686:9
+    let NGTCP2_ERR_INTERNAL* = -228 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:686:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_INTERNAL" &
@@ -5334,9 +5338,9 @@ else:
 when not declared(NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED):
   when -229 is static:
     const
-      NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED* = -229 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:693:9
+      NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED* = -229 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:693:9
   else:
-    let NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED* = -229 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:693:9
+    let NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED* = -229 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:693:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED" &
@@ -5344,9 +5348,9 @@ else:
 when not declared(NGTCP2_ERR_WRITE_MORE):
   when -230 is static:
     const
-      NGTCP2_ERR_WRITE_MORE* = -230 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:701:9
+      NGTCP2_ERR_WRITE_MORE* = -230 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:701:9
   else:
-    let NGTCP2_ERR_WRITE_MORE* = -230 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:701:9
+    let NGTCP2_ERR_WRITE_MORE* = -230 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:701:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_WRITE_MORE" &
@@ -5354,9 +5358,9 @@ else:
 when not declared(NGTCP2_ERR_RETRY):
   when -231 is static:
     const
-      NGTCP2_ERR_RETRY* = -231 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:708:9
+      NGTCP2_ERR_RETRY* = -231 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:708:9
   else:
-    let NGTCP2_ERR_RETRY* = -231 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:708:9
+    let NGTCP2_ERR_RETRY* = -231 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:708:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_RETRY" &
@@ -5364,9 +5368,9 @@ else:
 when not declared(NGTCP2_ERR_DROP_CONN):
   when -232 is static:
     const
-      NGTCP2_ERR_DROP_CONN* = -232 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:715:9
+      NGTCP2_ERR_DROP_CONN* = -232 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:715:9
   else:
-    let NGTCP2_ERR_DROP_CONN* = -232 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:715:9
+    let NGTCP2_ERR_DROP_CONN* = -232 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:715:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_DROP_CONN" &
@@ -5374,9 +5378,9 @@ else:
 when not declared(NGTCP2_ERR_AEAD_LIMIT_REACHED):
   when -233 is static:
     const
-      NGTCP2_ERR_AEAD_LIMIT_REACHED* = -233 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:723:9
+      NGTCP2_ERR_AEAD_LIMIT_REACHED* = -233 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:723:9
   else:
-    let NGTCP2_ERR_AEAD_LIMIT_REACHED* = -233 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:723:9
+    let NGTCP2_ERR_AEAD_LIMIT_REACHED* = -233 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:723:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_AEAD_LIMIT_REACHED" &
@@ -5384,9 +5388,9 @@ else:
 when not declared(NGTCP2_ERR_NO_VIABLE_PATH):
   when -234 is static:
     const
-      NGTCP2_ERR_NO_VIABLE_PATH* = -234 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:731:9
+      NGTCP2_ERR_NO_VIABLE_PATH* = -234 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:731:9
   else:
-    let NGTCP2_ERR_NO_VIABLE_PATH* = -234 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:731:9
+    let NGTCP2_ERR_NO_VIABLE_PATH* = -234 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:731:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_NO_VIABLE_PATH" &
@@ -5394,9 +5398,9 @@ else:
 when not declared(NGTCP2_ERR_VERSION_NEGOTIATION):
   when -235 is static:
     const
-      NGTCP2_ERR_VERSION_NEGOTIATION* = -235 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:738:9
+      NGTCP2_ERR_VERSION_NEGOTIATION* = -235 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:738:9
   else:
-    let NGTCP2_ERR_VERSION_NEGOTIATION* = -235 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:738:9
+    let NGTCP2_ERR_VERSION_NEGOTIATION* = -235 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:738:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_VERSION_NEGOTIATION" &
@@ -5404,9 +5408,9 @@ else:
 when not declared(NGTCP2_ERR_HANDSHAKE_TIMEOUT):
   when -236 is static:
     const
-      NGTCP2_ERR_HANDSHAKE_TIMEOUT* = -236 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:745:9
+      NGTCP2_ERR_HANDSHAKE_TIMEOUT* = -236 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:745:9
   else:
-    let NGTCP2_ERR_HANDSHAKE_TIMEOUT* = -236 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:745:9
+    let NGTCP2_ERR_HANDSHAKE_TIMEOUT* = -236 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:745:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_HANDSHAKE_TIMEOUT" &
@@ -5414,9 +5418,9 @@ else:
 when not declared(NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE):
   when -237 is static:
     const
-      NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE* = -237 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:752:9
+      NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE* = -237 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:752:9
   else:
-    let NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE* = -237 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:752:9
+    let NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE* = -237 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:752:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_VERSION_NEGOTIATION_FAILURE" &
@@ -5424,9 +5428,9 @@ else:
 when not declared(NGTCP2_ERR_IDLE_CLOSE):
   when -238 is static:
     const
-      NGTCP2_ERR_IDLE_CLOSE* = -238 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:759:9
+      NGTCP2_ERR_IDLE_CLOSE* = -238 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:759:9
   else:
-    let NGTCP2_ERR_IDLE_CLOSE* = -238 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:759:9
+    let NGTCP2_ERR_IDLE_CLOSE* = -238 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:759:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_IDLE_CLOSE" &
@@ -5434,9 +5438,9 @@ else:
 when not declared(NGTCP2_ERR_FATAL):
   when -500 is static:
     const
-      NGTCP2_ERR_FATAL* = -500 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:767:9
+      NGTCP2_ERR_FATAL* = -500 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:767:9
   else:
-    let NGTCP2_ERR_FATAL* = -500 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:767:9
+    let NGTCP2_ERR_FATAL* = -500 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:767:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_FATAL" &
@@ -5444,9 +5448,9 @@ else:
 when not declared(NGTCP2_ERR_NOMEM):
   when -501 is static:
     const
-      NGTCP2_ERR_NOMEM* = -501 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:773:9
+      NGTCP2_ERR_NOMEM* = -501 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:773:9
   else:
-    let NGTCP2_ERR_NOMEM* = -501 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:773:9
+    let NGTCP2_ERR_NOMEM* = -501 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:773:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_NOMEM" &
@@ -5454,9 +5458,9 @@ else:
 when not declared(NGTCP2_ERR_CALLBACK_FAILURE):
   when -502 is static:
     const
-      NGTCP2_ERR_CALLBACK_FAILURE* = -502 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:780:9
+      NGTCP2_ERR_CALLBACK_FAILURE* = -502 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:780:9
   else:
-    let NGTCP2_ERR_CALLBACK_FAILURE* = -502 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:780:9
+    let NGTCP2_ERR_CALLBACK_FAILURE* = -502 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:780:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_ERR_CALLBACK_FAILURE" &
@@ -5464,9 +5468,9 @@ else:
 when not declared(NGTCP2_PKT_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_PKT_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:793:9
+      NGTCP2_PKT_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:793:9
   else:
-    let NGTCP2_PKT_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:793:9
+    let NGTCP2_PKT_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:793:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_FLAG_NONE" &
@@ -5474,9 +5478,9 @@ else:
 when not declared(NGTCP2_PKT_FLAG_LONG_FORM):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_PKT_FLAG_LONG_FORM* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:801:9
+      NGTCP2_PKT_FLAG_LONG_FORM* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:801:9
   else:
-    let NGTCP2_PKT_FLAG_LONG_FORM* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:801:9
+    let NGTCP2_PKT_FLAG_LONG_FORM* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:801:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_FLAG_LONG_FORM" &
@@ -5484,9 +5488,9 @@ else:
 when not declared(NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR):
   when cast[cuint](2'i64) is static:
     const
-      NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:809:9
+      NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:809:9
   else:
-    let NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:809:9
+    let NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:809:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_FLAG_FIXED_BIT_CLEAR" &
@@ -5494,9 +5498,9 @@ else:
 when not declared(NGTCP2_PKT_FLAG_KEY_PHASE):
   when cast[cuint](4'i64) is static:
     const
-      NGTCP2_PKT_FLAG_KEY_PHASE* = cast[cuint](4'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:816:9
+      NGTCP2_PKT_FLAG_KEY_PHASE* = cast[cuint](4'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:816:9
   else:
-    let NGTCP2_PKT_FLAG_KEY_PHASE* = cast[cuint](4'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:816:9
+    let NGTCP2_PKT_FLAG_KEY_PHASE* = cast[cuint](4'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:816:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PKT_FLAG_KEY_PHASE" &
@@ -5504,9 +5508,9 @@ else:
 when not declared(NGTCP2_NO_ERROR):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_NO_ERROR* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:868:9
+      NGTCP2_NO_ERROR* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:868:9
   else:
-    let NGTCP2_NO_ERROR* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:868:9
+    let NGTCP2_NO_ERROR* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:868:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_NO_ERROR" &
@@ -5514,9 +5518,9 @@ else:
 when not declared(NGTCP2_INTERNAL_ERROR):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_INTERNAL_ERROR* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:876:9
+      NGTCP2_INTERNAL_ERROR* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:876:9
   else:
-    let NGTCP2_INTERNAL_ERROR* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:876:9
+    let NGTCP2_INTERNAL_ERROR* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:876:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_INTERNAL_ERROR" &
@@ -5524,9 +5528,9 @@ else:
 when not declared(NGTCP2_CONNECTION_REFUSED):
   when cast[cuint](2'i64) is static:
     const
-      NGTCP2_CONNECTION_REFUSED* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:884:9
+      NGTCP2_CONNECTION_REFUSED* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:884:9
   else:
-    let NGTCP2_CONNECTION_REFUSED* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:884:9
+    let NGTCP2_CONNECTION_REFUSED* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:884:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CONNECTION_REFUSED" &
@@ -5534,9 +5538,9 @@ else:
 when not declared(NGTCP2_FLOW_CONTROL_ERROR):
   when cast[cuint](3'i64) is static:
     const
-      NGTCP2_FLOW_CONTROL_ERROR* = cast[cuint](3'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:892:9
+      NGTCP2_FLOW_CONTROL_ERROR* = cast[cuint](3'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:892:9
   else:
-    let NGTCP2_FLOW_CONTROL_ERROR* = cast[cuint](3'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:892:9
+    let NGTCP2_FLOW_CONTROL_ERROR* = cast[cuint](3'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:892:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_FLOW_CONTROL_ERROR" &
@@ -5544,9 +5548,9 @@ else:
 when not declared(NGTCP2_STREAM_LIMIT_ERROR):
   when cast[cuint](4'i64) is static:
     const
-      NGTCP2_STREAM_LIMIT_ERROR* = cast[cuint](4'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:900:9
+      NGTCP2_STREAM_LIMIT_ERROR* = cast[cuint](4'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:900:9
   else:
-    let NGTCP2_STREAM_LIMIT_ERROR* = cast[cuint](4'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:900:9
+    let NGTCP2_STREAM_LIMIT_ERROR* = cast[cuint](4'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:900:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_LIMIT_ERROR" &
@@ -5554,9 +5558,9 @@ else:
 when not declared(NGTCP2_STREAM_STATE_ERROR):
   when cast[cuint](5'i64) is static:
     const
-      NGTCP2_STREAM_STATE_ERROR* = cast[cuint](5'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:908:9
+      NGTCP2_STREAM_STATE_ERROR* = cast[cuint](5'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:908:9
   else:
-    let NGTCP2_STREAM_STATE_ERROR* = cast[cuint](5'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:908:9
+    let NGTCP2_STREAM_STATE_ERROR* = cast[cuint](5'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:908:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_STATE_ERROR" &
@@ -5564,9 +5568,9 @@ else:
 when not declared(NGTCP2_FINAL_SIZE_ERROR):
   when cast[cuint](6'i64) is static:
     const
-      NGTCP2_FINAL_SIZE_ERROR* = cast[cuint](6'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:916:9
+      NGTCP2_FINAL_SIZE_ERROR* = cast[cuint](6'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:916:9
   else:
-    let NGTCP2_FINAL_SIZE_ERROR* = cast[cuint](6'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:916:9
+    let NGTCP2_FINAL_SIZE_ERROR* = cast[cuint](6'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:916:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_FINAL_SIZE_ERROR" &
@@ -5574,9 +5578,9 @@ else:
 when not declared(NGTCP2_FRAME_ENCODING_ERROR):
   when cast[cuint](7'i64) is static:
     const
-      NGTCP2_FRAME_ENCODING_ERROR* = cast[cuint](7'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:924:9
+      NGTCP2_FRAME_ENCODING_ERROR* = cast[cuint](7'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:924:9
   else:
-    let NGTCP2_FRAME_ENCODING_ERROR* = cast[cuint](7'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:924:9
+    let NGTCP2_FRAME_ENCODING_ERROR* = cast[cuint](7'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:924:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_FRAME_ENCODING_ERROR" &
@@ -5584,9 +5588,9 @@ else:
 when not declared(NGTCP2_TRANSPORT_PARAMETER_ERROR):
   when cast[cuint](8'i64) is static:
     const
-      NGTCP2_TRANSPORT_PARAMETER_ERROR* = cast[cuint](8'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:932:9
+      NGTCP2_TRANSPORT_PARAMETER_ERROR* = cast[cuint](8'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:932:9
   else:
-    let NGTCP2_TRANSPORT_PARAMETER_ERROR* = cast[cuint](8'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:932:9
+    let NGTCP2_TRANSPORT_PARAMETER_ERROR* = cast[cuint](8'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:932:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_TRANSPORT_PARAMETER_ERROR" &
@@ -5594,9 +5598,9 @@ else:
 when not declared(NGTCP2_CONNECTION_ID_LIMIT_ERROR):
   when cast[cuint](9'i64) is static:
     const
-      NGTCP2_CONNECTION_ID_LIMIT_ERROR* = cast[cuint](9'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:940:9
+      NGTCP2_CONNECTION_ID_LIMIT_ERROR* = cast[cuint](9'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:940:9
   else:
-    let NGTCP2_CONNECTION_ID_LIMIT_ERROR* = cast[cuint](9'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:940:9
+    let NGTCP2_CONNECTION_ID_LIMIT_ERROR* = cast[cuint](9'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:940:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CONNECTION_ID_LIMIT_ERROR" &
@@ -5604,9 +5608,9 @@ else:
 when not declared(NGTCP2_PROTOCOL_VIOLATION):
   when cast[cuint](10'i64) is static:
     const
-      NGTCP2_PROTOCOL_VIOLATION* = cast[cuint](10'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:948:9
+      NGTCP2_PROTOCOL_VIOLATION* = cast[cuint](10'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:948:9
   else:
-    let NGTCP2_PROTOCOL_VIOLATION* = cast[cuint](10'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:948:9
+    let NGTCP2_PROTOCOL_VIOLATION* = cast[cuint](10'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:948:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PROTOCOL_VIOLATION" &
@@ -5614,9 +5618,9 @@ else:
 when not declared(NGTCP2_INVALID_TOKEN):
   when cast[cuint](11'i64) is static:
     const
-      NGTCP2_INVALID_TOKEN* = cast[cuint](11'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:956:9
+      NGTCP2_INVALID_TOKEN* = cast[cuint](11'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:956:9
   else:
-    let NGTCP2_INVALID_TOKEN* = cast[cuint](11'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:956:9
+    let NGTCP2_INVALID_TOKEN* = cast[cuint](11'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:956:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_INVALID_TOKEN" &
@@ -5624,9 +5628,9 @@ else:
 when not declared(NGTCP2_APPLICATION_ERROR):
   when cast[cuint](12'i64) is static:
     const
-      NGTCP2_APPLICATION_ERROR* = cast[cuint](12'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:964:9
+      NGTCP2_APPLICATION_ERROR* = cast[cuint](12'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:964:9
   else:
-    let NGTCP2_APPLICATION_ERROR* = cast[cuint](12'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:964:9
+    let NGTCP2_APPLICATION_ERROR* = cast[cuint](12'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:964:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_APPLICATION_ERROR" &
@@ -5634,9 +5638,9 @@ else:
 when not declared(NGTCP2_CRYPTO_BUFFER_EXCEEDED):
   when cast[cuint](13'i64) is static:
     const
-      NGTCP2_CRYPTO_BUFFER_EXCEEDED* = cast[cuint](13'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:972:9
+      NGTCP2_CRYPTO_BUFFER_EXCEEDED* = cast[cuint](13'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:972:9
   else:
-    let NGTCP2_CRYPTO_BUFFER_EXCEEDED* = cast[cuint](13'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:972:9
+    let NGTCP2_CRYPTO_BUFFER_EXCEEDED* = cast[cuint](13'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:972:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_BUFFER_EXCEEDED" &
@@ -5644,9 +5648,9 @@ else:
 when not declared(NGTCP2_KEY_UPDATE_ERROR):
   when cast[cuint](14'i64) is static:
     const
-      NGTCP2_KEY_UPDATE_ERROR* = cast[cuint](14'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:980:9
+      NGTCP2_KEY_UPDATE_ERROR* = cast[cuint](14'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:980:9
   else:
-    let NGTCP2_KEY_UPDATE_ERROR* = cast[cuint](14'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:980:9
+    let NGTCP2_KEY_UPDATE_ERROR* = cast[cuint](14'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:980:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_KEY_UPDATE_ERROR" &
@@ -5654,9 +5658,9 @@ else:
 when not declared(NGTCP2_AEAD_LIMIT_REACHED):
   when cast[cuint](15'i64) is static:
     const
-      NGTCP2_AEAD_LIMIT_REACHED* = cast[cuint](15'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:988:9
+      NGTCP2_AEAD_LIMIT_REACHED* = cast[cuint](15'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:988:9
   else:
-    let NGTCP2_AEAD_LIMIT_REACHED* = cast[cuint](15'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:988:9
+    let NGTCP2_AEAD_LIMIT_REACHED* = cast[cuint](15'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:988:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_AEAD_LIMIT_REACHED" &
@@ -5664,9 +5668,9 @@ else:
 when not declared(NGTCP2_NO_VIABLE_PATH):
   when cast[cuint](16'i64) is static:
     const
-      NGTCP2_NO_VIABLE_PATH* = cast[cuint](16'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:996:9
+      NGTCP2_NO_VIABLE_PATH* = cast[cuint](16'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:996:9
   else:
-    let NGTCP2_NO_VIABLE_PATH* = cast[cuint](16'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:996:9
+    let NGTCP2_NO_VIABLE_PATH* = cast[cuint](16'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:996:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_NO_VIABLE_PATH" &
@@ -5674,9 +5678,9 @@ else:
 when not declared(NGTCP2_CRYPTO_ERROR):
   when cast[cuint](256'i64) is static:
     const
-      NGTCP2_CRYPTO_ERROR* = cast[cuint](256'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1004:9
+      NGTCP2_CRYPTO_ERROR* = cast[cuint](256'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1004:9
   else:
-    let NGTCP2_CRYPTO_ERROR* = cast[cuint](256'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1004:9
+    let NGTCP2_CRYPTO_ERROR* = cast[cuint](256'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1004:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_ERROR" &
@@ -5684,9 +5688,9 @@ else:
 when not declared(NGTCP2_VERSION_NEGOTIATION_ERROR):
   when 17 is static:
     const
-      NGTCP2_VERSION_NEGOTIATION_ERROR* = 17 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1012:9
+      NGTCP2_VERSION_NEGOTIATION_ERROR* = 17 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1012:9
   else:
-    let NGTCP2_VERSION_NEGOTIATION_ERROR* = 17 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1012:9
+    let NGTCP2_VERSION_NEGOTIATION_ERROR* = 17 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1012:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_VERSION_NEGOTIATION_ERROR" &
@@ -5694,9 +5698,9 @@ else:
 when not declared(NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE):
   when 65527 is static:
     const
-      NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE* = 65527 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1197:9
+      NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE* = 65527 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1197:9
   else:
-    let NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE* = 65527 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1197:9
+    let NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE* = 65527 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1197:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_DEFAULT_MAX_RECV_UDP_PAYLOAD_SIZE" &
@@ -5704,9 +5708,9 @@ else:
 when not declared(NGTCP2_DEFAULT_ACK_DELAY_EXPONENT):
   when 3 is static:
     const
-      NGTCP2_DEFAULT_ACK_DELAY_EXPONENT* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1205:9
+      NGTCP2_DEFAULT_ACK_DELAY_EXPONENT* = 3 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1205:9
   else:
-    let NGTCP2_DEFAULT_ACK_DELAY_EXPONENT* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1205:9
+    let NGTCP2_DEFAULT_ACK_DELAY_EXPONENT* = 3 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1205:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_DEFAULT_ACK_DELAY_EXPONENT" &
@@ -5714,9 +5718,9 @@ else:
 when not declared(NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT):
   when 2 is static:
     const
-      NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1223:9
+      NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT* = 2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1223:9
   else:
-    let NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1223:9
+    let NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT* = 2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1223:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT" &
@@ -5724,9 +5728,9 @@ else:
 when not declared(NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1):
   when cast[cuint](57'i64) is static:
     const
-      NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1* = cast[cuint](57'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1231:9
+      NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1* = cast[cuint](57'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1231:9
   else:
-    let NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1* = cast[cuint](57'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1231:9
+    let NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1* = cast[cuint](57'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1231:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1" &
@@ -5734,9 +5738,9 @@ else:
 when not declared(NGTCP2_TRANSPORT_PARAMS_V1):
   when 1 is static:
     const
-      NGTCP2_TRANSPORT_PARAMS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1384:9
+      NGTCP2_TRANSPORT_PARAMS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1384:9
   else:
-    let NGTCP2_TRANSPORT_PARAMS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1384:9
+    let NGTCP2_TRANSPORT_PARAMS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1384:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_TRANSPORT_PARAMS_V1" &
@@ -5744,13 +5748,13 @@ else:
 when not declared(NGTCP2_TRANSPORT_PARAMS_VERSION):
   when NGTCP2_TRANSPORT_PARAMS_V1 is typedesc:
     type
-      NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
+      NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
   else:
     when NGTCP2_TRANSPORT_PARAMS_V1 is static:
       const
-        NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
+        NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
     else:
-      let NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
+      let NGTCP2_TRANSPORT_PARAMS_VERSION* = NGTCP2_TRANSPORT_PARAMS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1385:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_TRANSPORT_PARAMS_VERSION" &
@@ -5758,9 +5762,9 @@ else:
 when not declared(NGTCP2_CONN_INFO_V1):
   when 1 is static:
     const
-      NGTCP2_CONN_INFO_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1555:9
+      NGTCP2_CONN_INFO_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1555:9
   else:
-    let NGTCP2_CONN_INFO_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1555:9
+    let NGTCP2_CONN_INFO_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1555:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CONN_INFO_V1" &
@@ -5768,13 +5772,13 @@ else:
 when not declared(NGTCP2_CONN_INFO_VERSION):
   when NGTCP2_CONN_INFO_V1 is typedesc:
     type
-      NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
+      NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
   else:
     when NGTCP2_CONN_INFO_V1 is static:
       const
-        NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
+        NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
     else:
-      let NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
+      let NGTCP2_CONN_INFO_VERSION* = NGTCP2_CONN_INFO_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1556:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CONN_INFO_VERSION" &
@@ -5782,9 +5786,9 @@ else:
 when not declared(NGTCP2_QLOG_WRITE_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_QLOG_WRITE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1637:9
+      NGTCP2_QLOG_WRITE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1637:9
   else:
-    let NGTCP2_QLOG_WRITE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1637:9
+    let NGTCP2_QLOG_WRITE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1637:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_QLOG_WRITE_FLAG_NONE" &
@@ -5792,9 +5796,9 @@ else:
 when not declared(NGTCP2_QLOG_WRITE_FLAG_FIN):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_QLOG_WRITE_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1644:9
+      NGTCP2_QLOG_WRITE_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1644:9
   else:
-    let NGTCP2_QLOG_WRITE_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1644:9
+    let NGTCP2_QLOG_WRITE_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1644:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_QLOG_WRITE_FLAG_FIN" &
@@ -5802,9 +5806,9 @@ else:
 when not declared(NGTCP2_SETTINGS_V1):
   when 1 is static:
     const
-      NGTCP2_SETTINGS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1697:9
+      NGTCP2_SETTINGS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1697:9
   else:
-    let NGTCP2_SETTINGS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1697:9
+    let NGTCP2_SETTINGS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1697:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_SETTINGS_V1" &
@@ -5812,9 +5816,9 @@ else:
 when not declared(NGTCP2_SETTINGS_V2):
   when 2 is static:
     const
-      NGTCP2_SETTINGS_V2* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1698:9
+      NGTCP2_SETTINGS_V2* = 2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1698:9
   else:
-    let NGTCP2_SETTINGS_V2* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1698:9
+    let NGTCP2_SETTINGS_V2* = 2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1698:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_SETTINGS_V2" &
@@ -5822,13 +5826,13 @@ else:
 when not declared(NGTCP2_SETTINGS_VERSION):
   when NGTCP2_SETTINGS_V2 is typedesc:
     type
-      NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
+      NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
   else:
     when NGTCP2_SETTINGS_V2 is static:
       const
-        NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
+        NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
     else:
-      let NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
+      let NGTCP2_SETTINGS_VERSION* = NGTCP2_SETTINGS_V2 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:1699:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_SETTINGS_VERSION" &
@@ -5836,9 +5840,9 @@ else:
 when not declared(NGTCP2_STREAM_DATA_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_STREAM_DATA_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2657:9
+      NGTCP2_STREAM_DATA_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2657:9
   else:
-    let NGTCP2_STREAM_DATA_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2657:9
+    let NGTCP2_STREAM_DATA_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2657:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_DATA_FLAG_NONE" &
@@ -5846,9 +5850,9 @@ else:
 when not declared(NGTCP2_STREAM_DATA_FLAG_FIN):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_STREAM_DATA_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2665:9
+      NGTCP2_STREAM_DATA_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2665:9
   else:
-    let NGTCP2_STREAM_DATA_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2665:9
+    let NGTCP2_STREAM_DATA_FLAG_FIN* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2665:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_DATA_FLAG_FIN" &
@@ -5856,9 +5860,9 @@ else:
 when not declared(NGTCP2_STREAM_DATA_FLAG_0RTT):
   when cast[cuint](2'i64) is static:
     const
-      NGTCP2_STREAM_DATA_FLAG_0RTT* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2674:9
+      NGTCP2_STREAM_DATA_FLAG_0RTT* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2674:9
   else:
-    let NGTCP2_STREAM_DATA_FLAG_0RTT* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2674:9
+    let NGTCP2_STREAM_DATA_FLAG_0RTT* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2674:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_DATA_FLAG_0RTT" &
@@ -5866,9 +5870,9 @@ else:
 when not declared(NGTCP2_STREAM_CLOSE_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_STREAM_CLOSE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2729:9
+      NGTCP2_STREAM_CLOSE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2729:9
   else:
-    let NGTCP2_STREAM_CLOSE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2729:9
+    let NGTCP2_STREAM_CLOSE_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2729:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_CLOSE_FLAG_NONE" &
@@ -5876,9 +5880,9 @@ else:
 when not declared(NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2737:9
+      NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2737:9
   else:
-    let NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2737:9
+    let NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2737:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET" &
@@ -5886,9 +5890,9 @@ else:
 when not declared(NGTCP2_PATH_VALIDATION_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_PATH_VALIDATION_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2945:9
+      NGTCP2_PATH_VALIDATION_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2945:9
   else:
-    let NGTCP2_PATH_VALIDATION_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2945:9
+    let NGTCP2_PATH_VALIDATION_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2945:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PATH_VALIDATION_FLAG_NONE" &
@@ -5896,9 +5900,9 @@ else:
 when not declared(NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2954:9
+      NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2954:9
   else:
-    let NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2954:9
+    let NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2954:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PATH_VALIDATION_FLAG_PREFERRED_ADDR" &
@@ -5906,9 +5910,9 @@ else:
 when not declared(NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN):
   when cast[cuint](2'i64) is static:
     const
-      NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2963:9
+      NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2963:9
   else:
-    let NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2963:9
+    let NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:2963:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_PATH_VALIDATION_FLAG_NEW_TOKEN" &
@@ -5916,9 +5920,9 @@ else:
 when not declared(NGTCP2_DATAGRAM_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3112:9
+      NGTCP2_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3112:9
   else:
-    let NGTCP2_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3112:9
+    let NGTCP2_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3112:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_DATAGRAM_FLAG_NONE" &
@@ -5926,9 +5930,9 @@ else:
 when not declared(NGTCP2_DATAGRAM_FLAG_0RTT):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_DATAGRAM_FLAG_0RTT* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3121:9
+      NGTCP2_DATAGRAM_FLAG_0RTT* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3121:9
   else:
-    let NGTCP2_DATAGRAM_FLAG_0RTT* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3121:9
+    let NGTCP2_DATAGRAM_FLAG_0RTT* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3121:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_DATAGRAM_FLAG_0RTT" &
@@ -5936,9 +5940,9 @@ else:
 when not declared(NGTCP2_CALLBACKS_V1):
   when 1 is static:
     const
-      NGTCP2_CALLBACKS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3255:9
+      NGTCP2_CALLBACKS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3255:9
   else:
-    let NGTCP2_CALLBACKS_V1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3255:9
+    let NGTCP2_CALLBACKS_V1* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3255:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CALLBACKS_V1" &
@@ -5946,13 +5950,13 @@ else:
 when not declared(NGTCP2_CALLBACKS_VERSION):
   when NGTCP2_CALLBACKS_V1 is typedesc:
     type
-      NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
+      NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
   else:
     when NGTCP2_CALLBACKS_V1 is static:
       const
-        NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
+        NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
     else:
-      let NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
+      let NGTCP2_CALLBACKS_VERSION* = NGTCP2_CALLBACKS_V1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:3256:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CALLBACKS_VERSION" &
@@ -5960,9 +5964,9 @@ else:
 when not declared(NGTCP2_WRITE_STREAM_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_WRITE_STREAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4383:9
+      NGTCP2_WRITE_STREAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4383:9
   else:
-    let NGTCP2_WRITE_STREAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4383:9
+    let NGTCP2_WRITE_STREAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4383:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_WRITE_STREAM_FLAG_NONE" &
@@ -5970,9 +5974,9 @@ else:
 when not declared(NGTCP2_WRITE_STREAM_FLAG_MORE):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_WRITE_STREAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4391:9
+      NGTCP2_WRITE_STREAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4391:9
   else:
-    let NGTCP2_WRITE_STREAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4391:9
+    let NGTCP2_WRITE_STREAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4391:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_WRITE_STREAM_FLAG_MORE" &
@@ -5980,9 +5984,9 @@ else:
 when not declared(NGTCP2_WRITE_STREAM_FLAG_FIN):
   when cast[cuint](2'i64) is static:
     const
-      NGTCP2_WRITE_STREAM_FLAG_FIN* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4399:9
+      NGTCP2_WRITE_STREAM_FLAG_FIN* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4399:9
   else:
-    let NGTCP2_WRITE_STREAM_FLAG_FIN* = cast[cuint](2'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4399:9
+    let NGTCP2_WRITE_STREAM_FLAG_FIN* = cast[cuint](2'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4399:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_WRITE_STREAM_FLAG_FIN" &
@@ -5990,9 +5994,9 @@ else:
 when not declared(NGTCP2_WRITE_DATAGRAM_FLAG_NONE):
   when cast[cuint](0'i64) is static:
     const
-      NGTCP2_WRITE_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4579:9
+      NGTCP2_WRITE_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4579:9
   else:
-    let NGTCP2_WRITE_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4579:9
+    let NGTCP2_WRITE_DATAGRAM_FLAG_NONE* = cast[cuint](0'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4579:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_WRITE_DATAGRAM_FLAG_NONE" &
@@ -6000,9 +6004,9 @@ else:
 when not declared(NGTCP2_WRITE_DATAGRAM_FLAG_MORE):
   when cast[cuint](1'i64) is static:
     const
-      NGTCP2_WRITE_DATAGRAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4587:9
+      NGTCP2_WRITE_DATAGRAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4587:9
   else:
-    let NGTCP2_WRITE_DATAGRAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4587:9
+    let NGTCP2_WRITE_DATAGRAM_FLAG_MORE* = cast[cuint](1'i64) ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:4587:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_WRITE_DATAGRAM_FLAG_MORE" &
@@ -6010,9 +6014,9 @@ else:
 when not declared(NGTCP2_VERSION_AGE):
   when 1 is static:
     const
-      NGTCP2_VERSION_AGE* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5667:9
+      NGTCP2_VERSION_AGE* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5667:9
   else:
-    let NGTCP2_VERSION_AGE* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5667:9
+    let NGTCP2_VERSION_AGE* = 1 ## Generated based on /nim-ngtcp2/libs/ngtcp2/lib/includes/ngtcp2/ngtcp2.h:5667:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_VERSION_AGE" &
@@ -6020,9 +6024,9 @@ else:
 when not declared(NGTCP2_CRYPTO_ERR_INTERNAL):
   when -201 is static:
     const
-      NGTCP2_CRYPTO_ERR_INTERNAL* = -201 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:52:9
+      NGTCP2_CRYPTO_ERR_INTERNAL* = -201 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:52:9
   else:
-    let NGTCP2_CRYPTO_ERR_INTERNAL* = -201 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:52:9
+    let NGTCP2_CRYPTO_ERR_INTERNAL* = -201 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:52:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_ERR_INTERNAL" &
@@ -6030,9 +6034,9 @@ else:
 when not declared(NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN):
   when -202 is static:
     const
-      NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN* = -202 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:61:9
+      NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN* = -202 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:61:9
   else:
-    let NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN* = -202 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:61:9
+    let NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN* = -202 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:61:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_ERR_UNREADABLE_TOKEN" &
@@ -6040,9 +6044,9 @@ else:
 when not declared(NGTCP2_CRYPTO_ERR_VERIFY_TOKEN):
   when -203 is static:
     const
-      NGTCP2_CRYPTO_ERR_VERIFY_TOKEN* = -203 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:70:9
+      NGTCP2_CRYPTO_ERR_VERIFY_TOKEN* = -203 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:70:9
   else:
-    let NGTCP2_CRYPTO_ERR_VERIFY_TOKEN* = -203 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:70:9
+    let NGTCP2_CRYPTO_ERR_VERIFY_TOKEN* = -203 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:70:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_ERR_VERIFY_TOKEN" &
@@ -6050,9 +6054,9 @@ else:
 when not declared(NGTCP2_CRYPTO_TOKEN_RAND_DATALEN):
   when 16 is static:
     const
-      NGTCP2_CRYPTO_TOKEN_RAND_DATALEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:571:9
+      NGTCP2_CRYPTO_TOKEN_RAND_DATALEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:571:9
   else:
-    let NGTCP2_CRYPTO_TOKEN_RAND_DATALEN* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:571:9
+    let NGTCP2_CRYPTO_TOKEN_RAND_DATALEN* = 16 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:571:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_TOKEN_RAND_DATALEN" &
@@ -6060,9 +6064,9 @@ else:
 when not declared(NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY):
   when 182 is static:
     const
-      NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY* = 182 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:579:9
+      NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY* = 182 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:579:9
   else:
-    let NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY* = 182 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:579:9
+    let NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY* = 182 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:579:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY" &
@@ -6070,9 +6074,9 @@ else:
 when not declared(NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2):
   when 183 is static:
     const
-      NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2* = 183 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:587:9
+      NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2* = 183 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:587:9
   else:
-    let NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2* = 183 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:587:9
+    let NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2* = 183 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:587:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_TOKEN_MAGIC_RETRY2" &
@@ -6080,9 +6084,9 @@ else:
 when not declared(NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR):
   when 54 is static:
     const
-      NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR* = 54 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:595:9
+      NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR* = 54 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:595:9
   else:
-    let NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR* = 54 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:595:9
+    let NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR* = 54 ## Generated based on /nim-ngtcp2/libs/ngtcp2/crypto/includes/ngtcp2/ngtcp2_crypto.h:595:9
 else:
   static :
     hint("Declaration of " & "NGTCP2_CRYPTO_TOKEN_MAGIC_REGULAR" &
@@ -6090,9 +6094,9 @@ else:
 when not declared(PTLS_HAVE_LOG):
   when 1 is static:
     const
-      PTLS_HAVE_LOG* = 1     ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:77:9
+      PTLS_HAVE_LOG* = 1     ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:77:9
   else:
-    let PTLS_HAVE_LOG* = 1   ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:77:9
+    let PTLS_HAVE_LOG* = 1   ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:77:9
 else:
   static :
     hint("Declaration of " & "PTLS_HAVE_LOG" &
@@ -6100,9 +6104,9 @@ else:
 when not declared(PTLS_FUZZ_HANDSHAKE):
   when 0 is static:
     const
-      PTLS_FUZZ_HANDSHAKE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:82:9
+      PTLS_FUZZ_HANDSHAKE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:82:9
   else:
-    let PTLS_FUZZ_HANDSHAKE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:82:9
+    let PTLS_FUZZ_HANDSHAKE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:82:9
 else:
   static :
     hint("Declaration of " & "PTLS_FUZZ_HANDSHAKE" &
@@ -6110,9 +6114,9 @@ else:
 when not declared(PTLS_HELLO_RANDOM_SIZE):
   when 32 is static:
     const
-      PTLS_HELLO_RANDOM_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:85:9
+      PTLS_HELLO_RANDOM_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:85:9
   else:
-    let PTLS_HELLO_RANDOM_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:85:9
+    let PTLS_HELLO_RANDOM_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:85:9
 else:
   static :
     hint("Declaration of " & "PTLS_HELLO_RANDOM_SIZE" &
@@ -6120,9 +6124,9 @@ else:
 when not declared(PTLS_AES128_KEY_SIZE):
   when 16 is static:
     const
-      PTLS_AES128_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:87:9
+      PTLS_AES128_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:87:9
   else:
-    let PTLS_AES128_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:87:9
+    let PTLS_AES128_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:87:9
 else:
   static :
     hint("Declaration of " & "PTLS_AES128_KEY_SIZE" &
@@ -6130,9 +6134,9 @@ else:
 when not declared(PTLS_AES256_KEY_SIZE):
   when 32 is static:
     const
-      PTLS_AES256_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:88:9
+      PTLS_AES256_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:88:9
   else:
-    let PTLS_AES256_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:88:9
+    let PTLS_AES256_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:88:9
 else:
   static :
     hint("Declaration of " & "PTLS_AES256_KEY_SIZE" &
@@ -6140,9 +6144,9 @@ else:
 when not declared(PTLS_AES_BLOCK_SIZE):
   when 16 is static:
     const
-      PTLS_AES_BLOCK_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:89:9
+      PTLS_AES_BLOCK_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:89:9
   else:
-    let PTLS_AES_BLOCK_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:89:9
+    let PTLS_AES_BLOCK_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:89:9
 else:
   static :
     hint("Declaration of " & "PTLS_AES_BLOCK_SIZE" &
@@ -6150,9 +6154,9 @@ else:
 when not declared(PTLS_AES_IV_SIZE):
   when 16 is static:
     const
-      PTLS_AES_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:90:9
+      PTLS_AES_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:90:9
   else:
-    let PTLS_AES_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:90:9
+    let PTLS_AES_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:90:9
 else:
   static :
     hint("Declaration of " & "PTLS_AES_IV_SIZE" &
@@ -6160,9 +6164,9 @@ else:
 when not declared(PTLS_AESGCM_IV_SIZE):
   when 12 is static:
     const
-      PTLS_AESGCM_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:91:9
+      PTLS_AESGCM_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:91:9
   else:
-    let PTLS_AESGCM_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:91:9
+    let PTLS_AESGCM_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:91:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESGCM_IV_SIZE" &
@@ -6170,9 +6174,9 @@ else:
 when not declared(PTLS_AESGCM_TAG_SIZE):
   when 16 is static:
     const
-      PTLS_AESGCM_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:92:9
+      PTLS_AESGCM_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:92:9
   else:
-    let PTLS_AESGCM_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:92:9
+    let PTLS_AESGCM_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:92:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESGCM_TAG_SIZE" &
@@ -6180,9 +6184,9 @@ else:
 when not declared(PTLS_AESGCM_CONFIDENTIALITY_LIMIT):
   when 33554432 is static:
     const
-      PTLS_AESGCM_CONFIDENTIALITY_LIMIT* = 33554432 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:93:9
+      PTLS_AESGCM_CONFIDENTIALITY_LIMIT* = 33554432 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:93:9
   else:
-    let PTLS_AESGCM_CONFIDENTIALITY_LIMIT* = 33554432 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:93:9
+    let PTLS_AESGCM_CONFIDENTIALITY_LIMIT* = 33554432 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:93:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESGCM_CONFIDENTIALITY_LIMIT" &
@@ -6190,9 +6194,9 @@ else:
 when not declared(PTLS_AESGCM_INTEGRITY_LIMIT):
   when cast[culonglong](18014398509481984'i64) is static:
     const
-      PTLS_AESGCM_INTEGRITY_LIMIT* = cast[culonglong](18014398509481984'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:94:9
+      PTLS_AESGCM_INTEGRITY_LIMIT* = cast[culonglong](18014398509481984'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:94:9
   else:
-    let PTLS_AESGCM_INTEGRITY_LIMIT* = cast[culonglong](18014398509481984'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:94:9
+    let PTLS_AESGCM_INTEGRITY_LIMIT* = cast[culonglong](18014398509481984'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:94:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESGCM_INTEGRITY_LIMIT" &
@@ -6200,9 +6204,9 @@ else:
 when not declared(PTLS_AESCCM_CONFIDENTIALITY_LIMIT):
   when 11863283 is static:
     const
-      PTLS_AESCCM_CONFIDENTIALITY_LIMIT* = 11863283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:95:9
+      PTLS_AESCCM_CONFIDENTIALITY_LIMIT* = 11863283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:95:9
   else:
-    let PTLS_AESCCM_CONFIDENTIALITY_LIMIT* = 11863283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:95:9
+    let PTLS_AESCCM_CONFIDENTIALITY_LIMIT* = 11863283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:95:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESCCM_CONFIDENTIALITY_LIMIT" &
@@ -6210,9 +6214,9 @@ else:
 when not declared(PTLS_AESCCM_INTEGRITY_LIMIT):
   when 11863283 is static:
     const
-      PTLS_AESCCM_INTEGRITY_LIMIT* = 11863283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:96:9
+      PTLS_AESCCM_INTEGRITY_LIMIT* = 11863283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:96:9
   else:
-    let PTLS_AESCCM_INTEGRITY_LIMIT* = 11863283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:96:9
+    let PTLS_AESCCM_INTEGRITY_LIMIT* = 11863283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:96:9
 else:
   static :
     hint("Declaration of " & "PTLS_AESCCM_INTEGRITY_LIMIT" &
@@ -6220,9 +6224,9 @@ else:
 when not declared(PTLS_CHACHA20_KEY_SIZE):
   when 32 is static:
     const
-      PTLS_CHACHA20_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:98:9
+      PTLS_CHACHA20_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:98:9
   else:
-    let PTLS_CHACHA20_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:98:9
+    let PTLS_CHACHA20_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:98:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20_KEY_SIZE" &
@@ -6230,9 +6234,9 @@ else:
 when not declared(PTLS_CHACHA20_IV_SIZE):
   when 16 is static:
     const
-      PTLS_CHACHA20_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:99:9
+      PTLS_CHACHA20_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:99:9
   else:
-    let PTLS_CHACHA20_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:99:9
+    let PTLS_CHACHA20_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:99:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20_IV_SIZE" &
@@ -6240,9 +6244,9 @@ else:
 when not declared(PTLS_CHACHA20POLY1305_IV_SIZE):
   when 12 is static:
     const
-      PTLS_CHACHA20POLY1305_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:100:9
+      PTLS_CHACHA20POLY1305_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:100:9
   else:
-    let PTLS_CHACHA20POLY1305_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:100:9
+    let PTLS_CHACHA20POLY1305_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:100:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20POLY1305_IV_SIZE" &
@@ -6250,9 +6254,9 @@ else:
 when not declared(PTLS_CHACHA20POLY1305_TAG_SIZE):
   when 16 is static:
     const
-      PTLS_CHACHA20POLY1305_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:101:9
+      PTLS_CHACHA20POLY1305_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:101:9
   else:
-    let PTLS_CHACHA20POLY1305_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:101:9
+    let PTLS_CHACHA20POLY1305_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:101:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20POLY1305_TAG_SIZE" &
@@ -6260,13 +6264,13 @@ else:
 when not declared(PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT):
   when UINT64_MAX is typedesc:
     type
-      PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:102:9
+      PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:102:9
   else:
     when UINT64_MAX is static:
       const
-        PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:102:9
+        PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:102:9
     else:
-      let PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:102:9
+      let PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:102:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT" &
@@ -6274,9 +6278,9 @@ else:
 when not declared(PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT):
   when cast[culonglong](68719476736'i64) is static:
     const
-      PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT* = cast[culonglong](68719476736'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:103:9
+      PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT* = cast[culonglong](68719476736'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:103:9
   else:
-    let PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT* = cast[culonglong](68719476736'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:103:9
+    let PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT* = cast[culonglong](68719476736'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:103:9
 else:
   static :
     hint("Declaration of " & "PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT" &
@@ -6284,9 +6288,9 @@ else:
 when not declared(PTLS_AEGIS128L_KEY_SIZE):
   when 16 is static:
     const
-      PTLS_AEGIS128L_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:105:9
+      PTLS_AEGIS128L_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:105:9
   else:
-    let PTLS_AEGIS128L_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:105:9
+    let PTLS_AEGIS128L_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:105:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS128L_KEY_SIZE" &
@@ -6294,9 +6298,9 @@ else:
 when not declared(PTLS_AEGIS128L_IV_SIZE):
   when 16 is static:
     const
-      PTLS_AEGIS128L_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:106:9
+      PTLS_AEGIS128L_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:106:9
   else:
-    let PTLS_AEGIS128L_IV_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:106:9
+    let PTLS_AEGIS128L_IV_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:106:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS128L_IV_SIZE" &
@@ -6304,9 +6308,9 @@ else:
 when not declared(PTLS_AEGIS128L_TAG_SIZE):
   when 16 is static:
     const
-      PTLS_AEGIS128L_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:107:9
+      PTLS_AEGIS128L_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:107:9
   else:
-    let PTLS_AEGIS128L_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:107:9
+    let PTLS_AEGIS128L_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:107:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS128L_TAG_SIZE" &
@@ -6314,13 +6318,13 @@ else:
 when not declared(PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT):
   when UINT64_MAX is typedesc:
     type
-      PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:108:9
+      PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:108:9
   else:
     when UINT64_MAX is static:
       const
-        PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:108:9
+        PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:108:9
     else:
-      let PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:108:9
+      let PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:108:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS128L_CONFIDENTIALITY_LIMIT" &
@@ -6328,9 +6332,9 @@ else:
 when not declared(PTLS_AEGIS128L_INTEGRITY_LIMIT):
   when cast[culonglong](281474976710656'i64) is static:
     const
-      PTLS_AEGIS128L_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:109:9
+      PTLS_AEGIS128L_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:109:9
   else:
-    let PTLS_AEGIS128L_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:109:9
+    let PTLS_AEGIS128L_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:109:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS128L_INTEGRITY_LIMIT" &
@@ -6338,9 +6342,9 @@ else:
 when not declared(PTLS_AEGIS256_KEY_SIZE):
   when 32 is static:
     const
-      PTLS_AEGIS256_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:111:9
+      PTLS_AEGIS256_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:111:9
   else:
-    let PTLS_AEGIS256_KEY_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:111:9
+    let PTLS_AEGIS256_KEY_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:111:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS256_KEY_SIZE" &
@@ -6348,9 +6352,9 @@ else:
 when not declared(PTLS_AEGIS256_IV_SIZE):
   when 32 is static:
     const
-      PTLS_AEGIS256_IV_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:112:9
+      PTLS_AEGIS256_IV_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:112:9
   else:
-    let PTLS_AEGIS256_IV_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:112:9
+    let PTLS_AEGIS256_IV_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:112:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS256_IV_SIZE" &
@@ -6358,9 +6362,9 @@ else:
 when not declared(PTLS_AEGIS256_TAG_SIZE):
   when 16 is static:
     const
-      PTLS_AEGIS256_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:113:9
+      PTLS_AEGIS256_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:113:9
   else:
-    let PTLS_AEGIS256_TAG_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:113:9
+    let PTLS_AEGIS256_TAG_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:113:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS256_TAG_SIZE" &
@@ -6368,13 +6372,13 @@ else:
 when not declared(PTLS_AEGIS256_CONFIDENTIALITY_LIMIT):
   when UINT64_MAX is typedesc:
     type
-      PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:114:9
+      PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:114:9
   else:
     when UINT64_MAX is static:
       const
-        PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:114:9
+        PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:114:9
     else:
-      let PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:114:9
+      let PTLS_AEGIS256_CONFIDENTIALITY_LIMIT* = UINT64_MAX ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:114:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS256_CONFIDENTIALITY_LIMIT" &
@@ -6382,9 +6386,9 @@ else:
 when not declared(PTLS_AEGIS256_INTEGRITY_LIMIT):
   when cast[culonglong](281474976710656'i64) is static:
     const
-      PTLS_AEGIS256_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:115:9
+      PTLS_AEGIS256_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:115:9
   else:
-    let PTLS_AEGIS256_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:115:9
+    let PTLS_AEGIS256_INTEGRITY_LIMIT* = cast[culonglong](281474976710656'i64) ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:115:9
 else:
   static :
     hint("Declaration of " & "PTLS_AEGIS256_INTEGRITY_LIMIT" &
@@ -6392,9 +6396,9 @@ else:
 when not declared(PTLS_BLOWFISH_KEY_SIZE):
   when 16 is static:
     const
-      PTLS_BLOWFISH_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:117:9
+      PTLS_BLOWFISH_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:117:9
   else:
-    let PTLS_BLOWFISH_KEY_SIZE* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:117:9
+    let PTLS_BLOWFISH_KEY_SIZE* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:117:9
 else:
   static :
     hint("Declaration of " & "PTLS_BLOWFISH_KEY_SIZE" &
@@ -6402,9 +6406,9 @@ else:
 when not declared(PTLS_BLOWFISH_BLOCK_SIZE):
   when 8 is static:
     const
-      PTLS_BLOWFISH_BLOCK_SIZE* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:118:9
+      PTLS_BLOWFISH_BLOCK_SIZE* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:118:9
   else:
-    let PTLS_BLOWFISH_BLOCK_SIZE* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:118:9
+    let PTLS_BLOWFISH_BLOCK_SIZE* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:118:9
 else:
   static :
     hint("Declaration of " & "PTLS_BLOWFISH_BLOCK_SIZE" &
@@ -6412,9 +6416,9 @@ else:
 when not declared(PTLS_SHA256_BLOCK_SIZE):
   when 64 is static:
     const
-      PTLS_SHA256_BLOCK_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:120:9
+      PTLS_SHA256_BLOCK_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:120:9
   else:
-    let PTLS_SHA256_BLOCK_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:120:9
+    let PTLS_SHA256_BLOCK_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:120:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA256_BLOCK_SIZE" &
@@ -6422,9 +6426,9 @@ else:
 when not declared(PTLS_SHA256_DIGEST_SIZE):
   when 32 is static:
     const
-      PTLS_SHA256_DIGEST_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:121:9
+      PTLS_SHA256_DIGEST_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:121:9
   else:
-    let PTLS_SHA256_DIGEST_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:121:9
+    let PTLS_SHA256_DIGEST_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:121:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA256_DIGEST_SIZE" &
@@ -6432,9 +6436,9 @@ else:
 when not declared(PTLS_SHA384_BLOCK_SIZE):
   when 128 is static:
     const
-      PTLS_SHA384_BLOCK_SIZE* = 128 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:123:9
+      PTLS_SHA384_BLOCK_SIZE* = 128 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:123:9
   else:
-    let PTLS_SHA384_BLOCK_SIZE* = 128 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:123:9
+    let PTLS_SHA384_BLOCK_SIZE* = 128 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:123:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA384_BLOCK_SIZE" &
@@ -6442,9 +6446,9 @@ else:
 when not declared(PTLS_SHA384_DIGEST_SIZE):
   when 48 is static:
     const
-      PTLS_SHA384_DIGEST_SIZE* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:124:9
+      PTLS_SHA384_DIGEST_SIZE* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:124:9
   else:
-    let PTLS_SHA384_DIGEST_SIZE* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:124:9
+    let PTLS_SHA384_DIGEST_SIZE* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:124:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA384_DIGEST_SIZE" &
@@ -6452,9 +6456,9 @@ else:
 when not declared(PTLS_SHA512_BLOCK_SIZE):
   when 128 is static:
     const
-      PTLS_SHA512_BLOCK_SIZE* = 128 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:126:9
+      PTLS_SHA512_BLOCK_SIZE* = 128 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:126:9
   else:
-    let PTLS_SHA512_BLOCK_SIZE* = 128 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:126:9
+    let PTLS_SHA512_BLOCK_SIZE* = 128 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:126:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA512_BLOCK_SIZE" &
@@ -6462,9 +6466,9 @@ else:
 when not declared(PTLS_SHA512_DIGEST_SIZE):
   when 64 is static:
     const
-      PTLS_SHA512_DIGEST_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:127:9
+      PTLS_SHA512_DIGEST_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:127:9
   else:
-    let PTLS_SHA512_DIGEST_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:127:9
+    let PTLS_SHA512_DIGEST_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:127:9
 else:
   static :
     hint("Declaration of " & "PTLS_SHA512_DIGEST_SIZE" &
@@ -6472,9 +6476,9 @@ else:
 when not declared(PTLS_MAX_SECRET_SIZE):
   when 32 is static:
     const
-      PTLS_MAX_SECRET_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:129:9
+      PTLS_MAX_SECRET_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:129:9
   else:
-    let PTLS_MAX_SECRET_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:129:9
+    let PTLS_MAX_SECRET_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:129:9
 else:
   static :
     hint("Declaration of " & "PTLS_MAX_SECRET_SIZE" &
@@ -6482,9 +6486,9 @@ else:
 when not declared(PTLS_MAX_IV_SIZE):
   when 32 is static:
     const
-      PTLS_MAX_IV_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:130:9
+      PTLS_MAX_IV_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:130:9
   else:
-    let PTLS_MAX_IV_SIZE* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:130:9
+    let PTLS_MAX_IV_SIZE* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:130:9
 else:
   static :
     hint("Declaration of " & "PTLS_MAX_IV_SIZE" &
@@ -6492,9 +6496,9 @@ else:
 when not declared(PTLS_MAX_DIGEST_SIZE):
   when 64 is static:
     const
-      PTLS_MAX_DIGEST_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:131:9
+      PTLS_MAX_DIGEST_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:131:9
   else:
-    let PTLS_MAX_DIGEST_SIZE* = 64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:131:9
+    let PTLS_MAX_DIGEST_SIZE* = 64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:131:9
 else:
   static :
     hint("Declaration of " & "PTLS_MAX_DIGEST_SIZE" &
@@ -6502,9 +6506,9 @@ else:
 when not declared(PTLS_PROTOCOL_VERSION_TLS12):
   when 771 is static:
     const
-      PTLS_PROTOCOL_VERSION_TLS12* = 771 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:134:9
+      PTLS_PROTOCOL_VERSION_TLS12* = 771 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:134:9
   else:
-    let PTLS_PROTOCOL_VERSION_TLS12* = 771 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:134:9
+    let PTLS_PROTOCOL_VERSION_TLS12* = 771 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:134:9
 else:
   static :
     hint("Declaration of " & "PTLS_PROTOCOL_VERSION_TLS12" &
@@ -6512,9 +6516,9 @@ else:
 when not declared(PTLS_PROTOCOL_VERSION_TLS13):
   when 772 is static:
     const
-      PTLS_PROTOCOL_VERSION_TLS13* = 772 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:135:9
+      PTLS_PROTOCOL_VERSION_TLS13* = 772 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:135:9
   else:
-    let PTLS_PROTOCOL_VERSION_TLS13* = 772 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:135:9
+    let PTLS_PROTOCOL_VERSION_TLS13* = 772 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:135:9
 else:
   static :
     hint("Declaration of " & "PTLS_PROTOCOL_VERSION_TLS13" &
@@ -6522,9 +6526,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_AES_128_GCM_SHA256):
   when 4865 is static:
     const
-      PTLS_CIPHER_SUITE_AES_128_GCM_SHA256* = 4865 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:138:9
+      PTLS_CIPHER_SUITE_AES_128_GCM_SHA256* = 4865 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:138:9
   else:
-    let PTLS_CIPHER_SUITE_AES_128_GCM_SHA256* = 4865 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:138:9
+    let PTLS_CIPHER_SUITE_AES_128_GCM_SHA256* = 4865 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:138:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_AES_128_GCM_SHA256" &
@@ -6532,9 +6536,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256):
   when "TLS_AES_128_GCM_SHA256" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256* = "TLS_AES_128_GCM_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:139:9
+      PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256* = "TLS_AES_128_GCM_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:139:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256* = "TLS_AES_128_GCM_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:139:9
+    let PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256* = "TLS_AES_128_GCM_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:139:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256" &
@@ -6542,9 +6546,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_AES_256_GCM_SHA384):
   when 4866 is static:
     const
-      PTLS_CIPHER_SUITE_AES_256_GCM_SHA384* = 4866 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:140:9
+      PTLS_CIPHER_SUITE_AES_256_GCM_SHA384* = 4866 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:140:9
   else:
-    let PTLS_CIPHER_SUITE_AES_256_GCM_SHA384* = 4866 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:140:9
+    let PTLS_CIPHER_SUITE_AES_256_GCM_SHA384* = 4866 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:140:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_AES_256_GCM_SHA384" &
@@ -6552,9 +6556,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384):
   when "TLS_AES_256_GCM_SHA384" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384* = "TLS_AES_256_GCM_SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:141:9
+      PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384* = "TLS_AES_256_GCM_SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:141:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384* = "TLS_AES_256_GCM_SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:141:9
+    let PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384* = "TLS_AES_256_GCM_SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:141:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384" &
@@ -6562,9 +6566,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256):
   when 4867 is static:
     const
-      PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256* = 4867 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:142:9
+      PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256* = 4867 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:142:9
   else:
-    let PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256* = 4867 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:142:9
+    let PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256* = 4867 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:142:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256" &
@@ -6572,9 +6576,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256):
   when "TLS_CHACHA20_POLY1305_SHA256" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256* = "TLS_CHACHA20_POLY1305_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:143:9
+      PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256* = "TLS_CHACHA20_POLY1305_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:143:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256* = "TLS_CHACHA20_POLY1305_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:143:9
+    let PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256* = "TLS_CHACHA20_POLY1305_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:143:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256" &
@@ -6582,9 +6586,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_AEGIS256_SHA512):
   when 4870 is static:
     const
-      PTLS_CIPHER_SUITE_AEGIS256_SHA512* = 4870 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:144:9
+      PTLS_CIPHER_SUITE_AEGIS256_SHA512* = 4870 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:144:9
   else:
-    let PTLS_CIPHER_SUITE_AEGIS256_SHA512* = 4870 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:144:9
+    let PTLS_CIPHER_SUITE_AEGIS256_SHA512* = 4870 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:144:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_AEGIS256_SHA512" &
@@ -6592,9 +6596,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512):
   when "TLS_AEGIS_256_SHA512" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512* = "TLS_AEGIS_256_SHA512" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:145:9
+      PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512* = "TLS_AEGIS_256_SHA512" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:145:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512* = "TLS_AEGIS_256_SHA512" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:145:9
+    let PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512* = "TLS_AEGIS_256_SHA512" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:145:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_NAME_AEGIS256_SHA512" &
@@ -6602,9 +6606,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_AEGIS128L_SHA256):
   when 4871 is static:
     const
-      PTLS_CIPHER_SUITE_AEGIS128L_SHA256* = 4871 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:146:9
+      PTLS_CIPHER_SUITE_AEGIS128L_SHA256* = 4871 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:146:9
   else:
-    let PTLS_CIPHER_SUITE_AEGIS128L_SHA256* = 4871 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:146:9
+    let PTLS_CIPHER_SUITE_AEGIS128L_SHA256* = 4871 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:146:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_AEGIS128L_SHA256" &
@@ -6612,9 +6616,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256):
   when "TLS_AEGIS_128L_SHA256" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256* = "TLS_AEGIS_128L_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:147:9
+      PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256* = "TLS_AEGIS_128L_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:147:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256* = "TLS_AEGIS_128L_SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:147:9
+    let PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256* = "TLS_AEGIS_128L_SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:147:9
 else:
   static :
     hint("Declaration of " & "PTLS_CIPHER_SUITE_NAME_AEGIS128L_SHA256" &
@@ -6622,9 +6626,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256):
   when 49195 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = 49195 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:150:9
+      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = 49195 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:150:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = 49195 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:150:9
+    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = 49195 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:150:9
 else:
   static :
     hint("Declaration of " &
@@ -6633,9 +6637,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256):
   when "ECDHE-ECDSA-AES128-GCM-SHA256" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = "ECDHE-ECDSA-AES128-GCM-SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:151:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = "ECDHE-ECDSA-AES128-GCM-SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:151:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = "ECDHE-ECDSA-AES128-GCM-SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:151:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256* = "ECDHE-ECDSA-AES128-GCM-SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:151:9
 else:
   static :
     hint("Declaration of " &
@@ -6644,9 +6648,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384):
   when 49196 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = 49196 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:152:9
+      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = 49196 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:152:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = 49196 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:152:9
+    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = 49196 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:152:9
 else:
   static :
     hint("Declaration of " &
@@ -6655,9 +6659,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384):
   when "ECDHE-ECDSA-AES256-GCM-SHA384" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = "ECDHE-ECDSA-AES256-GCM-SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:153:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = "ECDHE-ECDSA-AES256-GCM-SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:153:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = "ECDHE-ECDSA-AES256-GCM-SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:153:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384* = "ECDHE-ECDSA-AES256-GCM-SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:153:9
 else:
   static :
     hint("Declaration of " &
@@ -6666,9 +6670,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256):
   when 49199 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = 49199 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:154:9
+      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = 49199 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:154:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = 49199 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:154:9
+    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = 49199 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:154:9
 else:
   static :
     hint("Declaration of " &
@@ -6677,9 +6681,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_128_GCM_SHA256):
   when "ECDHE-RSA-AES128-GCM-SHA256" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = "ECDHE-RSA-AES128-GCM-SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:155:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = "ECDHE-RSA-AES128-GCM-SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:155:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = "ECDHE-RSA-AES128-GCM-SHA256" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:155:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_128_GCM_SHA256* = "ECDHE-RSA-AES128-GCM-SHA256" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:155:9
 else:
   static :
     hint("Declaration of " &
@@ -6688,9 +6692,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384):
   when 49200 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = 49200 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:156:9
+      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = 49200 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:156:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = 49200 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:156:9
+    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = 49200 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:156:9
 else:
   static :
     hint("Declaration of " &
@@ -6699,9 +6703,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_256_GCM_SHA384):
   when "ECDHE-RSA-AES256-GCM-SHA384" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = "ECDHE-RSA-AES256-GCM-SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:157:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = "ECDHE-RSA-AES256-GCM-SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:157:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = "ECDHE-RSA-AES256-GCM-SHA384" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:157:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_AES_256_GCM_SHA384* = "ECDHE-RSA-AES256-GCM-SHA384" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:157:9
 else:
   static :
     hint("Declaration of " &
@@ -6710,9 +6714,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256):
   when 52392 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = 52392 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:158:9
+      PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = 52392 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:158:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = 52392 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:158:9
+    let PTLS_CIPHER_SUITE_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = 52392 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:158:9
 else:
   static :
     hint("Declaration of " &
@@ -6721,9 +6725,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256):
   when "ECDHE-RSA-CHACHA20-POLY1305" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-RSA-CHACHA20-POLY1305" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:159:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-RSA-CHACHA20-POLY1305" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:159:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-RSA-CHACHA20-POLY1305" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:159:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-RSA-CHACHA20-POLY1305" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:159:9
 else:
   static :
     hint("Declaration of " &
@@ -6732,9 +6736,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256):
   when 52393 is static:
     const
-      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = 52393 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:160:9
+      PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = 52393 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:160:9
   else:
-    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = 52393 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:160:9
+    let PTLS_CIPHER_SUITE_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = 52393 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:160:9
 else:
   static :
     hint("Declaration of " &
@@ -6743,9 +6747,9 @@ else:
 when not declared(PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256):
   when "ECDHE-ECDSA-CHACHA20-POLY1305" is static:
     const
-      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-ECDSA-CHACHA20-POLY1305" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:161:9
+      PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-ECDSA-CHACHA20-POLY1305" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:161:9
   else:
-    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-ECDSA-CHACHA20-POLY1305" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:161:9
+    let PTLS_CIPHER_SUITE_NAME_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256* = "ECDHE-ECDSA-CHACHA20-POLY1305" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:161:9
 else:
   static :
     hint("Declaration of " &
@@ -6754,9 +6758,9 @@ else:
 when not declared(PTLS_GROUP_SECP256R1):
   when 23 is static:
     const
-      PTLS_GROUP_SECP256R1* = 23 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:164:9
+      PTLS_GROUP_SECP256R1* = 23 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:164:9
   else:
-    let PTLS_GROUP_SECP256R1* = 23 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:164:9
+    let PTLS_GROUP_SECP256R1* = 23 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:164:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_SECP256R1" &
@@ -6764,9 +6768,9 @@ else:
 when not declared(PTLS_GROUP_NAME_SECP256R1):
   when "secp256r1" is static:
     const
-      PTLS_GROUP_NAME_SECP256R1* = "secp256r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:165:9
+      PTLS_GROUP_NAME_SECP256R1* = "secp256r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:165:9
   else:
-    let PTLS_GROUP_NAME_SECP256R1* = "secp256r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:165:9
+    let PTLS_GROUP_NAME_SECP256R1* = "secp256r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:165:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_SECP256R1" &
@@ -6774,9 +6778,9 @@ else:
 when not declared(PTLS_GROUP_SECP384R1):
   when 24 is static:
     const
-      PTLS_GROUP_SECP384R1* = 24 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:166:9
+      PTLS_GROUP_SECP384R1* = 24 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:166:9
   else:
-    let PTLS_GROUP_SECP384R1* = 24 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:166:9
+    let PTLS_GROUP_SECP384R1* = 24 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:166:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_SECP384R1" &
@@ -6784,9 +6788,9 @@ else:
 when not declared(PTLS_GROUP_NAME_SECP384R1):
   when "secp384r1" is static:
     const
-      PTLS_GROUP_NAME_SECP384R1* = "secp384r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:167:9
+      PTLS_GROUP_NAME_SECP384R1* = "secp384r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:167:9
   else:
-    let PTLS_GROUP_NAME_SECP384R1* = "secp384r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:167:9
+    let PTLS_GROUP_NAME_SECP384R1* = "secp384r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:167:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_SECP384R1" &
@@ -6794,9 +6798,9 @@ else:
 when not declared(PTLS_GROUP_SECP521R1):
   when 25 is static:
     const
-      PTLS_GROUP_SECP521R1* = 25 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:168:9
+      PTLS_GROUP_SECP521R1* = 25 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:168:9
   else:
-    let PTLS_GROUP_SECP521R1* = 25 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:168:9
+    let PTLS_GROUP_SECP521R1* = 25 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:168:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_SECP521R1" &
@@ -6804,9 +6808,9 @@ else:
 when not declared(PTLS_GROUP_NAME_SECP521R1):
   when "secp521r1" is static:
     const
-      PTLS_GROUP_NAME_SECP521R1* = "secp521r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:169:9
+      PTLS_GROUP_NAME_SECP521R1* = "secp521r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:169:9
   else:
-    let PTLS_GROUP_NAME_SECP521R1* = "secp521r1" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:169:9
+    let PTLS_GROUP_NAME_SECP521R1* = "secp521r1" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:169:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_SECP521R1" &
@@ -6814,9 +6818,9 @@ else:
 when not declared(PTLS_GROUP_X25519):
   when 29 is static:
     const
-      PTLS_GROUP_X25519* = 29 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:170:9
+      PTLS_GROUP_X25519* = 29 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:170:9
   else:
-    let PTLS_GROUP_X25519* = 29 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:170:9
+    let PTLS_GROUP_X25519* = 29 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:170:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_X25519" &
@@ -6824,9 +6828,9 @@ else:
 when not declared(PTLS_GROUP_NAME_X25519):
   when "x25519" is static:
     const
-      PTLS_GROUP_NAME_X25519* = "x25519" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:171:9
+      PTLS_GROUP_NAME_X25519* = "x25519" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:171:9
   else:
-    let PTLS_GROUP_NAME_X25519* = "x25519" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:171:9
+    let PTLS_GROUP_NAME_X25519* = "x25519" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:171:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_X25519" &
@@ -6834,9 +6838,9 @@ else:
 when not declared(PTLS_GROUP_X448):
   when 30 is static:
     const
-      PTLS_GROUP_X448* = 30  ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:172:9
+      PTLS_GROUP_X448* = 30  ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:172:9
   else:
-    let PTLS_GROUP_X448* = 30 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:172:9
+    let PTLS_GROUP_X448* = 30 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:172:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_X448" &
@@ -6844,9 +6848,9 @@ else:
 when not declared(PTLS_GROUP_NAME_X448):
   when "x448" is static:
     const
-      PTLS_GROUP_NAME_X448* = "x448" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:173:9
+      PTLS_GROUP_NAME_X448* = "x448" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:173:9
   else:
-    let PTLS_GROUP_NAME_X448* = "x448" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:173:9
+    let PTLS_GROUP_NAME_X448* = "x448" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:173:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_X448" &
@@ -6854,9 +6858,9 @@ else:
 when not declared(PTLS_GROUP_X25519MLKEM768):
   when 4588 is static:
     const
-      PTLS_GROUP_X25519MLKEM768* = 4588 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:174:9
+      PTLS_GROUP_X25519MLKEM768* = 4588 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:174:9
   else:
-    let PTLS_GROUP_X25519MLKEM768* = 4588 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:174:9
+    let PTLS_GROUP_X25519MLKEM768* = 4588 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:174:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_X25519MLKEM768" &
@@ -6864,9 +6868,9 @@ else:
 when not declared(PTLS_GROUP_NAME_X25519MLKEM768):
   when "X25519MLKEM768" is static:
     const
-      PTLS_GROUP_NAME_X25519MLKEM768* = "X25519MLKEM768" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:175:9
+      PTLS_GROUP_NAME_X25519MLKEM768* = "X25519MLKEM768" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:175:9
   else:
-    let PTLS_GROUP_NAME_X25519MLKEM768* = "X25519MLKEM768" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:175:9
+    let PTLS_GROUP_NAME_X25519MLKEM768* = "X25519MLKEM768" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:175:9
 else:
   static :
     hint("Declaration of " & "PTLS_GROUP_NAME_X25519MLKEM768" &
@@ -6874,9 +6878,9 @@ else:
 when not declared(PTLS_SIGNATURE_RSA_PKCS1_SHA1):
   when 513 is static:
     const
-      PTLS_SIGNATURE_RSA_PKCS1_SHA1* = 513 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:178:9
+      PTLS_SIGNATURE_RSA_PKCS1_SHA1* = 513 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:178:9
   else:
-    let PTLS_SIGNATURE_RSA_PKCS1_SHA1* = 513 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:178:9
+    let PTLS_SIGNATURE_RSA_PKCS1_SHA1* = 513 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:178:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_RSA_PKCS1_SHA1" &
@@ -6884,9 +6888,9 @@ else:
 when not declared(PTLS_SIGNATURE_RSA_PKCS1_SHA256):
   when 1025 is static:
     const
-      PTLS_SIGNATURE_RSA_PKCS1_SHA256* = 1025 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:179:9
+      PTLS_SIGNATURE_RSA_PKCS1_SHA256* = 1025 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:179:9
   else:
-    let PTLS_SIGNATURE_RSA_PKCS1_SHA256* = 1025 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:179:9
+    let PTLS_SIGNATURE_RSA_PKCS1_SHA256* = 1025 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:179:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_RSA_PKCS1_SHA256" &
@@ -6894,9 +6898,9 @@ else:
 when not declared(PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256):
   when 1027 is static:
     const
-      PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256* = 1027 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:180:9
+      PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256* = 1027 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:180:9
   else:
-    let PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256* = 1027 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:180:9
+    let PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256* = 1027 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:180:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256" &
@@ -6904,9 +6908,9 @@ else:
 when not declared(PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384):
   when 1283 is static:
     const
-      PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384* = 1283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:181:9
+      PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384* = 1283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:181:9
   else:
-    let PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384* = 1283 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:181:9
+    let PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384* = 1283 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:181:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384" &
@@ -6914,9 +6918,9 @@ else:
 when not declared(PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512):
   when 1539 is static:
     const
-      PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512* = 1539 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:182:9
+      PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512* = 1539 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:182:9
   else:
-    let PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512* = 1539 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:182:9
+    let PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512* = 1539 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:182:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512" &
@@ -6924,9 +6928,9 @@ else:
 when not declared(PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256):
   when 2052 is static:
     const
-      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256* = 2052 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:183:9
+      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256* = 2052 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:183:9
   else:
-    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256* = 2052 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:183:9
+    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256* = 2052 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:183:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256" &
@@ -6934,9 +6938,9 @@ else:
 when not declared(PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384):
   when 2053 is static:
     const
-      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384* = 2053 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:184:9
+      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384* = 2053 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:184:9
   else:
-    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384* = 2053 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:184:9
+    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384* = 2053 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:184:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384" &
@@ -6944,9 +6948,9 @@ else:
 when not declared(PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512):
   when 2054 is static:
     const
-      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512* = 2054 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:185:9
+      PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512* = 2054 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:185:9
   else:
-    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512* = 2054 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:185:9
+    let PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512* = 2054 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:185:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512" &
@@ -6954,9 +6958,9 @@ else:
 when not declared(PTLS_SIGNATURE_ED25519):
   when 2055 is static:
     const
-      PTLS_SIGNATURE_ED25519* = 2055 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:186:9
+      PTLS_SIGNATURE_ED25519* = 2055 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:186:9
   else:
-    let PTLS_SIGNATURE_ED25519* = 2055 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:186:9
+    let PTLS_SIGNATURE_ED25519* = 2055 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:186:9
 else:
   static :
     hint("Declaration of " & "PTLS_SIGNATURE_ED25519" &
@@ -6964,9 +6968,9 @@ else:
 when not declared(PTLS_HPKE_MODE_BASE):
   when 0 is static:
     const
-      PTLS_HPKE_MODE_BASE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:189:9
+      PTLS_HPKE_MODE_BASE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:189:9
   else:
-    let PTLS_HPKE_MODE_BASE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:189:9
+    let PTLS_HPKE_MODE_BASE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:189:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_MODE_BASE" &
@@ -6974,9 +6978,9 @@ else:
 when not declared(PTLS_HPKE_MODE_PSK):
   when 1 is static:
     const
-      PTLS_HPKE_MODE_PSK* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:190:9
+      PTLS_HPKE_MODE_PSK* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:190:9
   else:
-    let PTLS_HPKE_MODE_PSK* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:190:9
+    let PTLS_HPKE_MODE_PSK* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:190:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_MODE_PSK" &
@@ -6984,9 +6988,9 @@ else:
 when not declared(PTLS_HPKE_MODE_AUTH):
   when 2 is static:
     const
-      PTLS_HPKE_MODE_AUTH* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:191:9
+      PTLS_HPKE_MODE_AUTH* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:191:9
   else:
-    let PTLS_HPKE_MODE_AUTH* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:191:9
+    let PTLS_HPKE_MODE_AUTH* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:191:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_MODE_AUTH" &
@@ -6994,9 +6998,9 @@ else:
 when not declared(PTLS_HPKE_MODE_AUTH_PSK):
   when 3 is static:
     const
-      PTLS_HPKE_MODE_AUTH_PSK* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:192:9
+      PTLS_HPKE_MODE_AUTH_PSK* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:192:9
   else:
-    let PTLS_HPKE_MODE_AUTH_PSK* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:192:9
+    let PTLS_HPKE_MODE_AUTH_PSK* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:192:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_MODE_AUTH_PSK" &
@@ -7004,9 +7008,9 @@ else:
 when not declared(PTLS_HPKE_KEM_P256_SHA256):
   when 16 is static:
     const
-      PTLS_HPKE_KEM_P256_SHA256* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:193:9
+      PTLS_HPKE_KEM_P256_SHA256* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:193:9
   else:
-    let PTLS_HPKE_KEM_P256_SHA256* = 16 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:193:9
+    let PTLS_HPKE_KEM_P256_SHA256* = 16 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:193:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_KEM_P256_SHA256" &
@@ -7014,9 +7018,9 @@ else:
 when not declared(PTLS_HPKE_KEM_P384_SHA384):
   when 17 is static:
     const
-      PTLS_HPKE_KEM_P384_SHA384* = 17 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:194:9
+      PTLS_HPKE_KEM_P384_SHA384* = 17 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:194:9
   else:
-    let PTLS_HPKE_KEM_P384_SHA384* = 17 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:194:9
+    let PTLS_HPKE_KEM_P384_SHA384* = 17 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:194:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_KEM_P384_SHA384" &
@@ -7024,9 +7028,9 @@ else:
 when not declared(PTLS_HPKE_KEM_X25519_SHA256):
   when 32 is static:
     const
-      PTLS_HPKE_KEM_X25519_SHA256* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:195:9
+      PTLS_HPKE_KEM_X25519_SHA256* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:195:9
   else:
-    let PTLS_HPKE_KEM_X25519_SHA256* = 32 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:195:9
+    let PTLS_HPKE_KEM_X25519_SHA256* = 32 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:195:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_KEM_X25519_SHA256" &
@@ -7034,9 +7038,9 @@ else:
 when not declared(PTLS_HPKE_HKDF_SHA256):
   when 1 is static:
     const
-      PTLS_HPKE_HKDF_SHA256* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:196:9
+      PTLS_HPKE_HKDF_SHA256* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:196:9
   else:
-    let PTLS_HPKE_HKDF_SHA256* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:196:9
+    let PTLS_HPKE_HKDF_SHA256* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:196:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_HKDF_SHA256" &
@@ -7044,9 +7048,9 @@ else:
 when not declared(PTLS_HPKE_HKDF_SHA384):
   when 2 is static:
     const
-      PTLS_HPKE_HKDF_SHA384* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:197:9
+      PTLS_HPKE_HKDF_SHA384* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:197:9
   else:
-    let PTLS_HPKE_HKDF_SHA384* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:197:9
+    let PTLS_HPKE_HKDF_SHA384* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:197:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_HKDF_SHA384" &
@@ -7054,9 +7058,9 @@ else:
 when not declared(PTLS_HPKE_HKDF_SHA512):
   when 3 is static:
     const
-      PTLS_HPKE_HKDF_SHA512* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:198:9
+      PTLS_HPKE_HKDF_SHA512* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:198:9
   else:
-    let PTLS_HPKE_HKDF_SHA512* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:198:9
+    let PTLS_HPKE_HKDF_SHA512* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:198:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_HKDF_SHA512" &
@@ -7064,9 +7068,9 @@ else:
 when not declared(PTLS_HPKE_AEAD_AES_128_GCM):
   when 1 is static:
     const
-      PTLS_HPKE_AEAD_AES_128_GCM* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:199:9
+      PTLS_HPKE_AEAD_AES_128_GCM* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:199:9
   else:
-    let PTLS_HPKE_AEAD_AES_128_GCM* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:199:9
+    let PTLS_HPKE_AEAD_AES_128_GCM* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:199:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_AEAD_AES_128_GCM" &
@@ -7074,9 +7078,9 @@ else:
 when not declared(PTLS_HPKE_AEAD_AES_256_GCM):
   when 2 is static:
     const
-      PTLS_HPKE_AEAD_AES_256_GCM* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:200:9
+      PTLS_HPKE_AEAD_AES_256_GCM* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:200:9
   else:
-    let PTLS_HPKE_AEAD_AES_256_GCM* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:200:9
+    let PTLS_HPKE_AEAD_AES_256_GCM* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:200:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_AEAD_AES_256_GCM" &
@@ -7084,9 +7088,9 @@ else:
 when not declared(PTLS_HPKE_AEAD_CHACHA20POLY1305):
   when 3 is static:
     const
-      PTLS_HPKE_AEAD_CHACHA20POLY1305* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:201:9
+      PTLS_HPKE_AEAD_CHACHA20POLY1305* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:201:9
   else:
-    let PTLS_HPKE_AEAD_CHACHA20POLY1305* = 3 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:201:9
+    let PTLS_HPKE_AEAD_CHACHA20POLY1305* = 3 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:201:9
 else:
   static :
     hint("Declaration of " & "PTLS_HPKE_AEAD_CHACHA20POLY1305" &
@@ -7094,9 +7098,9 @@ else:
 when not declared(PTLS_ERROR_CLASS_SELF_ALERT):
   when 0 is static:
     const
-      PTLS_ERROR_CLASS_SELF_ALERT* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:204:9
+      PTLS_ERROR_CLASS_SELF_ALERT* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:204:9
   else:
-    let PTLS_ERROR_CLASS_SELF_ALERT* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:204:9
+    let PTLS_ERROR_CLASS_SELF_ALERT* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:204:9
 else:
   static :
     hint("Declaration of " & "PTLS_ERROR_CLASS_SELF_ALERT" &
@@ -7104,9 +7108,9 @@ else:
 when not declared(PTLS_ERROR_CLASS_PEER_ALERT):
   when 256 is static:
     const
-      PTLS_ERROR_CLASS_PEER_ALERT* = 256 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:205:9
+      PTLS_ERROR_CLASS_PEER_ALERT* = 256 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:205:9
   else:
-    let PTLS_ERROR_CLASS_PEER_ALERT* = 256 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:205:9
+    let PTLS_ERROR_CLASS_PEER_ALERT* = 256 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:205:9
 else:
   static :
     hint("Declaration of " & "PTLS_ERROR_CLASS_PEER_ALERT" &
@@ -7114,9 +7118,9 @@ else:
 when not declared(PTLS_ERROR_CLASS_INTERNAL):
   when 512 is static:
     const
-      PTLS_ERROR_CLASS_INTERNAL* = 512 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:206:9
+      PTLS_ERROR_CLASS_INTERNAL* = 512 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:206:9
   else:
-    let PTLS_ERROR_CLASS_INTERNAL* = 512 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:206:9
+    let PTLS_ERROR_CLASS_INTERNAL* = 512 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:206:9
 else:
   static :
     hint("Declaration of " & "PTLS_ERROR_CLASS_INTERNAL" &
@@ -7124,9 +7128,9 @@ else:
 when not declared(PTLS_HKDF_EXPAND_LABEL_PREFIX):
   when "tls13 " is static:
     const
-      PTLS_HKDF_EXPAND_LABEL_PREFIX* = "tls13 " ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:214:9
+      PTLS_HKDF_EXPAND_LABEL_PREFIX* = "tls13 " ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:214:9
   else:
-    let PTLS_HKDF_EXPAND_LABEL_PREFIX* = "tls13 " ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:214:9
+    let PTLS_HKDF_EXPAND_LABEL_PREFIX* = "tls13 " ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:214:9
 else:
   static :
     hint("Declaration of " & "PTLS_HKDF_EXPAND_LABEL_PREFIX" &
@@ -7134,9 +7138,9 @@ else:
 when not declared(PTLS_ALERT_LEVEL_WARNING):
   when 1 is static:
     const
-      PTLS_ALERT_LEVEL_WARNING* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:217:9
+      PTLS_ALERT_LEVEL_WARNING* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:217:9
   else:
-    let PTLS_ALERT_LEVEL_WARNING* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:217:9
+    let PTLS_ALERT_LEVEL_WARNING* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:217:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_LEVEL_WARNING" &
@@ -7144,9 +7148,9 @@ else:
 when not declared(PTLS_ALERT_LEVEL_FATAL):
   when 2 is static:
     const
-      PTLS_ALERT_LEVEL_FATAL* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:218:9
+      PTLS_ALERT_LEVEL_FATAL* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:218:9
   else:
-    let PTLS_ALERT_LEVEL_FATAL* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:218:9
+    let PTLS_ALERT_LEVEL_FATAL* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:218:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_LEVEL_FATAL" &
@@ -7154,9 +7158,9 @@ else:
 when not declared(PTLS_ALERT_CLOSE_NOTIFY):
   when 0 is static:
     const
-      PTLS_ALERT_CLOSE_NOTIFY* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:220:9
+      PTLS_ALERT_CLOSE_NOTIFY* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:220:9
   else:
-    let PTLS_ALERT_CLOSE_NOTIFY* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:220:9
+    let PTLS_ALERT_CLOSE_NOTIFY* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:220:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_CLOSE_NOTIFY" &
@@ -7164,9 +7168,9 @@ else:
 when not declared(PTLS_ALERT_UNEXPECTED_MESSAGE):
   when 10 is static:
     const
-      PTLS_ALERT_UNEXPECTED_MESSAGE* = 10 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:221:9
+      PTLS_ALERT_UNEXPECTED_MESSAGE* = 10 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:221:9
   else:
-    let PTLS_ALERT_UNEXPECTED_MESSAGE* = 10 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:221:9
+    let PTLS_ALERT_UNEXPECTED_MESSAGE* = 10 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:221:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNEXPECTED_MESSAGE" &
@@ -7174,9 +7178,9 @@ else:
 when not declared(PTLS_ALERT_BAD_RECORD_MAC):
   when 20 is static:
     const
-      PTLS_ALERT_BAD_RECORD_MAC* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:222:9
+      PTLS_ALERT_BAD_RECORD_MAC* = 20 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:222:9
   else:
-    let PTLS_ALERT_BAD_RECORD_MAC* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:222:9
+    let PTLS_ALERT_BAD_RECORD_MAC* = 20 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:222:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_BAD_RECORD_MAC" &
@@ -7184,9 +7188,9 @@ else:
 when not declared(PTLS_ALERT_HANDSHAKE_FAILURE):
   when 40 is static:
     const
-      PTLS_ALERT_HANDSHAKE_FAILURE* = 40 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:223:9
+      PTLS_ALERT_HANDSHAKE_FAILURE* = 40 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:223:9
   else:
-    let PTLS_ALERT_HANDSHAKE_FAILURE* = 40 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:223:9
+    let PTLS_ALERT_HANDSHAKE_FAILURE* = 40 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:223:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_HANDSHAKE_FAILURE" &
@@ -7194,9 +7198,9 @@ else:
 when not declared(PTLS_ALERT_BAD_CERTIFICATE):
   when 42 is static:
     const
-      PTLS_ALERT_BAD_CERTIFICATE* = 42 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:224:9
+      PTLS_ALERT_BAD_CERTIFICATE* = 42 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:224:9
   else:
-    let PTLS_ALERT_BAD_CERTIFICATE* = 42 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:224:9
+    let PTLS_ALERT_BAD_CERTIFICATE* = 42 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:224:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_BAD_CERTIFICATE" &
@@ -7204,9 +7208,9 @@ else:
 when not declared(PTLS_ALERT_UNSUPPORTED_CERTIFICATE):
   when 43 is static:
     const
-      PTLS_ALERT_UNSUPPORTED_CERTIFICATE* = 43 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:225:9
+      PTLS_ALERT_UNSUPPORTED_CERTIFICATE* = 43 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:225:9
   else:
-    let PTLS_ALERT_UNSUPPORTED_CERTIFICATE* = 43 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:225:9
+    let PTLS_ALERT_UNSUPPORTED_CERTIFICATE* = 43 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:225:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNSUPPORTED_CERTIFICATE" &
@@ -7214,9 +7218,9 @@ else:
 when not declared(PTLS_ALERT_CERTIFICATE_REVOKED):
   when 44 is static:
     const
-      PTLS_ALERT_CERTIFICATE_REVOKED* = 44 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:226:9
+      PTLS_ALERT_CERTIFICATE_REVOKED* = 44 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:226:9
   else:
-    let PTLS_ALERT_CERTIFICATE_REVOKED* = 44 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:226:9
+    let PTLS_ALERT_CERTIFICATE_REVOKED* = 44 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:226:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_CERTIFICATE_REVOKED" &
@@ -7224,9 +7228,9 @@ else:
 when not declared(PTLS_ALERT_CERTIFICATE_EXPIRED):
   when 45 is static:
     const
-      PTLS_ALERT_CERTIFICATE_EXPIRED* = 45 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:227:9
+      PTLS_ALERT_CERTIFICATE_EXPIRED* = 45 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:227:9
   else:
-    let PTLS_ALERT_CERTIFICATE_EXPIRED* = 45 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:227:9
+    let PTLS_ALERT_CERTIFICATE_EXPIRED* = 45 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:227:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_CERTIFICATE_EXPIRED" &
@@ -7234,9 +7238,9 @@ else:
 when not declared(PTLS_ALERT_CERTIFICATE_UNKNOWN):
   when 46 is static:
     const
-      PTLS_ALERT_CERTIFICATE_UNKNOWN* = 46 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:228:9
+      PTLS_ALERT_CERTIFICATE_UNKNOWN* = 46 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:228:9
   else:
-    let PTLS_ALERT_CERTIFICATE_UNKNOWN* = 46 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:228:9
+    let PTLS_ALERT_CERTIFICATE_UNKNOWN* = 46 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:228:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_CERTIFICATE_UNKNOWN" &
@@ -7244,9 +7248,9 @@ else:
 when not declared(PTLS_ALERT_ILLEGAL_PARAMETER):
   when 47 is static:
     const
-      PTLS_ALERT_ILLEGAL_PARAMETER* = 47 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:229:9
+      PTLS_ALERT_ILLEGAL_PARAMETER* = 47 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:229:9
   else:
-    let PTLS_ALERT_ILLEGAL_PARAMETER* = 47 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:229:9
+    let PTLS_ALERT_ILLEGAL_PARAMETER* = 47 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:229:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_ILLEGAL_PARAMETER" &
@@ -7254,9 +7258,9 @@ else:
 when not declared(PTLS_ALERT_UNKNOWN_CA):
   when 48 is static:
     const
-      PTLS_ALERT_UNKNOWN_CA* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:230:9
+      PTLS_ALERT_UNKNOWN_CA* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:230:9
   else:
-    let PTLS_ALERT_UNKNOWN_CA* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:230:9
+    let PTLS_ALERT_UNKNOWN_CA* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:230:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNKNOWN_CA" &
@@ -7264,9 +7268,9 @@ else:
 when not declared(PTLS_ALERT_ACCESS_DENIED):
   when 49 is static:
     const
-      PTLS_ALERT_ACCESS_DENIED* = 49 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:231:9
+      PTLS_ALERT_ACCESS_DENIED* = 49 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:231:9
   else:
-    let PTLS_ALERT_ACCESS_DENIED* = 49 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:231:9
+    let PTLS_ALERT_ACCESS_DENIED* = 49 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:231:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_ACCESS_DENIED" &
@@ -7274,9 +7278,9 @@ else:
 when not declared(PTLS_ALERT_DECODE_ERROR):
   when 50 is static:
     const
-      PTLS_ALERT_DECODE_ERROR* = 50 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:232:9
+      PTLS_ALERT_DECODE_ERROR* = 50 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:232:9
   else:
-    let PTLS_ALERT_DECODE_ERROR* = 50 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:232:9
+    let PTLS_ALERT_DECODE_ERROR* = 50 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:232:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_DECODE_ERROR" &
@@ -7284,9 +7288,9 @@ else:
 when not declared(PTLS_ALERT_DECRYPT_ERROR):
   when 51 is static:
     const
-      PTLS_ALERT_DECRYPT_ERROR* = 51 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:233:9
+      PTLS_ALERT_DECRYPT_ERROR* = 51 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:233:9
   else:
-    let PTLS_ALERT_DECRYPT_ERROR* = 51 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:233:9
+    let PTLS_ALERT_DECRYPT_ERROR* = 51 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:233:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_DECRYPT_ERROR" &
@@ -7294,9 +7298,9 @@ else:
 when not declared(PTLS_ALERT_PROTOCOL_VERSION):
   when 70 is static:
     const
-      PTLS_ALERT_PROTOCOL_VERSION* = 70 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:234:9
+      PTLS_ALERT_PROTOCOL_VERSION* = 70 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:234:9
   else:
-    let PTLS_ALERT_PROTOCOL_VERSION* = 70 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:234:9
+    let PTLS_ALERT_PROTOCOL_VERSION* = 70 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:234:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_PROTOCOL_VERSION" &
@@ -7304,9 +7308,9 @@ else:
 when not declared(PTLS_ALERT_INTERNAL_ERROR):
   when 80 is static:
     const
-      PTLS_ALERT_INTERNAL_ERROR* = 80 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:235:9
+      PTLS_ALERT_INTERNAL_ERROR* = 80 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:235:9
   else:
-    let PTLS_ALERT_INTERNAL_ERROR* = 80 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:235:9
+    let PTLS_ALERT_INTERNAL_ERROR* = 80 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:235:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_INTERNAL_ERROR" &
@@ -7314,9 +7318,9 @@ else:
 when not declared(PTLS_ALERT_USER_CANCELED):
   when 90 is static:
     const
-      PTLS_ALERT_USER_CANCELED* = 90 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:236:9
+      PTLS_ALERT_USER_CANCELED* = 90 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:236:9
   else:
-    let PTLS_ALERT_USER_CANCELED* = 90 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:236:9
+    let PTLS_ALERT_USER_CANCELED* = 90 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:236:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_USER_CANCELED" &
@@ -7324,9 +7328,9 @@ else:
 when not declared(PTLS_ALERT_MISSING_EXTENSION):
   when 109 is static:
     const
-      PTLS_ALERT_MISSING_EXTENSION* = 109 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:237:9
+      PTLS_ALERT_MISSING_EXTENSION* = 109 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:237:9
   else:
-    let PTLS_ALERT_MISSING_EXTENSION* = 109 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:237:9
+    let PTLS_ALERT_MISSING_EXTENSION* = 109 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:237:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_MISSING_EXTENSION" &
@@ -7334,9 +7338,9 @@ else:
 when not declared(PTLS_ALERT_UNSUPPORTED_EXTENSION):
   when 110 is static:
     const
-      PTLS_ALERT_UNSUPPORTED_EXTENSION* = 110 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:238:9
+      PTLS_ALERT_UNSUPPORTED_EXTENSION* = 110 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:238:9
   else:
-    let PTLS_ALERT_UNSUPPORTED_EXTENSION* = 110 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:238:9
+    let PTLS_ALERT_UNSUPPORTED_EXTENSION* = 110 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:238:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNSUPPORTED_EXTENSION" &
@@ -7344,9 +7348,9 @@ else:
 when not declared(PTLS_ALERT_UNRECOGNIZED_NAME):
   when 112 is static:
     const
-      PTLS_ALERT_UNRECOGNIZED_NAME* = 112 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:239:9
+      PTLS_ALERT_UNRECOGNIZED_NAME* = 112 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:239:9
   else:
-    let PTLS_ALERT_UNRECOGNIZED_NAME* = 112 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:239:9
+    let PTLS_ALERT_UNRECOGNIZED_NAME* = 112 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:239:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNRECOGNIZED_NAME" &
@@ -7354,9 +7358,9 @@ else:
 when not declared(PTLS_ALERT_UNKNOWN_PSK_IDENTITY):
   when 115 is static:
     const
-      PTLS_ALERT_UNKNOWN_PSK_IDENTITY* = 115 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:240:9
+      PTLS_ALERT_UNKNOWN_PSK_IDENTITY* = 115 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:240:9
   else:
-    let PTLS_ALERT_UNKNOWN_PSK_IDENTITY* = 115 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:240:9
+    let PTLS_ALERT_UNKNOWN_PSK_IDENTITY* = 115 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:240:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_UNKNOWN_PSK_IDENTITY" &
@@ -7364,9 +7368,9 @@ else:
 when not declared(PTLS_ALERT_CERTIFICATE_REQUIRED):
   when 116 is static:
     const
-      PTLS_ALERT_CERTIFICATE_REQUIRED* = 116 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:241:9
+      PTLS_ALERT_CERTIFICATE_REQUIRED* = 116 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:241:9
   else:
-    let PTLS_ALERT_CERTIFICATE_REQUIRED* = 116 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:241:9
+    let PTLS_ALERT_CERTIFICATE_REQUIRED* = 116 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:241:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_CERTIFICATE_REQUIRED" &
@@ -7374,9 +7378,9 @@ else:
 when not declared(PTLS_ALERT_NO_APPLICATION_PROTOCOL):
   when 120 is static:
     const
-      PTLS_ALERT_NO_APPLICATION_PROTOCOL* = 120 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:242:9
+      PTLS_ALERT_NO_APPLICATION_PROTOCOL* = 120 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:242:9
   else:
-    let PTLS_ALERT_NO_APPLICATION_PROTOCOL* = 120 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:242:9
+    let PTLS_ALERT_NO_APPLICATION_PROTOCOL* = 120 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:242:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_NO_APPLICATION_PROTOCOL" &
@@ -7384,9 +7388,9 @@ else:
 when not declared(PTLS_ALERT_ECH_REQUIRED):
   when 121 is static:
     const
-      PTLS_ALERT_ECH_REQUIRED* = 121 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:243:9
+      PTLS_ALERT_ECH_REQUIRED* = 121 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:243:9
   else:
-    let PTLS_ALERT_ECH_REQUIRED* = 121 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:243:9
+    let PTLS_ALERT_ECH_REQUIRED* = 121 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:243:9
 else:
   static :
     hint("Declaration of " & "PTLS_ALERT_ECH_REQUIRED" &
@@ -7394,9 +7398,9 @@ else:
 when not declared(PTLS_TLS12_MASTER_SECRET_SIZE):
   when 48 is static:
     const
-      PTLS_TLS12_MASTER_SECRET_SIZE* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:246:9
+      PTLS_TLS12_MASTER_SECRET_SIZE* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:246:9
   else:
-    let PTLS_TLS12_MASTER_SECRET_SIZE* = 48 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:246:9
+    let PTLS_TLS12_MASTER_SECRET_SIZE* = 48 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:246:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_MASTER_SECRET_SIZE" &
@@ -7404,9 +7408,9 @@ else:
 when not declared(PTLS_TLS12_AAD_SIZE):
   when 13 is static:
     const
-      PTLS_TLS12_AAD_SIZE* = 13 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:247:9
+      PTLS_TLS12_AAD_SIZE* = 13 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:247:9
   else:
-    let PTLS_TLS12_AAD_SIZE* = 13 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:247:9
+    let PTLS_TLS12_AAD_SIZE* = 13 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:247:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_AAD_SIZE" &
@@ -7414,9 +7418,9 @@ else:
 when not declared(PTLS_TLS12_AESGCM_FIXED_IV_SIZE):
   when 4 is static:
     const
-      PTLS_TLS12_AESGCM_FIXED_IV_SIZE* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:248:9
+      PTLS_TLS12_AESGCM_FIXED_IV_SIZE* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:248:9
   else:
-    let PTLS_TLS12_AESGCM_FIXED_IV_SIZE* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:248:9
+    let PTLS_TLS12_AESGCM_FIXED_IV_SIZE* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:248:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_AESGCM_FIXED_IV_SIZE" &
@@ -7424,9 +7428,9 @@ else:
 when not declared(PTLS_TLS12_AESGCM_RECORD_IV_SIZE):
   when 8 is static:
     const
-      PTLS_TLS12_AESGCM_RECORD_IV_SIZE* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:249:9
+      PTLS_TLS12_AESGCM_RECORD_IV_SIZE* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:249:9
   else:
-    let PTLS_TLS12_AESGCM_RECORD_IV_SIZE* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:249:9
+    let PTLS_TLS12_AESGCM_RECORD_IV_SIZE* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:249:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_AESGCM_RECORD_IV_SIZE" &
@@ -7434,9 +7438,9 @@ else:
 when not declared(PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE):
   when 12 is static:
     const
-      PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:250:9
+      PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:250:9
   else:
-    let PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE* = 12 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:250:9
+    let PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE* = 12 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:250:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_CHACHAPOLY_FIXED_IV_SIZE" &
@@ -7444,9 +7448,9 @@ else:
 when not declared(PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE):
   when 0 is static:
     const
-      PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:251:9
+      PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:251:9
   else:
-    let PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:251:9
+    let PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:251:9
 else:
   static :
     hint("Declaration of " & "PTLS_TLS12_CHACHAPOLY_RECORD_IV_SIZE" &
@@ -7454,9 +7458,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_CLIENT_HELLO):
   when 1 is static:
     const
-      PTLS_HANDSHAKE_TYPE_CLIENT_HELLO* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:283:9
+      PTLS_HANDSHAKE_TYPE_CLIENT_HELLO* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:283:9
   else:
-    let PTLS_HANDSHAKE_TYPE_CLIENT_HELLO* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:283:9
+    let PTLS_HANDSHAKE_TYPE_CLIENT_HELLO* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:283:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_CLIENT_HELLO" &
@@ -7464,9 +7468,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_SERVER_HELLO):
   when 2 is static:
     const
-      PTLS_HANDSHAKE_TYPE_SERVER_HELLO* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:284:9
+      PTLS_HANDSHAKE_TYPE_SERVER_HELLO* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:284:9
   else:
-    let PTLS_HANDSHAKE_TYPE_SERVER_HELLO* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:284:9
+    let PTLS_HANDSHAKE_TYPE_SERVER_HELLO* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:284:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_SERVER_HELLO" &
@@ -7474,9 +7478,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET):
   when 4 is static:
     const
-      PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:285:9
+      PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:285:9
   else:
-    let PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:285:9
+    let PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:285:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET" &
@@ -7484,9 +7488,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA):
   when 5 is static:
     const
-      PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:286:9
+      PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA* = 5 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:286:9
   else:
-    let PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA* = 5 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:286:9
+    let PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA* = 5 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:286:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA" &
@@ -7494,9 +7498,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS):
   when 8 is static:
     const
-      PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:287:9
+      PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:287:9
   else:
-    let PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:287:9
+    let PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:287:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS" &
@@ -7504,9 +7508,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_CERTIFICATE):
   when 11 is static:
     const
-      PTLS_HANDSHAKE_TYPE_CERTIFICATE* = 11 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:288:9
+      PTLS_HANDSHAKE_TYPE_CERTIFICATE* = 11 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:288:9
   else:
-    let PTLS_HANDSHAKE_TYPE_CERTIFICATE* = 11 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:288:9
+    let PTLS_HANDSHAKE_TYPE_CERTIFICATE* = 11 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:288:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_CERTIFICATE" &
@@ -7514,9 +7518,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST):
   when 13 is static:
     const
-      PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST* = 13 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:289:9
+      PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST* = 13 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:289:9
   else:
-    let PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST* = 13 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:289:9
+    let PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST* = 13 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:289:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST" &
@@ -7524,9 +7528,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY):
   when 15 is static:
     const
-      PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY* = 15 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:290:9
+      PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY* = 15 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:290:9
   else:
-    let PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY* = 15 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:290:9
+    let PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY* = 15 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:290:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY" &
@@ -7534,9 +7538,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_FINISHED):
   when 20 is static:
     const
-      PTLS_HANDSHAKE_TYPE_FINISHED* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:291:9
+      PTLS_HANDSHAKE_TYPE_FINISHED* = 20 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:291:9
   else:
-    let PTLS_HANDSHAKE_TYPE_FINISHED* = 20 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:291:9
+    let PTLS_HANDSHAKE_TYPE_FINISHED* = 20 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:291:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_FINISHED" &
@@ -7544,9 +7548,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_KEY_UPDATE):
   when 24 is static:
     const
-      PTLS_HANDSHAKE_TYPE_KEY_UPDATE* = 24 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:292:9
+      PTLS_HANDSHAKE_TYPE_KEY_UPDATE* = 24 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:292:9
   else:
-    let PTLS_HANDSHAKE_TYPE_KEY_UPDATE* = 24 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:292:9
+    let PTLS_HANDSHAKE_TYPE_KEY_UPDATE* = 24 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:292:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_KEY_UPDATE" &
@@ -7554,9 +7558,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE):
   when 25 is static:
     const
-      PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE* = 25 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:293:9
+      PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE* = 25 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:293:9
   else:
-    let PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE* = 25 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:293:9
+    let PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE* = 25 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:293:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE" &
@@ -7564,9 +7568,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_MESSAGE_HASH):
   when 254 is static:
     const
-      PTLS_HANDSHAKE_TYPE_MESSAGE_HASH* = 254 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:294:9
+      PTLS_HANDSHAKE_TYPE_MESSAGE_HASH* = 254 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:294:9
   else:
-    let PTLS_HANDSHAKE_TYPE_MESSAGE_HASH* = 254 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:294:9
+    let PTLS_HANDSHAKE_TYPE_MESSAGE_HASH* = 254 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:294:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_MESSAGE_HASH" &
@@ -7574,9 +7578,9 @@ else:
 when not declared(PTLS_HANDSHAKE_TYPE_PSEUDO_HRR):
   when -1 is static:
     const
-      PTLS_HANDSHAKE_TYPE_PSEUDO_HRR* = -1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:295:9
+      PTLS_HANDSHAKE_TYPE_PSEUDO_HRR* = -1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:295:9
   else:
-    let PTLS_HANDSHAKE_TYPE_PSEUDO_HRR* = -1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:295:9
+    let PTLS_HANDSHAKE_TYPE_PSEUDO_HRR* = -1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:295:9
 else:
   static :
     hint("Declaration of " & "PTLS_HANDSHAKE_TYPE_PSEUDO_HRR" &
@@ -7584,9 +7588,9 @@ else:
 when not declared(PTLS_CERTIFICATE_TYPE_X509):
   when 0 is static:
     const
-      PTLS_CERTIFICATE_TYPE_X509* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:297:9
+      PTLS_CERTIFICATE_TYPE_X509* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:297:9
   else:
-    let PTLS_CERTIFICATE_TYPE_X509* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:297:9
+    let PTLS_CERTIFICATE_TYPE_X509* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:297:9
 else:
   static :
     hint("Declaration of " & "PTLS_CERTIFICATE_TYPE_X509" &
@@ -7594,9 +7598,9 @@ else:
 when not declared(PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY):
   when 2 is static:
     const
-      PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:298:9
+      PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:298:9
   else:
-    let PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY* = 2 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:298:9
+    let PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY* = 2 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:298:9
 else:
   static :
     hint("Declaration of " & "PTLS_CERTIFICATE_TYPE_RAW_PUBLIC_KEY" &
@@ -7604,9 +7608,9 @@ else:
 when not declared(PTLS_DEFAULT_MAX_TICKETS_TO_SERVE):
   when 4 is static:
     const
-      PTLS_DEFAULT_MAX_TICKETS_TO_SERVE* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:321:9
+      PTLS_DEFAULT_MAX_TICKETS_TO_SERVE* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:321:9
   else:
-    let PTLS_DEFAULT_MAX_TICKETS_TO_SERVE* = 4 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:321:9
+    let PTLS_DEFAULT_MAX_TICKETS_TO_SERVE* = 4 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:321:9
 else:
   static :
     hint("Declaration of " & "PTLS_DEFAULT_MAX_TICKETS_TO_SERVE" &
@@ -7614,9 +7618,9 @@ else:
 when not declared(PTLS_ENCODE_QUICINT_CAPACITY):
   when 8 is static:
     const
-      PTLS_ENCODE_QUICINT_CAPACITY* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1219:9
+      PTLS_ENCODE_QUICINT_CAPACITY* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1219:9
   else:
-    let PTLS_ENCODE_QUICINT_CAPACITY* = 8 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1219:9
+    let PTLS_ENCODE_QUICINT_CAPACITY* = 8 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1219:9
 else:
   static :
     hint("Declaration of " & "PTLS_ENCODE_QUICINT_CAPACITY" &
@@ -7624,9 +7628,9 @@ else:
 when not declared(PTLS_QUICINT_MAX):
   when 4611686018427387903 is static:
     const
-      PTLS_QUICINT_MAX* = 4611686018427387903'i64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1221:9
+      PTLS_QUICINT_MAX* = 4611686018427387903'i64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1221:9
   else:
-    let PTLS_QUICINT_MAX* = 4611686018427387903'i64 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1221:9
+    let PTLS_QUICINT_MAX* = 4611686018427387903'i64 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1221:9
 else:
   static :
     hint("Declaration of " & "PTLS_QUICINT_MAX" &
@@ -7634,9 +7638,9 @@ else:
 when not declared(PTLS_QUICINT_LONGEST_STR):
   when "4611686018427387903" is static:
     const
-      PTLS_QUICINT_LONGEST_STR* = "4611686018427387903" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1222:9
+      PTLS_QUICINT_LONGEST_STR* = "4611686018427387903" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1222:9
   else:
-    let PTLS_QUICINT_LONGEST_STR* = "4611686018427387903" ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls.h:1222:9
+    let PTLS_QUICINT_LONGEST_STR* = "4611686018427387903" ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls.h:1222:9
 else:
   static :
     hint("Declaration of " & "PTLS_QUICINT_LONGEST_STR" &
@@ -7644,9 +7648,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_CHACHA20_POLY1305):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_CHACHA20_POLY1305* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:37:9
+      PTLS_OPENSSL_HAVE_CHACHA20_POLY1305* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:37:9
   else:
-    let PTLS_OPENSSL_HAVE_CHACHA20_POLY1305* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:37:9
+    let PTLS_OPENSSL_HAVE_CHACHA20_POLY1305* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:37:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_CHACHA20_POLY1305" &
@@ -7654,9 +7658,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_ASYNC):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_ASYNC* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:44:9
+      PTLS_OPENSSL_HAVE_ASYNC* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:44:9
   else:
-    let PTLS_OPENSSL_HAVE_ASYNC* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:44:9
+    let PTLS_OPENSSL_HAVE_ASYNC* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:44:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_ASYNC" &
@@ -7664,9 +7668,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_SECP384R1):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_SECP384R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:51:9
+      PTLS_OPENSSL_HAVE_SECP384R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:51:9
   else:
-    let PTLS_OPENSSL_HAVE_SECP384R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:51:9
+    let PTLS_OPENSSL_HAVE_SECP384R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:51:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_SECP384R1" &
@@ -7674,9 +7678,9 @@ else:
 when not declared(PTLS_OPENSSL_HAS_SECP384R1):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAS_SECP384R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:52:9
+      PTLS_OPENSSL_HAS_SECP384R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:52:9
   else:
-    let PTLS_OPENSSL_HAS_SECP384R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:52:9
+    let PTLS_OPENSSL_HAS_SECP384R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:52:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAS_SECP384R1" &
@@ -7684,9 +7688,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_SECP521R1):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_SECP521R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:56:9
+      PTLS_OPENSSL_HAVE_SECP521R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:56:9
   else:
-    let PTLS_OPENSSL_HAVE_SECP521R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:56:9
+    let PTLS_OPENSSL_HAVE_SECP521R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:56:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_SECP521R1" &
@@ -7694,9 +7698,9 @@ else:
 when not declared(PTLS_OPENSSL_HAS_SECP521R1):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAS_SECP521R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:57:9
+      PTLS_OPENSSL_HAS_SECP521R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:57:9
   else:
-    let PTLS_OPENSSL_HAS_SECP521R1* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:57:9
+    let PTLS_OPENSSL_HAS_SECP521R1* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:57:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAS_SECP521R1" &
@@ -7704,9 +7708,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_ED25519):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_ED25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:61:9
+      PTLS_OPENSSL_HAVE_ED25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:61:9
   else:
-    let PTLS_OPENSSL_HAVE_ED25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:61:9
+    let PTLS_OPENSSL_HAVE_ED25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:61:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_ED25519" &
@@ -7714,9 +7718,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_X25519):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_X25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:64:9
+      PTLS_OPENSSL_HAVE_X25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:64:9
   else:
-    let PTLS_OPENSSL_HAVE_X25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:64:9
+    let PTLS_OPENSSL_HAVE_X25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:64:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_X25519" &
@@ -7724,9 +7728,9 @@ else:
 when not declared(PTLS_OPENSSL_HAS_X25519):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAS_X25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:65:9
+      PTLS_OPENSSL_HAS_X25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:65:9
   else:
-    let PTLS_OPENSSL_HAS_X25519* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:65:9
+    let PTLS_OPENSSL_HAS_X25519* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:65:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAS_X25519" &
@@ -7734,9 +7738,9 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_X25519MLKEM768):
   when 0 is static:
     const
-      PTLS_OPENSSL_HAVE_X25519MLKEM768* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:75:9
+      PTLS_OPENSSL_HAVE_X25519MLKEM768* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:75:9
   else:
-    let PTLS_OPENSSL_HAVE_X25519MLKEM768* = 0 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:75:9
+    let PTLS_OPENSSL_HAVE_X25519MLKEM768* = 0 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:75:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_X25519MLKEM768" &
@@ -7744,15 +7748,15 @@ else:
 when not declared(PTLS_OPENSSL_HAVE_BF):
   when 1 is static:
     const
-      PTLS_OPENSSL_HAVE_BF* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:80:9
+      PTLS_OPENSSL_HAVE_BF* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:80:9
   else:
-    let PTLS_OPENSSL_HAVE_BF* = 1 ## Generated based on /home/r/vacp2p/nim-ngtcp2/libs/picotls/include/picotls/openssl.h:80:9
+    let PTLS_OPENSSL_HAVE_BF* = 1 ## Generated based on /nim-ngtcp2/libs/picotls/include/picotls/openssl.h:80:9
 else:
   static :
     hint("Declaration of " & "PTLS_OPENSSL_HAVE_BF" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_cid_init):
-  proc ngtcp2_cid_init*(cid: ptr ngtcp2_cid_536871405; data: ptr uint8;
+  proc ngtcp2_cid_init*(cid: ptr ngtcp2_cid_553648620; data: ptr uint8;
                         datalen: csize_t): void {.cdecl,
       importc: "ngtcp2_cid_init".}
 else:
@@ -7760,7 +7764,7 @@ else:
     hint("Declaration of " & "ngtcp2_cid_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_cid_eq):
-  proc ngtcp2_cid_eq*(a: ptr ngtcp2_cid_536871405; b: ptr ngtcp2_cid_536871405): cint {.
+  proc ngtcp2_cid_eq*(a: ptr ngtcp2_cid_553648620; b: ptr ngtcp2_cid_553648620): cint {.
       cdecl, importc: "ngtcp2_cid_eq".}
 else:
   static :
@@ -7769,7 +7773,7 @@ else:
 when not declared(ngtcp2_transport_params_encode_versioned):
   proc ngtcp2_transport_params_encode_versioned*(dest: ptr uint8;
       destlen: csize_t; transport_params_version: cint;
-      params: ptr ngtcp2_transport_params_536871449): ngtcp2_ssize_536871371 {.
+      params: ptr ngtcp2_transport_params_553648664): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_transport_params_encode_versioned".}
 else:
   static :
@@ -7777,7 +7781,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_transport_params_decode_versioned):
   proc ngtcp2_transport_params_decode_versioned*(transport_params_version: cint;
-      params: ptr ngtcp2_transport_params_536871449; data: ptr uint8;
+      params: ptr ngtcp2_transport_params_553648664; data: ptr uint8;
       datalen: csize_t): cint {.cdecl, importc: "ngtcp2_transport_params_decode_versioned".}
 else:
   static :
@@ -7785,23 +7789,23 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_transport_params_decode_new):
   proc ngtcp2_transport_params_decode_new*(
-      pparams: ptr ptr ngtcp2_transport_params_536871449; data: ptr uint8;
-      datalen: csize_t; mem: ptr ngtcp2_mem_536871385): cint {.cdecl,
+      pparams: ptr ptr ngtcp2_transport_params_553648664; data: ptr uint8;
+      datalen: csize_t; mem: ptr ngtcp2_mem_553648600): cint {.cdecl,
       importc: "ngtcp2_transport_params_decode_new".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_transport_params_decode_new" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_transport_params_del):
-  proc ngtcp2_transport_params_del*(params: ptr ngtcp2_transport_params_536871449;
-                                    mem: ptr ngtcp2_mem_536871385): void {.
+  proc ngtcp2_transport_params_del*(params: ptr ngtcp2_transport_params_553648664;
+                                    mem: ptr ngtcp2_mem_553648600): void {.
       cdecl, importc: "ngtcp2_transport_params_del".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_transport_params_del" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_decode_version_cid):
-  proc ngtcp2_pkt_decode_version_cid*(dest: ptr ngtcp2_version_cid_536871520;
+  proc ngtcp2_pkt_decode_version_cid*(dest: ptr ngtcp2_version_cid_553648735;
                                       data: ptr uint8; datalen: csize_t;
                                       short_dcidlen: csize_t): cint {.cdecl,
       importc: "ngtcp2_pkt_decode_version_cid".}
@@ -7810,17 +7814,17 @@ else:
     hint("Declaration of " & "ngtcp2_pkt_decode_version_cid" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_decode_hd_long):
-  proc ngtcp2_pkt_decode_hd_long*(dest: ptr ngtcp2_pkt_hd_536871413;
-                                  pkt: ptr uint8; pktlen: csize_t): ngtcp2_ssize_536871371 {.
+  proc ngtcp2_pkt_decode_hd_long*(dest: ptr ngtcp2_pkt_hd_553648628;
+                                  pkt: ptr uint8; pktlen: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_decode_hd_long".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_pkt_decode_hd_long" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_decode_hd_short):
-  proc ngtcp2_pkt_decode_hd_short*(dest: ptr ngtcp2_pkt_hd_536871413;
+  proc ngtcp2_pkt_decode_hd_short*(dest: ptr ngtcp2_pkt_hd_553648628;
                                    pkt: ptr uint8; pktlen: csize_t;
-                                   dcidlen: csize_t): ngtcp2_ssize_536871371 {.
+                                   dcidlen: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_decode_hd_short".}
 else:
   static :
@@ -7828,7 +7832,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_write_stateless_reset):
   proc ngtcp2_pkt_write_stateless_reset*(dest: ptr uint8; destlen: csize_t;
-      stateless_reset_token: ptr uint8; rand: ptr uint8; randlen: csize_t): ngtcp2_ssize_536871371 {.
+      stateless_reset_token: ptr uint8; rand: ptr uint8; randlen: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_write_stateless_reset".}
 else:
   static :
@@ -7837,7 +7841,7 @@ else:
 when not declared(ngtcp2_pkt_write_version_negotiation):
   proc ngtcp2_pkt_write_version_negotiation*(dest: ptr uint8; destlen: csize_t;
       unused_random: uint8; dcid: ptr uint8; dcidlen: csize_t; scid: ptr uint8;
-      scidlen: csize_t; sv: ptr uint32; nsv: csize_t): ngtcp2_ssize_536871371 {.
+      scidlen: csize_t; sv: ptr uint32; nsv: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_write_version_negotiation".}
 else:
   static :
@@ -7845,12 +7849,12 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_write_connection_close):
   proc ngtcp2_pkt_write_connection_close*(dest: ptr uint8; destlen: csize_t;
-      version: uint32; dcid: ptr ngtcp2_cid_536871405; scid: ptr ngtcp2_cid_536871405;
+      version: uint32; dcid: ptr ngtcp2_cid_553648620; scid: ptr ngtcp2_cid_553648620;
       error_code: uint64; reason: ptr uint8; reasonlen: csize_t;
-      encrypt: ngtcp2_encrypt_536871542; aead: ptr ngtcp2_crypto_aead_536871500;
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; iv: ptr uint8;
-      hp_mask: ngtcp2_hp_mask_536871546; hp: ptr ngtcp2_crypto_cipher_536871504;
-      hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): ngtcp2_ssize_536871371 {.
+      encrypt: ngtcp2_encrypt_553648757; aead: ptr ngtcp2_crypto_aead_553648715;
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; iv: ptr uint8;
+      hp_mask: ngtcp2_hp_mask_553648761; hp: ptr ngtcp2_crypto_cipher_553648719;
+      hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_write_connection_close".}
 else:
   static :
@@ -7858,101 +7862,101 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_pkt_write_retry):
   proc ngtcp2_pkt_write_retry*(dest: ptr uint8; destlen: csize_t;
-                               version: uint32; dcid: ptr ngtcp2_cid_536871405;
-                               scid: ptr ngtcp2_cid_536871405;
-                               odcid: ptr ngtcp2_cid_536871405;
+                               version: uint32; dcid: ptr ngtcp2_cid_553648620;
+                               scid: ptr ngtcp2_cid_553648620;
+                               odcid: ptr ngtcp2_cid_553648620;
                                token: ptr uint8; tokenlen: csize_t;
-                               encrypt: ngtcp2_encrypt_536871542;
-                               aead: ptr ngtcp2_crypto_aead_536871500;
-                               aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508): ngtcp2_ssize_536871371 {.
+                               encrypt: ngtcp2_encrypt_553648757;
+                               aead: ptr ngtcp2_crypto_aead_553648715;
+                               aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_pkt_write_retry".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_pkt_write_retry" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_accept):
-  proc ngtcp2_accept*(dest: ptr ngtcp2_pkt_hd_536871413; pkt: ptr uint8;
+  proc ngtcp2_accept*(dest: ptr ngtcp2_pkt_hd_553648628; pkt: ptr uint8;
                       pktlen: csize_t): cint {.cdecl, importc: "ngtcp2_accept".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_accept" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_client_new_versioned):
-  proc ngtcp2_conn_client_new_versioned*(pconn: ptr ptr ngtcp2_conn_536871522;
-      dcid: ptr ngtcp2_cid_536871405; scid: ptr ngtcp2_cid_536871405;
-      path: ptr ngtcp2_path_536871488; client_chosen_version: uint32;
-      callbacks_version: cint; callbacks: ptr ngtcp2_callbacks_536871606;
-      settings_version: cint; settings: ptr ngtcp2_settings_536871480;
-      transport_params_version: cint; params: ptr ngtcp2_transport_params_536871449;
-      mem: ptr ngtcp2_mem_536871385; user_data: pointer): cint {.cdecl,
+  proc ngtcp2_conn_client_new_versioned*(pconn: ptr ptr ngtcp2_conn_553648737;
+      dcid: ptr ngtcp2_cid_553648620; scid: ptr ngtcp2_cid_553648620;
+      path: ptr ngtcp2_path_553648703; client_chosen_version: uint32;
+      callbacks_version: cint; callbacks: ptr ngtcp2_callbacks_553648821;
+      settings_version: cint; settings: ptr ngtcp2_settings_553648695;
+      transport_params_version: cint; params: ptr ngtcp2_transport_params_553648664;
+      mem: ptr ngtcp2_mem_553648600; user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_conn_client_new_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_client_new_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_server_new_versioned):
-  proc ngtcp2_conn_server_new_versioned*(pconn: ptr ptr ngtcp2_conn_536871522;
-      dcid: ptr ngtcp2_cid_536871405; scid: ptr ngtcp2_cid_536871405;
-      path: ptr ngtcp2_path_536871488; client_chosen_version: uint32;
-      callbacks_version: cint; callbacks: ptr ngtcp2_callbacks_536871606;
-      settings_version: cint; settings: ptr ngtcp2_settings_536871480;
-      transport_params_version: cint; params: ptr ngtcp2_transport_params_536871449;
-      mem: ptr ngtcp2_mem_536871385; user_data: pointer): cint {.cdecl,
+  proc ngtcp2_conn_server_new_versioned*(pconn: ptr ptr ngtcp2_conn_553648737;
+      dcid: ptr ngtcp2_cid_553648620; scid: ptr ngtcp2_cid_553648620;
+      path: ptr ngtcp2_path_553648703; client_chosen_version: uint32;
+      callbacks_version: cint; callbacks: ptr ngtcp2_callbacks_553648821;
+      settings_version: cint; settings: ptr ngtcp2_settings_553648695;
+      transport_params_version: cint; params: ptr ngtcp2_transport_params_553648664;
+      mem: ptr ngtcp2_mem_553648600; user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_conn_server_new_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_server_new_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_del):
-  proc ngtcp2_conn_del*(conn: ptr ngtcp2_conn_536871522): void {.cdecl,
+  proc ngtcp2_conn_del*(conn: ptr ngtcp2_conn_553648737): void {.cdecl,
       importc: "ngtcp2_conn_del".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_del" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_read_pkt_versioned):
-  proc ngtcp2_conn_read_pkt_versioned*(conn: ptr ngtcp2_conn_536871522;
-                                       path: ptr ngtcp2_path_536871488;
+  proc ngtcp2_conn_read_pkt_versioned*(conn: ptr ngtcp2_conn_553648737;
+                                       path: ptr ngtcp2_path_553648703;
                                        pkt_info_version: cint;
-                                       pi: ptr ngtcp2_pkt_info_536871389;
+                                       pi: ptr ngtcp2_pkt_info_553648604;
                                        pkt: ptr uint8; pktlen: csize_t;
-                                       ts: ngtcp2_tstamp_536871399): cint {.
+                                       ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_conn_read_pkt_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_read_pkt_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_write_pkt_versioned):
-  proc ngtcp2_conn_write_pkt_versioned*(conn: ptr ngtcp2_conn_536871522;
-                                        path: ptr ngtcp2_path_536871488;
+  proc ngtcp2_conn_write_pkt_versioned*(conn: ptr ngtcp2_conn_553648737;
+                                        path: ptr ngtcp2_path_553648703;
                                         pkt_info_version: cint;
-                                        pi: ptr ngtcp2_pkt_info_536871389;
+                                        pi: ptr ngtcp2_pkt_info_553648604;
                                         dest: ptr uint8; destlen: csize_t;
-                                        ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+                                        ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_write_pkt_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_write_pkt_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_tls_handshake_completed):
-  proc ngtcp2_conn_tls_handshake_completed*(conn: ptr ngtcp2_conn_536871522): void {.
+  proc ngtcp2_conn_tls_handshake_completed*(conn: ptr ngtcp2_conn_553648737): void {.
       cdecl, importc: "ngtcp2_conn_tls_handshake_completed".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_tls_handshake_completed" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_handshake_completed):
-  proc ngtcp2_conn_get_handshake_completed*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_get_handshake_completed*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_get_handshake_completed".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_handshake_completed" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_initial_key):
-  proc ngtcp2_conn_install_initial_key*(conn: ptr ngtcp2_conn_536871522;
-      rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; rx_iv: ptr uint8;
-      rx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512; tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
-                                        tx_iv: ptr uint8; tx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512;
+  proc ngtcp2_conn_install_initial_key*(conn: ptr ngtcp2_conn_553648737;
+      rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; rx_iv: ptr uint8;
+      rx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727; tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
+                                        tx_iv: ptr uint8; tx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727;
                                         ivlen: csize_t): cint {.cdecl,
       importc: "ngtcp2_conn_install_initial_key".}
 else:
@@ -7960,127 +7964,127 @@ else:
     hint("Declaration of " & "ngtcp2_conn_install_initial_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_vneg_initial_key):
-  proc ngtcp2_conn_install_vneg_initial_key*(conn: ptr ngtcp2_conn_536871522;
-      version: uint32; rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
-      rx_iv: ptr uint8; rx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512;
-      tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; tx_iv: ptr uint8;
-      tx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512; ivlen: csize_t): cint {.
+  proc ngtcp2_conn_install_vneg_initial_key*(conn: ptr ngtcp2_conn_553648737;
+      version: uint32; rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
+      rx_iv: ptr uint8; rx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727;
+      tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; tx_iv: ptr uint8;
+      tx_hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727; ivlen: csize_t): cint {.
       cdecl, importc: "ngtcp2_conn_install_vneg_initial_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_vneg_initial_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_rx_handshake_key):
-  proc ngtcp2_conn_install_rx_handshake_key*(conn: ptr ngtcp2_conn_536871522;
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; iv: ptr uint8;
-      ivlen: csize_t; hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): cint {.
+  proc ngtcp2_conn_install_rx_handshake_key*(conn: ptr ngtcp2_conn_553648737;
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; iv: ptr uint8;
+      ivlen: csize_t; hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): cint {.
       cdecl, importc: "ngtcp2_conn_install_rx_handshake_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_rx_handshake_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_tx_handshake_key):
-  proc ngtcp2_conn_install_tx_handshake_key*(conn: ptr ngtcp2_conn_536871522;
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; iv: ptr uint8;
-      ivlen: csize_t; hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): cint {.
+  proc ngtcp2_conn_install_tx_handshake_key*(conn: ptr ngtcp2_conn_553648737;
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; iv: ptr uint8;
+      ivlen: csize_t; hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): cint {.
       cdecl, importc: "ngtcp2_conn_install_tx_handshake_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_tx_handshake_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_0rtt_key):
-  proc ngtcp2_conn_install_0rtt_key*(conn: ptr ngtcp2_conn_536871522;
-                                     aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+  proc ngtcp2_conn_install_0rtt_key*(conn: ptr ngtcp2_conn_553648737;
+                                     aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                      iv: ptr uint8; ivlen: csize_t;
-                                     hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): cint {.
+                                     hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): cint {.
       cdecl, importc: "ngtcp2_conn_install_0rtt_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_0rtt_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_rx_key):
-  proc ngtcp2_conn_install_rx_key*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_install_rx_key*(conn: ptr ngtcp2_conn_553648737;
                                    secret: ptr uint8; secretlen: csize_t;
-                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                    iv: ptr uint8; ivlen: csize_t;
-                                   hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): cint {.
+                                   hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): cint {.
       cdecl, importc: "ngtcp2_conn_install_rx_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_rx_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_install_tx_key):
-  proc ngtcp2_conn_install_tx_key*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_install_tx_key*(conn: ptr ngtcp2_conn_553648737;
                                    secret: ptr uint8; secretlen: csize_t;
-                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                    iv: ptr uint8; ivlen: csize_t;
-                                   hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512): cint {.
+                                   hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727): cint {.
       cdecl, importc: "ngtcp2_conn_install_tx_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_install_tx_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_initiate_key_update):
-  proc ngtcp2_conn_initiate_key_update*(conn: ptr ngtcp2_conn_536871522;
-                                        ts: ngtcp2_tstamp_536871399): cint {.
+  proc ngtcp2_conn_initiate_key_update*(conn: ptr ngtcp2_conn_553648737;
+                                        ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_conn_initiate_key_update".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_initiate_key_update" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_tls_error):
-  proc ngtcp2_conn_set_tls_error*(conn: ptr ngtcp2_conn_536871522; liberr: cint): void {.
+  proc ngtcp2_conn_set_tls_error*(conn: ptr ngtcp2_conn_553648737; liberr: cint): void {.
       cdecl, importc: "ngtcp2_conn_set_tls_error".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_tls_error" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_tls_error):
-  proc ngtcp2_conn_get_tls_error*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_get_tls_error*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_get_tls_error".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_tls_error" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_tls_alert):
-  proc ngtcp2_conn_set_tls_alert*(conn: ptr ngtcp2_conn_536871522; alert: uint8): void {.
+  proc ngtcp2_conn_set_tls_alert*(conn: ptr ngtcp2_conn_553648737; alert: uint8): void {.
       cdecl, importc: "ngtcp2_conn_set_tls_alert".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_tls_alert" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_tls_alert):
-  proc ngtcp2_conn_get_tls_alert*(conn: ptr ngtcp2_conn_536871522): uint8 {.
+  proc ngtcp2_conn_get_tls_alert*(conn: ptr ngtcp2_conn_553648737): uint8 {.
       cdecl, importc: "ngtcp2_conn_get_tls_alert".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_tls_alert" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_keep_alive_timeout):
-  proc ngtcp2_conn_set_keep_alive_timeout*(conn: ptr ngtcp2_conn_536871522;
-      timeout: ngtcp2_duration_536871401): void {.cdecl,
+  proc ngtcp2_conn_set_keep_alive_timeout*(conn: ptr ngtcp2_conn_553648737;
+      timeout: ngtcp2_duration_553648616): void {.cdecl,
       importc: "ngtcp2_conn_set_keep_alive_timeout".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_keep_alive_timeout" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_expiry):
-  proc ngtcp2_conn_get_expiry*(conn: ptr ngtcp2_conn_536871522): ngtcp2_tstamp_536871399 {.
+  proc ngtcp2_conn_get_expiry*(conn: ptr ngtcp2_conn_553648737): ngtcp2_tstamp_553648614 {.
       cdecl, importc: "ngtcp2_conn_get_expiry".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_expiry" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_handle_expiry):
-  proc ngtcp2_conn_handle_expiry*(conn: ptr ngtcp2_conn_536871522;
-                                  ts: ngtcp2_tstamp_536871399): cint {.cdecl,
+  proc ngtcp2_conn_handle_expiry*(conn: ptr ngtcp2_conn_553648737;
+                                  ts: ngtcp2_tstamp_553648614): cint {.cdecl,
       importc: "ngtcp2_conn_handle_expiry".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_handle_expiry" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_pto):
-  proc ngtcp2_conn_get_pto*(conn: ptr ngtcp2_conn_536871522): ngtcp2_duration_536871401 {.
+  proc ngtcp2_conn_get_pto*(conn: ptr ngtcp2_conn_553648737): ngtcp2_duration_553648616 {.
       cdecl, importc: "ngtcp2_conn_get_pto".}
 else:
   static :
@@ -8088,7 +8092,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_decode_and_set_remote_transport_params):
   proc ngtcp2_conn_decode_and_set_remote_transport_params*(
-      conn: ptr ngtcp2_conn_536871522; data: ptr uint8; datalen: csize_t): cint {.
+      conn: ptr ngtcp2_conn_553648737; data: ptr uint8; datalen: csize_t): cint {.
       cdecl, importc: "ngtcp2_conn_decode_and_set_remote_transport_params".}
 else:
   static :
@@ -8096,22 +8100,22 @@ else:
         "ngtcp2_conn_decode_and_set_remote_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_remote_transport_params):
-  proc ngtcp2_conn_get_remote_transport_params*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_transport_params_536871449 {.
+  proc ngtcp2_conn_get_remote_transport_params*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_transport_params_553648664 {.
       cdecl, importc: "ngtcp2_conn_get_remote_transport_params".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_remote_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_encode_0rtt_transport_params):
-  proc ngtcp2_conn_encode_0rtt_transport_params*(conn: ptr ngtcp2_conn_536871522;
-      dest: ptr uint8; destlen: csize_t): ngtcp2_ssize_536871371 {.cdecl,
+  proc ngtcp2_conn_encode_0rtt_transport_params*(conn: ptr ngtcp2_conn_553648737;
+      dest: ptr uint8; destlen: csize_t): ngtcp2_ssize_553648586 {.cdecl,
       importc: "ngtcp2_conn_encode_0rtt_transport_params".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_encode_0rtt_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_decode_and_set_0rtt_transport_params):
-  proc ngtcp2_conn_decode_and_set_0rtt_transport_params*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_decode_and_set_0rtt_transport_params*(conn: ptr ngtcp2_conn_553648737;
       data: ptr uint8; datalen: csize_t): cint {.cdecl,
       importc: "ngtcp2_conn_decode_and_set_0rtt_transport_params".}
 else:
@@ -8119,30 +8123,30 @@ else:
     hint("Declaration of " & "ngtcp2_conn_decode_and_set_0rtt_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_local_transport_params_versioned):
-  proc ngtcp2_conn_set_local_transport_params_versioned*(conn: ptr ngtcp2_conn_536871522;
-      transport_params_version: cint; params: ptr ngtcp2_transport_params_536871449): cint {.
+  proc ngtcp2_conn_set_local_transport_params_versioned*(conn: ptr ngtcp2_conn_553648737;
+      transport_params_version: cint; params: ptr ngtcp2_transport_params_553648664): cint {.
       cdecl, importc: "ngtcp2_conn_set_local_transport_params_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_local_transport_params_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_local_transport_params):
-  proc ngtcp2_conn_get_local_transport_params*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_transport_params_536871449 {.
+  proc ngtcp2_conn_get_local_transport_params*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_transport_params_553648664 {.
       cdecl, importc: "ngtcp2_conn_get_local_transport_params".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_local_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_encode_local_transport_params):
-  proc ngtcp2_conn_encode_local_transport_params*(conn: ptr ngtcp2_conn_536871522;
-      dest: ptr uint8; destlen: csize_t): ngtcp2_ssize_536871371 {.cdecl,
+  proc ngtcp2_conn_encode_local_transport_params*(conn: ptr ngtcp2_conn_553648737;
+      dest: ptr uint8; destlen: csize_t): ngtcp2_ssize_553648586 {.cdecl,
       importc: "ngtcp2_conn_encode_local_transport_params".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_encode_local_transport_params" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_open_bidi_stream):
-  proc ngtcp2_conn_open_bidi_stream*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_open_bidi_stream*(conn: ptr ngtcp2_conn_553648737;
                                      pstream_id: ptr int64;
                                      stream_user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_conn_open_bidi_stream".}
@@ -8151,7 +8155,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_open_bidi_stream" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_open_uni_stream):
-  proc ngtcp2_conn_open_uni_stream*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_open_uni_stream*(conn: ptr ngtcp2_conn_553648737;
                                     pstream_id: ptr int64;
                                     stream_user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_conn_open_uni_stream".}
@@ -8160,7 +8164,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_open_uni_stream" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_shutdown_stream):
-  proc ngtcp2_conn_shutdown_stream*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_shutdown_stream*(conn: ptr ngtcp2_conn_553648737;
                                     flags: uint32; stream_id: int64;
                                     app_error_code: uint64): cint {.cdecl,
       importc: "ngtcp2_conn_shutdown_stream".}
@@ -8169,7 +8173,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_shutdown_stream" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_shutdown_stream_write):
-  proc ngtcp2_conn_shutdown_stream_write*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_shutdown_stream_write*(conn: ptr ngtcp2_conn_553648737;
       flags: uint32; stream_id: int64; app_error_code: uint64): cint {.cdecl,
       importc: "ngtcp2_conn_shutdown_stream_write".}
 else:
@@ -8177,7 +8181,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_shutdown_stream_write" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_shutdown_stream_read):
-  proc ngtcp2_conn_shutdown_stream_read*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_shutdown_stream_read*(conn: ptr ngtcp2_conn_553648737;
       flags: uint32; stream_id: int64; app_error_code: uint64): cint {.cdecl,
       importc: "ngtcp2_conn_shutdown_stream_read".}
 else:
@@ -8185,65 +8189,65 @@ else:
     hint("Declaration of " & "ngtcp2_conn_shutdown_stream_read" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_write_stream_versioned):
-  proc ngtcp2_conn_write_stream_versioned*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; pkt_info_version: cint;
-      pi: ptr ngtcp2_pkt_info_536871389; dest: ptr uint8; destlen: csize_t;
-      pdatalen: ptr ngtcp2_ssize_536871371; flags: uint32; stream_id: int64;
-      data: ptr uint8; datalen: csize_t; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+  proc ngtcp2_conn_write_stream_versioned*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; pkt_info_version: cint;
+      pi: ptr ngtcp2_pkt_info_553648604; dest: ptr uint8; destlen: csize_t;
+      pdatalen: ptr ngtcp2_ssize_553648586; flags: uint32; stream_id: int64;
+      data: ptr uint8; datalen: csize_t; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_write_stream_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_write_stream_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_writev_stream_versioned):
-  proc ngtcp2_conn_writev_stream_versioned*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; pkt_info_version: cint;
-      pi: ptr ngtcp2_pkt_info_536871389; dest: ptr uint8; destlen: csize_t;
-      pdatalen: ptr ngtcp2_ssize_536871371; flags: uint32; stream_id: int64;
-      datav: ptr ngtcp2_vec_536871409; datavcnt: csize_t; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+  proc ngtcp2_conn_writev_stream_versioned*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; pkt_info_version: cint;
+      pi: ptr ngtcp2_pkt_info_553648604; dest: ptr uint8; destlen: csize_t;
+      pdatalen: ptr ngtcp2_ssize_553648586; flags: uint32; stream_id: int64;
+      datav: ptr ngtcp2_vec_553648624; datavcnt: csize_t; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_writev_stream_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_writev_stream_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_write_datagram_versioned):
-  proc ngtcp2_conn_write_datagram_versioned*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; pkt_info_version: cint;
-      pi: ptr ngtcp2_pkt_info_536871389; dest: ptr uint8; destlen: csize_t;
+  proc ngtcp2_conn_write_datagram_versioned*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; pkt_info_version: cint;
+      pi: ptr ngtcp2_pkt_info_553648604; dest: ptr uint8; destlen: csize_t;
       paccepted: ptr cint; flags: uint32; dgram_id: uint64; data: ptr uint8;
-      datalen: csize_t; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+      datalen: csize_t; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_write_datagram_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_write_datagram_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_writev_datagram_versioned):
-  proc ngtcp2_conn_writev_datagram_versioned*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; pkt_info_version: cint;
-      pi: ptr ngtcp2_pkt_info_536871389; dest: ptr uint8; destlen: csize_t;
+  proc ngtcp2_conn_writev_datagram_versioned*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; pkt_info_version: cint;
+      pi: ptr ngtcp2_pkt_info_553648604; dest: ptr uint8; destlen: csize_t;
       paccepted: ptr cint; flags: uint32; dgram_id: uint64;
-      datav: ptr ngtcp2_vec_536871409; datavcnt: csize_t; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+      datav: ptr ngtcp2_vec_553648624; datavcnt: csize_t; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_writev_datagram_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_writev_datagram_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_in_closing_period):
-  proc ngtcp2_conn_in_closing_period*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_in_closing_period*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_in_closing_period".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_in_closing_period" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_in_draining_period):
-  proc ngtcp2_conn_in_draining_period*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_in_draining_period*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_in_draining_period".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_in_draining_period" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_extend_max_stream_offset):
-  proc ngtcp2_conn_extend_max_stream_offset*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_extend_max_stream_offset*(conn: ptr ngtcp2_conn_553648737;
       stream_id: int64; datalen: uint64): cint {.cdecl,
       importc: "ngtcp2_conn_extend_max_stream_offset".}
 else:
@@ -8251,7 +8255,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_extend_max_stream_offset" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_extend_max_offset):
-  proc ngtcp2_conn_extend_max_offset*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_extend_max_offset*(conn: ptr ngtcp2_conn_553648737;
                                       datalen: uint64): void {.cdecl,
       importc: "ngtcp2_conn_extend_max_offset".}
 else:
@@ -8259,88 +8263,88 @@ else:
     hint("Declaration of " & "ngtcp2_conn_extend_max_offset" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_extend_max_streams_bidi):
-  proc ngtcp2_conn_extend_max_streams_bidi*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_extend_max_streams_bidi*(conn: ptr ngtcp2_conn_553648737;
       n: csize_t): void {.cdecl, importc: "ngtcp2_conn_extend_max_streams_bidi".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_extend_max_streams_bidi" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_extend_max_streams_uni):
-  proc ngtcp2_conn_extend_max_streams_uni*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_extend_max_streams_uni*(conn: ptr ngtcp2_conn_553648737;
       n: csize_t): void {.cdecl, importc: "ngtcp2_conn_extend_max_streams_uni".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_extend_max_streams_uni" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_dcid):
-  proc ngtcp2_conn_get_dcid*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_cid_536871405 {.
+  proc ngtcp2_conn_get_dcid*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_cid_553648620 {.
       cdecl, importc: "ngtcp2_conn_get_dcid".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_dcid" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_client_initial_dcid):
-  proc ngtcp2_conn_get_client_initial_dcid*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_cid_536871405 {.
+  proc ngtcp2_conn_get_client_initial_dcid*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_cid_553648620 {.
       cdecl, importc: "ngtcp2_conn_get_client_initial_dcid".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_client_initial_dcid" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_scid):
-  proc ngtcp2_conn_get_scid*(conn: ptr ngtcp2_conn_536871522;
-                             dest: ptr ngtcp2_cid_536871405): csize_t {.cdecl,
+  proc ngtcp2_conn_get_scid*(conn: ptr ngtcp2_conn_553648737;
+                             dest: ptr ngtcp2_cid_553648620): csize_t {.cdecl,
       importc: "ngtcp2_conn_get_scid".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_scid" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_active_dcid):
-  proc ngtcp2_conn_get_active_dcid*(conn: ptr ngtcp2_conn_536871522;
-                                    dest: ptr ngtcp2_cid_token_536871610): csize_t {.
+  proc ngtcp2_conn_get_active_dcid*(conn: ptr ngtcp2_conn_553648737;
+                                    dest: ptr ngtcp2_cid_token_553648825): csize_t {.
       cdecl, importc: "ngtcp2_conn_get_active_dcid".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_active_dcid" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_client_chosen_version):
-  proc ngtcp2_conn_get_client_chosen_version*(conn: ptr ngtcp2_conn_536871522): uint32 {.
+  proc ngtcp2_conn_get_client_chosen_version*(conn: ptr ngtcp2_conn_553648737): uint32 {.
       cdecl, importc: "ngtcp2_conn_get_client_chosen_version".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_client_chosen_version" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_negotiated_version):
-  proc ngtcp2_conn_get_negotiated_version*(conn: ptr ngtcp2_conn_536871522): uint32 {.
+  proc ngtcp2_conn_get_negotiated_version*(conn: ptr ngtcp2_conn_553648737): uint32 {.
       cdecl, importc: "ngtcp2_conn_get_negotiated_version".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_negotiated_version" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_tls_early_data_rejected):
-  proc ngtcp2_conn_tls_early_data_rejected*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_tls_early_data_rejected*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_tls_early_data_rejected".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_tls_early_data_rejected" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_tls_early_data_rejected):
-  proc ngtcp2_conn_get_tls_early_data_rejected*(conn: ptr ngtcp2_conn_536871522): cint {.
+  proc ngtcp2_conn_get_tls_early_data_rejected*(conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_conn_get_tls_early_data_rejected".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_tls_early_data_rejected" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_conn_info_versioned):
-  proc ngtcp2_conn_get_conn_info_versioned*(conn: ptr ngtcp2_conn_536871522;
-      conn_info_version: cint; cinfo: ptr ngtcp2_conn_info_536871460): void {.
+  proc ngtcp2_conn_get_conn_info_versioned*(conn: ptr ngtcp2_conn_553648737;
+      conn_info_version: cint; cinfo: ptr ngtcp2_conn_info_553648668): void {.
       cdecl, importc: "ngtcp2_conn_get_conn_info_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_conn_info_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_submit_crypto_data):
-  proc ngtcp2_conn_submit_crypto_data*(conn: ptr ngtcp2_conn_536871522;
-      encryption_level: ngtcp2_encryption_level_536871530; data: ptr uint8;
+  proc ngtcp2_conn_submit_crypto_data*(conn: ptr ngtcp2_conn_553648737;
+      encryption_level: ngtcp2_encryption_level_553648745; data: ptr uint8;
                                        datalen: csize_t): cint {.cdecl,
       importc: "ngtcp2_conn_submit_crypto_data".}
 else:
@@ -8348,7 +8352,7 @@ else:
     hint("Declaration of " & "ngtcp2_conn_submit_crypto_data" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_submit_new_token):
-  proc ngtcp2_conn_submit_new_token*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_submit_new_token*(conn: ptr ngtcp2_conn_553648737;
                                      token: ptr uint8; tokenlen: csize_t): cint {.
       cdecl, importc: "ngtcp2_conn_submit_new_token".}
 else:
@@ -8356,15 +8360,15 @@ else:
     hint("Declaration of " & "ngtcp2_conn_submit_new_token" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_local_addr):
-  proc ngtcp2_conn_set_local_addr*(conn: ptr ngtcp2_conn_536871522;
-                                   addr_arg: ptr ngtcp2_addr_536871484): void {.
+  proc ngtcp2_conn_set_local_addr*(conn: ptr ngtcp2_conn_553648737;
+                                   addr_arg: ptr ngtcp2_addr_553648699): void {.
       cdecl, importc: "ngtcp2_conn_set_local_addr".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_local_addr" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_path_user_data):
-  proc ngtcp2_conn_set_path_user_data*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_set_path_user_data*(conn: ptr ngtcp2_conn_553648737;
                                        path_user_data: pointer): void {.cdecl,
       importc: "ngtcp2_conn_set_path_user_data".}
 else:
@@ -8372,132 +8376,132 @@ else:
     hint("Declaration of " & "ngtcp2_conn_set_path_user_data" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_path):
-  proc ngtcp2_conn_get_path*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_path_536871488 {.
+  proc ngtcp2_conn_get_path*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_path_553648703 {.
       cdecl, importc: "ngtcp2_conn_get_path".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_path" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_max_tx_udp_payload_size):
-  proc ngtcp2_conn_get_max_tx_udp_payload_size*(conn: ptr ngtcp2_conn_536871522): csize_t {.
+  proc ngtcp2_conn_get_max_tx_udp_payload_size*(conn: ptr ngtcp2_conn_553648737): csize_t {.
       cdecl, importc: "ngtcp2_conn_get_max_tx_udp_payload_size".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_max_tx_udp_payload_size" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_path_max_tx_udp_payload_size):
-  proc ngtcp2_conn_get_path_max_tx_udp_payload_size*(conn: ptr ngtcp2_conn_536871522): csize_t {.
+  proc ngtcp2_conn_get_path_max_tx_udp_payload_size*(conn: ptr ngtcp2_conn_553648737): csize_t {.
       cdecl, importc: "ngtcp2_conn_get_path_max_tx_udp_payload_size".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_path_max_tx_udp_payload_size" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_initiate_immediate_migration):
-  proc ngtcp2_conn_initiate_immediate_migration*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; ts: ngtcp2_tstamp_536871399): cint {.
+  proc ngtcp2_conn_initiate_immediate_migration*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_conn_initiate_immediate_migration".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_initiate_immediate_migration" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_initiate_migration):
-  proc ngtcp2_conn_initiate_migration*(conn: ptr ngtcp2_conn_536871522;
-                                       path: ptr ngtcp2_path_536871488;
-                                       ts: ngtcp2_tstamp_536871399): cint {.
+  proc ngtcp2_conn_initiate_migration*(conn: ptr ngtcp2_conn_553648737;
+                                       path: ptr ngtcp2_path_553648703;
+                                       ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_conn_initiate_migration".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_initiate_migration" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_max_data_left):
-  proc ngtcp2_conn_get_max_data_left*(conn: ptr ngtcp2_conn_536871522): uint64 {.
+  proc ngtcp2_conn_get_max_data_left*(conn: ptr ngtcp2_conn_553648737): uint64 {.
       cdecl, importc: "ngtcp2_conn_get_max_data_left".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_max_data_left" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_max_stream_data_left):
-  proc ngtcp2_conn_get_max_stream_data_left*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_get_max_stream_data_left*(conn: ptr ngtcp2_conn_553648737;
       stream_id: int64): uint64 {.cdecl, importc: "ngtcp2_conn_get_max_stream_data_left".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_max_stream_data_left" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_streams_bidi_left):
-  proc ngtcp2_conn_get_streams_bidi_left*(conn: ptr ngtcp2_conn_536871522): uint64 {.
+  proc ngtcp2_conn_get_streams_bidi_left*(conn: ptr ngtcp2_conn_553648737): uint64 {.
       cdecl, importc: "ngtcp2_conn_get_streams_bidi_left".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_streams_bidi_left" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_streams_uni_left):
-  proc ngtcp2_conn_get_streams_uni_left*(conn: ptr ngtcp2_conn_536871522): uint64 {.
+  proc ngtcp2_conn_get_streams_uni_left*(conn: ptr ngtcp2_conn_553648737): uint64 {.
       cdecl, importc: "ngtcp2_conn_get_streams_uni_left".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_streams_uni_left" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_cwnd_left):
-  proc ngtcp2_conn_get_cwnd_left*(conn: ptr ngtcp2_conn_536871522): uint64 {.
+  proc ngtcp2_conn_get_cwnd_left*(conn: ptr ngtcp2_conn_553648737): uint64 {.
       cdecl, importc: "ngtcp2_conn_get_cwnd_left".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_cwnd_left" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_initial_crypto_ctx):
-  proc ngtcp2_conn_set_initial_crypto_ctx*(conn: ptr ngtcp2_conn_536871522;
-      ctx: ptr ngtcp2_crypto_ctx_536871516): void {.cdecl,
+  proc ngtcp2_conn_set_initial_crypto_ctx*(conn: ptr ngtcp2_conn_553648737;
+      ctx: ptr ngtcp2_crypto_ctx_553648731): void {.cdecl,
       importc: "ngtcp2_conn_set_initial_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_initial_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_initial_crypto_ctx):
-  proc ngtcp2_conn_get_initial_crypto_ctx*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_crypto_ctx_536871516 {.
+  proc ngtcp2_conn_get_initial_crypto_ctx*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_crypto_ctx_553648731 {.
       cdecl, importc: "ngtcp2_conn_get_initial_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_initial_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_crypto_ctx):
-  proc ngtcp2_conn_set_crypto_ctx*(conn: ptr ngtcp2_conn_536871522;
-                                   ctx: ptr ngtcp2_crypto_ctx_536871516): void {.
+  proc ngtcp2_conn_set_crypto_ctx*(conn: ptr ngtcp2_conn_553648737;
+                                   ctx: ptr ngtcp2_crypto_ctx_553648731): void {.
       cdecl, importc: "ngtcp2_conn_set_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_crypto_ctx):
-  proc ngtcp2_conn_get_crypto_ctx*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_crypto_ctx_536871516 {.
+  proc ngtcp2_conn_get_crypto_ctx*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_crypto_ctx_553648731 {.
       cdecl, importc: "ngtcp2_conn_get_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_0rtt_crypto_ctx):
-  proc ngtcp2_conn_set_0rtt_crypto_ctx*(conn: ptr ngtcp2_conn_536871522;
-                                        ctx: ptr ngtcp2_crypto_ctx_536871516): void {.
+  proc ngtcp2_conn_set_0rtt_crypto_ctx*(conn: ptr ngtcp2_conn_553648737;
+                                        ctx: ptr ngtcp2_crypto_ctx_553648731): void {.
       cdecl, importc: "ngtcp2_conn_set_0rtt_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_0rtt_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_0rtt_crypto_ctx):
-  proc ngtcp2_conn_get_0rtt_crypto_ctx*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_crypto_ctx_536871516 {.
+  proc ngtcp2_conn_get_0rtt_crypto_ctx*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_crypto_ctx_553648731 {.
       cdecl, importc: "ngtcp2_conn_get_0rtt_crypto_ctx".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_0rtt_crypto_ctx" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_tls_native_handle):
-  proc ngtcp2_conn_get_tls_native_handle*(conn: ptr ngtcp2_conn_536871522): pointer {.
+  proc ngtcp2_conn_get_tls_native_handle*(conn: ptr ngtcp2_conn_553648737): pointer {.
       cdecl, importc: "ngtcp2_conn_get_tls_native_handle".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_tls_native_handle" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_tls_native_handle):
-  proc ngtcp2_conn_set_tls_native_handle*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_set_tls_native_handle*(conn: ptr ngtcp2_conn_553648737;
       tls_native_handle: pointer): void {.cdecl,
       importc: "ngtcp2_conn_set_tls_native_handle".}
 else:
@@ -8505,23 +8509,23 @@ else:
     hint("Declaration of " & "ngtcp2_conn_set_tls_native_handle" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_retry_aead):
-  proc ngtcp2_conn_set_retry_aead*(conn: ptr ngtcp2_conn_536871522;
-                                   aead: ptr ngtcp2_crypto_aead_536871500;
-                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508): void {.
+  proc ngtcp2_conn_set_retry_aead*(conn: ptr ngtcp2_conn_553648737;
+                                   aead: ptr ngtcp2_crypto_aead_553648715;
+                                   aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723): void {.
       cdecl, importc: "ngtcp2_conn_set_retry_aead".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_set_retry_aead" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_ccerr_default):
-  proc ngtcp2_ccerr_default*(ccerr: ptr ngtcp2_ccerr_536871618): void {.cdecl,
+  proc ngtcp2_ccerr_default*(ccerr: ptr ngtcp2_ccerr_553648833): void {.cdecl,
       importc: "ngtcp2_ccerr_default".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_ccerr_default" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_ccerr_set_transport_error):
-  proc ngtcp2_ccerr_set_transport_error*(ccerr: ptr ngtcp2_ccerr_536871618;
+  proc ngtcp2_ccerr_set_transport_error*(ccerr: ptr ngtcp2_ccerr_553648833;
       error_code: uint64; reason: ptr uint8; reasonlen: csize_t): void {.cdecl,
       importc: "ngtcp2_ccerr_set_transport_error".}
 else:
@@ -8529,7 +8533,7 @@ else:
     hint("Declaration of " & "ngtcp2_ccerr_set_transport_error" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_ccerr_set_liberr):
-  proc ngtcp2_ccerr_set_liberr*(ccerr: ptr ngtcp2_ccerr_536871618; liberr: cint;
+  proc ngtcp2_ccerr_set_liberr*(ccerr: ptr ngtcp2_ccerr_553648833; liberr: cint;
                                 reason: ptr uint8; reasonlen: csize_t): void {.
       cdecl, importc: "ngtcp2_ccerr_set_liberr".}
 else:
@@ -8537,7 +8541,7 @@ else:
     hint("Declaration of " & "ngtcp2_ccerr_set_liberr" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_ccerr_set_tls_alert):
-  proc ngtcp2_ccerr_set_tls_alert*(ccerr: ptr ngtcp2_ccerr_536871618;
+  proc ngtcp2_ccerr_set_tls_alert*(ccerr: ptr ngtcp2_ccerr_553648833;
                                    tls_alert: uint8; reason: ptr uint8;
                                    reasonlen: csize_t): void {.cdecl,
       importc: "ngtcp2_ccerr_set_tls_alert".}
@@ -8546,7 +8550,7 @@ else:
     hint("Declaration of " & "ngtcp2_ccerr_set_tls_alert" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_ccerr_set_application_error):
-  proc ngtcp2_ccerr_set_application_error*(ccerr: ptr ngtcp2_ccerr_536871618;
+  proc ngtcp2_ccerr_set_application_error*(ccerr: ptr ngtcp2_ccerr_553648833;
       error_code: uint64; reason: ptr uint8; reasonlen: csize_t): void {.cdecl,
       importc: "ngtcp2_ccerr_set_application_error".}
 else:
@@ -8554,24 +8558,24 @@ else:
     hint("Declaration of " & "ngtcp2_ccerr_set_application_error" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_write_connection_close_versioned):
-  proc ngtcp2_conn_write_connection_close_versioned*(conn: ptr ngtcp2_conn_536871522;
-      path: ptr ngtcp2_path_536871488; pkt_info_version: cint;
-      pi: ptr ngtcp2_pkt_info_536871389; dest: ptr uint8; destlen: csize_t;
-      ccerr: ptr ngtcp2_ccerr_536871618; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+  proc ngtcp2_conn_write_connection_close_versioned*(conn: ptr ngtcp2_conn_553648737;
+      path: ptr ngtcp2_path_553648703; pkt_info_version: cint;
+      pi: ptr ngtcp2_pkt_info_553648604; dest: ptr uint8; destlen: csize_t;
+      ccerr: ptr ngtcp2_ccerr_553648833; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_conn_write_connection_close_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_write_connection_close_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_ccerr):
-  proc ngtcp2_conn_get_ccerr*(conn: ptr ngtcp2_conn_536871522): ptr ngtcp2_ccerr_536871618 {.
+  proc ngtcp2_conn_get_ccerr*(conn: ptr ngtcp2_conn_553648737): ptr ngtcp2_ccerr_553648833 {.
       cdecl, importc: "ngtcp2_conn_get_ccerr".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_ccerr" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_is_local_stream):
-  proc ngtcp2_conn_is_local_stream*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_is_local_stream*(conn: ptr ngtcp2_conn_553648737;
                                     stream_id: int64): cint {.cdecl,
       importc: "ngtcp2_conn_is_local_stream".}
 else:
@@ -8579,21 +8583,21 @@ else:
     hint("Declaration of " & "ngtcp2_conn_is_local_stream" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_is_server):
-  proc ngtcp2_conn_is_server*(conn: ptr ngtcp2_conn_536871522): cint {.cdecl,
+  proc ngtcp2_conn_is_server*(conn: ptr ngtcp2_conn_553648737): cint {.cdecl,
       importc: "ngtcp2_conn_is_server".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_is_server" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_after_retry):
-  proc ngtcp2_conn_after_retry*(conn: ptr ngtcp2_conn_536871522): cint {.cdecl,
+  proc ngtcp2_conn_after_retry*(conn: ptr ngtcp2_conn_553648737): cint {.cdecl,
       importc: "ngtcp2_conn_after_retry".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_after_retry" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_set_stream_user_data):
-  proc ngtcp2_conn_set_stream_user_data*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_set_stream_user_data*(conn: ptr ngtcp2_conn_553648737;
       stream_id: int64; stream_user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_conn_set_stream_user_data".}
 else:
@@ -8601,22 +8605,22 @@ else:
     hint("Declaration of " & "ngtcp2_conn_set_stream_user_data" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_update_pkt_tx_time):
-  proc ngtcp2_conn_update_pkt_tx_time*(conn: ptr ngtcp2_conn_536871522;
-                                       ts: ngtcp2_tstamp_536871399): void {.
+  proc ngtcp2_conn_update_pkt_tx_time*(conn: ptr ngtcp2_conn_553648737;
+                                       ts: ngtcp2_tstamp_553648614): void {.
       cdecl, importc: "ngtcp2_conn_update_pkt_tx_time".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_update_pkt_tx_time" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_send_quantum):
-  proc ngtcp2_conn_get_send_quantum*(conn: ptr ngtcp2_conn_536871522): csize_t {.
+  proc ngtcp2_conn_get_send_quantum*(conn: ptr ngtcp2_conn_553648737): csize_t {.
       cdecl, importc: "ngtcp2_conn_get_send_quantum".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_conn_get_send_quantum" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_conn_get_stream_loss_count):
-  proc ngtcp2_conn_get_stream_loss_count*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_conn_get_stream_loss_count*(conn: ptr ngtcp2_conn_553648737;
       stream_id: int64): csize_t {.cdecl,
                                    importc: "ngtcp2_conn_get_stream_loss_count".}
 else:
@@ -8645,29 +8649,29 @@ else:
     hint("Declaration of " & "ngtcp2_err_infer_quic_transport_error_code" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_addr_init):
-  proc ngtcp2_addr_init*(dest: ptr ngtcp2_addr_536871484;
-                         addr_arg: ptr ngtcp2_sockaddr_536871419;
-                         addrlen: ngtcp2_socklen_536871431): ptr ngtcp2_addr_536871484 {.
+  proc ngtcp2_addr_init*(dest: ptr ngtcp2_addr_553648699;
+                         addr_arg: ptr ngtcp2_sockaddr_553648634;
+                         addrlen: ngtcp2_socklen_553648646): ptr ngtcp2_addr_553648699 {.
       cdecl, importc: "ngtcp2_addr_init".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_addr_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_addr_copy_byte):
-  proc ngtcp2_addr_copy_byte*(dest: ptr ngtcp2_addr_536871484;
-                              addr_arg: ptr ngtcp2_sockaddr_536871419;
-                              addrlen: ngtcp2_socklen_536871431): void {.cdecl,
+  proc ngtcp2_addr_copy_byte*(dest: ptr ngtcp2_addr_553648699;
+                              addr_arg: ptr ngtcp2_sockaddr_553648634;
+                              addrlen: ngtcp2_socklen_553648646): void {.cdecl,
       importc: "ngtcp2_addr_copy_byte".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_addr_copy_byte" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_path_storage_init):
-  proc ngtcp2_path_storage_init*(ps: ptr ngtcp2_path_storage_536871492;
-                                 local_addr: ptr ngtcp2_sockaddr_536871419;
-                                 local_addrlen: ngtcp2_socklen_536871431;
-                                 remote_addr: ptr ngtcp2_sockaddr_536871419;
-                                 remote_addrlen: ngtcp2_socklen_536871431;
+  proc ngtcp2_path_storage_init*(ps: ptr ngtcp2_path_storage_553648707;
+                                 local_addr: ptr ngtcp2_sockaddr_553648634;
+                                 local_addrlen: ngtcp2_socklen_553648646;
+                                 remote_addr: ptr ngtcp2_sockaddr_553648634;
+                                 remote_addrlen: ngtcp2_socklen_553648646;
                                  user_data: pointer): void {.cdecl,
       importc: "ngtcp2_path_storage_init".}
 else:
@@ -8675,7 +8679,7 @@ else:
     hint("Declaration of " & "ngtcp2_path_storage_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_path_storage_zero):
-  proc ngtcp2_path_storage_zero*(ps: ptr ngtcp2_path_storage_536871492): void {.
+  proc ngtcp2_path_storage_zero*(ps: ptr ngtcp2_path_storage_553648707): void {.
       cdecl, importc: "ngtcp2_path_storage_zero".}
 else:
   static :
@@ -8683,7 +8687,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_settings_default_versioned):
   proc ngtcp2_settings_default_versioned*(settings_version: cint;
-      settings: ptr ngtcp2_settings_536871480): void {.cdecl,
+      settings: ptr ngtcp2_settings_553648695): void {.cdecl,
       importc: "ngtcp2_settings_default_versioned".}
 else:
   static :
@@ -8691,21 +8695,21 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_transport_params_default_versioned):
   proc ngtcp2_transport_params_default_versioned*(
-      transport_params_version: cint; params: ptr ngtcp2_transport_params_536871449): void {.
+      transport_params_version: cint; params: ptr ngtcp2_transport_params_553648664): void {.
       cdecl, importc: "ngtcp2_transport_params_default_versioned".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_transport_params_default_versioned" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_mem_default):
-  proc ngtcp2_mem_default*(): ptr ngtcp2_mem_536871385 {.cdecl,
+  proc ngtcp2_mem_default*(): ptr ngtcp2_mem_553648600 {.cdecl,
       importc: "ngtcp2_mem_default".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_mem_default" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_version):
-  proc ngtcp2_version*(least_version: cint): ptr ngtcp2_info_536871622 {.cdecl,
+  proc ngtcp2_version*(least_version: cint): ptr ngtcp2_info_553648837 {.cdecl,
       importc: "ngtcp2_version".}
 else:
   static :
@@ -8719,14 +8723,14 @@ else:
     hint("Declaration of " & "ngtcp2_is_bidi_stream" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_path_copy):
-  proc ngtcp2_path_copy*(dest: ptr ngtcp2_path_536871488; src: ptr ngtcp2_path_536871488): void {.
+  proc ngtcp2_path_copy*(dest: ptr ngtcp2_path_553648703; src: ptr ngtcp2_path_553648703): void {.
       cdecl, importc: "ngtcp2_path_copy".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_path_copy" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_path_eq):
-  proc ngtcp2_path_eq*(a: ptr ngtcp2_path_536871488; b: ptr ngtcp2_path_536871488): cint {.
+  proc ngtcp2_path_eq*(a: ptr ngtcp2_path_553648703; b: ptr ngtcp2_path_553648703): cint {.
       cdecl, importc: "ngtcp2_path_eq".}
 else:
   static :
@@ -8757,52 +8761,52 @@ else:
     hint("Declaration of " & "ngtcp2_select_version" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_ctx_tls):
-  proc ngtcp2_crypto_ctx_tls*(ctx: ptr ngtcp2_crypto_ctx_536871516;
-                              tls_native_handle: pointer): ptr ngtcp2_crypto_ctx_536871516 {.
+  proc ngtcp2_crypto_ctx_tls*(ctx: ptr ngtcp2_crypto_ctx_553648731;
+                              tls_native_handle: pointer): ptr ngtcp2_crypto_ctx_553648731 {.
       cdecl, importc: "ngtcp2_crypto_ctx_tls".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_ctx_tls" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_ctx_tls_early):
-  proc ngtcp2_crypto_ctx_tls_early*(ctx: ptr ngtcp2_crypto_ctx_536871516;
-                                    tls_native_handle: pointer): ptr ngtcp2_crypto_ctx_536871516 {.
+  proc ngtcp2_crypto_ctx_tls_early*(ctx: ptr ngtcp2_crypto_ctx_553648731;
+                                    tls_native_handle: pointer): ptr ngtcp2_crypto_ctx_553648731 {.
       cdecl, importc: "ngtcp2_crypto_ctx_tls_early".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_ctx_tls_early" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_md_init):
-  proc ngtcp2_crypto_md_init*(md: ptr ngtcp2_crypto_md_536871496;
-                              md_native_handle: pointer): ptr ngtcp2_crypto_md_536871496 {.
+  proc ngtcp2_crypto_md_init*(md: ptr ngtcp2_crypto_md_553648711;
+                              md_native_handle: pointer): ptr ngtcp2_crypto_md_553648711 {.
       cdecl, importc: "ngtcp2_crypto_md_init".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_md_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_md_hashlen):
-  proc ngtcp2_crypto_md_hashlen*(md: ptr ngtcp2_crypto_md_536871496): csize_t {.
+  proc ngtcp2_crypto_md_hashlen*(md: ptr ngtcp2_crypto_md_553648711): csize_t {.
       cdecl, importc: "ngtcp2_crypto_md_hashlen".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_md_hashlen" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead_keylen):
-  proc ngtcp2_crypto_aead_keylen*(aead: ptr ngtcp2_crypto_aead_536871500): csize_t {.
+  proc ngtcp2_crypto_aead_keylen*(aead: ptr ngtcp2_crypto_aead_553648715): csize_t {.
       cdecl, importc: "ngtcp2_crypto_aead_keylen".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_aead_keylen" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead_noncelen):
-  proc ngtcp2_crypto_aead_noncelen*(aead: ptr ngtcp2_crypto_aead_536871500): csize_t {.
+  proc ngtcp2_crypto_aead_noncelen*(aead: ptr ngtcp2_crypto_aead_553648715): csize_t {.
       cdecl, importc: "ngtcp2_crypto_aead_noncelen".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_aead_noncelen" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_hkdf_extract):
-  proc ngtcp2_crypto_hkdf_extract*(dest: ptr uint8; md: ptr ngtcp2_crypto_md_536871496;
+  proc ngtcp2_crypto_hkdf_extract*(dest: ptr uint8; md: ptr ngtcp2_crypto_md_553648711;
                                    secret: ptr uint8; secretlen: csize_t;
                                    salt: ptr uint8; saltlen: csize_t): cint {.
       cdecl, importc: "ngtcp2_crypto_hkdf_extract".}
@@ -8812,7 +8816,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_hkdf_expand):
   proc ngtcp2_crypto_hkdf_expand*(dest: ptr uint8; destlen: csize_t;
-                                  md: ptr ngtcp2_crypto_md_536871496;
+                                  md: ptr ngtcp2_crypto_md_553648711;
                                   secret: ptr uint8; secretlen: csize_t;
                                   info: ptr uint8; infolen: csize_t): cint {.
       cdecl, importc: "ngtcp2_crypto_hkdf_expand".}
@@ -8822,7 +8826,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_hkdf):
   proc ngtcp2_crypto_hkdf*(dest: ptr uint8; destlen: csize_t;
-                           md: ptr ngtcp2_crypto_md_536871496;
+                           md: ptr ngtcp2_crypto_md_553648711;
                            secret: ptr uint8; secretlen: csize_t;
                            salt: ptr uint8; saltlen: csize_t; info: ptr uint8;
                            infolen: csize_t): cint {.cdecl,
@@ -8832,15 +8836,15 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_hkdf" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_packet_protection_ivlen):
-  proc ngtcp2_crypto_packet_protection_ivlen*(aead: ptr ngtcp2_crypto_aead_536871500): csize_t {.
+  proc ngtcp2_crypto_packet_protection_ivlen*(aead: ptr ngtcp2_crypto_aead_553648715): csize_t {.
       cdecl, importc: "ngtcp2_crypto_packet_protection_ivlen".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_packet_protection_ivlen" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_encrypt):
-  proc ngtcp2_crypto_encrypt*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_536871500;
-                              aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+  proc ngtcp2_crypto_encrypt*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_553648715;
+                              aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                               plaintext: ptr uint8; plaintextlen: csize_t;
                               nonce: ptr uint8; noncelen: csize_t;
                               aad: ptr uint8; aadlen: csize_t): cint {.cdecl,
@@ -8850,8 +8854,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_encrypt" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_encrypt_cb):
-  proc ngtcp2_crypto_encrypt_cb*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_536871500;
-                                 aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+  proc ngtcp2_crypto_encrypt_cb*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_553648715;
+                                 aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                  plaintext: ptr uint8; plaintextlen: csize_t;
                                  nonce: ptr uint8; noncelen: csize_t;
                                  aad: ptr uint8; aadlen: csize_t): cint {.cdecl,
@@ -8861,8 +8865,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_encrypt_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_decrypt):
-  proc ngtcp2_crypto_decrypt*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_536871500;
-                              aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+  proc ngtcp2_crypto_decrypt*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_553648715;
+                              aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                               ciphertext: ptr uint8; ciphertextlen: csize_t;
                               nonce: ptr uint8; noncelen: csize_t;
                               aad: ptr uint8; aadlen: csize_t): cint {.cdecl,
@@ -8872,8 +8876,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_decrypt" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_decrypt_cb):
-  proc ngtcp2_crypto_decrypt_cb*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_536871500;
-                                 aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+  proc ngtcp2_crypto_decrypt_cb*(dest: ptr uint8; aead: ptr ngtcp2_crypto_aead_553648715;
+                                 aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                  ciphertext: ptr uint8; ciphertextlen: csize_t;
                                  nonce: ptr uint8; noncelen: csize_t;
                                  aad: ptr uint8; aadlen: csize_t): cint {.cdecl,
@@ -8883,8 +8887,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_decrypt_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_hp_mask):
-  proc ngtcp2_crypto_hp_mask*(dest: ptr uint8; hp: ptr ngtcp2_crypto_cipher_536871504;
-                              hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512;
+  proc ngtcp2_crypto_hp_mask*(dest: ptr uint8; hp: ptr ngtcp2_crypto_cipher_553648719;
+                              hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727;
                               sample: ptr uint8): cint {.cdecl,
       importc: "ngtcp2_crypto_hp_mask".}
 else:
@@ -8892,8 +8896,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_hp_mask" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_hp_mask_cb):
-  proc ngtcp2_crypto_hp_mask_cb*(dest: ptr uint8; hp: ptr ngtcp2_crypto_cipher_536871504;
-                                 hp_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512;
+  proc ngtcp2_crypto_hp_mask_cb*(dest: ptr uint8; hp: ptr ngtcp2_crypto_cipher_553648719;
+                                 hp_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727;
                                  sample: ptr uint8): cint {.cdecl,
       importc: "ngtcp2_crypto_hp_mask_cb".}
 else:
@@ -8901,29 +8905,29 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_hp_mask_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_derive_and_install_rx_key):
-  proc ngtcp2_crypto_derive_and_install_rx_key*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_derive_and_install_rx_key*(conn: ptr ngtcp2_conn_553648737;
       key: ptr uint8; iv: ptr uint8; hp: ptr uint8;
-      level: ngtcp2_encryption_level_536871530; secret: ptr uint8;
+      level: ngtcp2_encryption_level_553648745; secret: ptr uint8;
       secretlen: csize_t): cint {.cdecl, importc: "ngtcp2_crypto_derive_and_install_rx_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_derive_and_install_rx_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_derive_and_install_tx_key):
-  proc ngtcp2_crypto_derive_and_install_tx_key*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_derive_and_install_tx_key*(conn: ptr ngtcp2_conn_553648737;
       key: ptr uint8; iv: ptr uint8; hp: ptr uint8;
-      level: ngtcp2_encryption_level_536871530; secret: ptr uint8;
+      level: ngtcp2_encryption_level_553648745; secret: ptr uint8;
       secretlen: csize_t): cint {.cdecl, importc: "ngtcp2_crypto_derive_and_install_tx_key".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_derive_and_install_tx_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_update_key):
-  proc ngtcp2_crypto_update_key*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_update_key*(conn: ptr ngtcp2_conn_553648737;
                                  rx_secret: ptr uint8; tx_secret: ptr uint8;
-                                 rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                 rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                  rx_key: ptr uint8; rx_iv: ptr uint8;
-                                 tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                 tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                  tx_key: ptr uint8; tx_iv: ptr uint8;
                                  current_rx_secret: ptr uint8;
                                  current_tx_secret: ptr uint8;
@@ -8934,11 +8938,11 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_update_key" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_update_key_cb):
-  proc ngtcp2_crypto_update_key_cb*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_update_key_cb*(conn: ptr ngtcp2_conn_553648737;
                                     rx_secret: ptr uint8; tx_secret: ptr uint8;
-                                    rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                    rx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                     rx_iv: ptr uint8;
-                                    tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
+                                    tx_aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
                                     tx_iv: ptr uint8;
                                     current_rx_secret: ptr uint8;
                                     current_tx_secret: ptr uint8;
@@ -8949,7 +8953,7 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_update_key_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_client_initial_cb):
-  proc ngtcp2_crypto_client_initial_cb*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_client_initial_cb*(conn: ptr ngtcp2_conn_553648737;
                                         user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_crypto_client_initial_cb".}
 else:
@@ -8957,8 +8961,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_client_initial_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_recv_retry_cb):
-  proc ngtcp2_crypto_recv_retry_cb*(conn: ptr ngtcp2_conn_536871522;
-                                    hd: ptr ngtcp2_pkt_hd_536871413;
+  proc ngtcp2_crypto_recv_retry_cb*(conn: ptr ngtcp2_conn_553648737;
+                                    hd: ptr ngtcp2_pkt_hd_553648628;
                                     user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_crypto_recv_retry_cb".}
 else:
@@ -8966,16 +8970,16 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_recv_retry_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_recv_client_initial_cb):
-  proc ngtcp2_crypto_recv_client_initial_cb*(conn: ptr ngtcp2_conn_536871522;
-      dcid: ptr ngtcp2_cid_536871405; user_data: pointer): cint {.cdecl,
+  proc ngtcp2_crypto_recv_client_initial_cb*(conn: ptr ngtcp2_conn_553648737;
+      dcid: ptr ngtcp2_cid_553648620; user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_crypto_recv_client_initial_cb".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_recv_client_initial_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_read_write_crypto_data):
-  proc ngtcp2_crypto_read_write_crypto_data*(conn: ptr ngtcp2_conn_536871522;
-      encryption_level: ngtcp2_encryption_level_536871530; data: ptr uint8;
+  proc ngtcp2_crypto_read_write_crypto_data*(conn: ptr ngtcp2_conn_553648737;
+      encryption_level: ngtcp2_encryption_level_553648745; data: ptr uint8;
       datalen: csize_t): cint {.cdecl,
                                 importc: "ngtcp2_crypto_read_write_crypto_data".}
 else:
@@ -8983,8 +8987,8 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_read_write_crypto_data" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_recv_crypto_data_cb):
-  proc ngtcp2_crypto_recv_crypto_data_cb*(conn: ptr ngtcp2_conn_536871522;
-      encryption_level: ngtcp2_encryption_level_536871530; offset: uint64;
+  proc ngtcp2_crypto_recv_crypto_data_cb*(conn: ptr ngtcp2_conn_553648737;
+      encryption_level: ngtcp2_encryption_level_553648745; offset: uint64;
       data: ptr uint8; datalen: csize_t; user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_crypto_recv_crypto_data_cb".}
 else:
@@ -8993,7 +8997,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_generate_stateless_reset_token):
   proc ngtcp2_crypto_generate_stateless_reset_token*(token: ptr uint8;
-      secret: ptr uint8; secretlen: csize_t; cid: ptr ngtcp2_cid_536871405): cint {.
+      secret: ptr uint8; secretlen: csize_t; cid: ptr ngtcp2_cid_553648620): cint {.
       cdecl, importc: "ngtcp2_crypto_generate_stateless_reset_token".}
 else:
   static :
@@ -9001,20 +9005,20 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_generate_retry_token):
   proc ngtcp2_crypto_generate_retry_token*(token: ptr uint8; secret: ptr uint8;
-      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; retry_scid: ptr ngtcp2_cid_536871405;
-      odcid: ptr ngtcp2_cid_536871405; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; retry_scid: ptr ngtcp2_cid_553648620;
+      odcid: ptr ngtcp2_cid_553648620; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_crypto_generate_retry_token".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_generate_retry_token" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_verify_retry_token):
-  proc ngtcp2_crypto_verify_retry_token*(odcid: ptr ngtcp2_cid_536871405;
+  proc ngtcp2_crypto_verify_retry_token*(odcid: ptr ngtcp2_cid_553648620;
       token: ptr uint8; tokenlen: csize_t; secret: ptr uint8;
-      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; dcid: ptr ngtcp2_cid_536871405;
-      timeout: ngtcp2_duration_536871401; ts: ngtcp2_tstamp_536871399): cint {.
+      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; dcid: ptr ngtcp2_cid_553648620;
+      timeout: ngtcp2_duration_553648616; ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_crypto_verify_retry_token".}
 else:
   static :
@@ -9022,20 +9026,20 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_generate_retry_token2):
   proc ngtcp2_crypto_generate_retry_token2*(token: ptr uint8; secret: ptr uint8;
-      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; retry_scid: ptr ngtcp2_cid_536871405;
-      odcid: ptr ngtcp2_cid_536871405; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; retry_scid: ptr ngtcp2_cid_553648620;
+      odcid: ptr ngtcp2_cid_553648620; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_crypto_generate_retry_token2".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_generate_retry_token2" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_verify_retry_token2):
-  proc ngtcp2_crypto_verify_retry_token2*(odcid: ptr ngtcp2_cid_536871405;
+  proc ngtcp2_crypto_verify_retry_token2*(odcid: ptr ngtcp2_cid_553648620;
       token: ptr uint8; tokenlen: csize_t; secret: ptr uint8;
-      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; dcid: ptr ngtcp2_cid_536871405;
-      timeout: ngtcp2_duration_536871401; ts: ngtcp2_tstamp_536871399): cint {.
+      secretlen: csize_t; version: uint32; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; dcid: ptr ngtcp2_cid_553648620;
+      timeout: ngtcp2_duration_553648616; ts: ngtcp2_tstamp_553648614): cint {.
       cdecl, importc: "ngtcp2_crypto_verify_retry_token2".}
 else:
   static :
@@ -9043,8 +9047,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_generate_regular_token):
   proc ngtcp2_crypto_generate_regular_token*(token: ptr uint8;
-      secret: ptr uint8; secretlen: csize_t; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; ts: ngtcp2_tstamp_536871399): ngtcp2_ssize_536871371 {.
+      secret: ptr uint8; secretlen: csize_t; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; ts: ngtcp2_tstamp_553648614): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_crypto_generate_regular_token".}
 else:
   static :
@@ -9052,9 +9056,9 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_verify_regular_token):
   proc ngtcp2_crypto_verify_regular_token*(token: ptr uint8; tokenlen: csize_t;
-      secret: ptr uint8; secretlen: csize_t; remote_addr: ptr ngtcp2_sockaddr_536871419;
-      remote_addrlen: ngtcp2_socklen_536871431; timeout: ngtcp2_duration_536871401;
-      ts: ngtcp2_tstamp_536871399): cint {.cdecl,
+      secret: ptr uint8; secretlen: csize_t; remote_addr: ptr ngtcp2_sockaddr_553648634;
+      remote_addrlen: ngtcp2_socklen_553648646; timeout: ngtcp2_duration_553648616;
+      ts: ngtcp2_tstamp_553648614): cint {.cdecl,
       importc: "ngtcp2_crypto_verify_regular_token".}
 else:
   static :
@@ -9062,8 +9066,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_write_connection_close):
   proc ngtcp2_crypto_write_connection_close*(dest: ptr uint8; destlen: csize_t;
-      version: uint32; dcid: ptr ngtcp2_cid_536871405; scid: ptr ngtcp2_cid_536871405;
-      error_code: uint64; reason: ptr uint8; reasonlen: csize_t): ngtcp2_ssize_536871371 {.
+      version: uint32; dcid: ptr ngtcp2_cid_553648620; scid: ptr ngtcp2_cid_553648620;
+      error_code: uint64; reason: ptr uint8; reasonlen: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_crypto_write_connection_close".}
 else:
   static :
@@ -9071,10 +9075,10 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_write_retry):
   proc ngtcp2_crypto_write_retry*(dest: ptr uint8; destlen: csize_t;
-                                  version: uint32; dcid: ptr ngtcp2_cid_536871405;
-                                  scid: ptr ngtcp2_cid_536871405;
-                                  odcid: ptr ngtcp2_cid_536871405;
-                                  token: ptr uint8; tokenlen: csize_t): ngtcp2_ssize_536871371 {.
+                                  version: uint32; dcid: ptr ngtcp2_cid_553648620;
+                                  scid: ptr ngtcp2_cid_553648620;
+                                  odcid: ptr ngtcp2_cid_553648620;
+                                  token: ptr uint8; tokenlen: csize_t): ngtcp2_ssize_553648586 {.
       cdecl, importc: "ngtcp2_crypto_write_retry".}
 else:
   static :
@@ -9082,8 +9086,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead_ctx_encrypt_init):
   proc ngtcp2_crypto_aead_ctx_encrypt_init*(
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
-      aead: ptr ngtcp2_crypto_aead_536871500; key: ptr uint8; noncelen: csize_t): cint {.
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
+      aead: ptr ngtcp2_crypto_aead_553648715; key: ptr uint8; noncelen: csize_t): cint {.
       cdecl, importc: "ngtcp2_crypto_aead_ctx_encrypt_init".}
 else:
   static :
@@ -9091,38 +9095,38 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead_ctx_decrypt_init):
   proc ngtcp2_crypto_aead_ctx_decrypt_init*(
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508;
-      aead: ptr ngtcp2_crypto_aead_536871500; key: ptr uint8; noncelen: csize_t): cint {.
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723;
+      aead: ptr ngtcp2_crypto_aead_553648715; key: ptr uint8; noncelen: csize_t): cint {.
       cdecl, importc: "ngtcp2_crypto_aead_ctx_decrypt_init".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_aead_ctx_decrypt_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_aead_ctx_free):
-  proc ngtcp2_crypto_aead_ctx_free*(aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508): void {.
+  proc ngtcp2_crypto_aead_ctx_free*(aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723): void {.
       cdecl, importc: "ngtcp2_crypto_aead_ctx_free".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_aead_ctx_free" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_delete_crypto_aead_ctx_cb):
-  proc ngtcp2_crypto_delete_crypto_aead_ctx_cb*(conn: ptr ngtcp2_conn_536871522;
-      aead_ctx: ptr ngtcp2_crypto_aead_ctx_536871508; user_data: pointer): void {.
+  proc ngtcp2_crypto_delete_crypto_aead_ctx_cb*(conn: ptr ngtcp2_conn_553648737;
+      aead_ctx: ptr ngtcp2_crypto_aead_ctx_553648723; user_data: pointer): void {.
       cdecl, importc: "ngtcp2_crypto_delete_crypto_aead_ctx_cb".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_delete_crypto_aead_ctx_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_delete_crypto_cipher_ctx_cb):
-  proc ngtcp2_crypto_delete_crypto_cipher_ctx_cb*(conn: ptr ngtcp2_conn_536871522;
-      cipher_ctx: ptr ngtcp2_crypto_cipher_ctx_536871512; user_data: pointer): void {.
+  proc ngtcp2_crypto_delete_crypto_cipher_ctx_cb*(conn: ptr ngtcp2_conn_553648737;
+      cipher_ctx: ptr ngtcp2_crypto_cipher_ctx_553648727; user_data: pointer): void {.
       cdecl, importc: "ngtcp2_crypto_delete_crypto_cipher_ctx_cb".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_delete_crypto_cipher_ctx_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_get_path_challenge_data_cb):
-  proc ngtcp2_crypto_get_path_challenge_data_cb*(conn: ptr ngtcp2_conn_536871522;
+  proc ngtcp2_crypto_get_path_challenge_data_cb*(conn: ptr ngtcp2_conn_553648737;
       data: ptr uint8; user_data: pointer): cint {.cdecl,
       importc: "ngtcp2_crypto_get_path_challenge_data_cb".}
 else:
@@ -9130,29 +9134,29 @@ else:
     hint("Declaration of " & "ngtcp2_crypto_get_path_challenge_data_cb" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_version_negotiation_cb):
-  proc ngtcp2_crypto_version_negotiation_cb*(conn: ptr ngtcp2_conn_536871522;
-      version: uint32; client_dcid: ptr ngtcp2_cid_536871405; user_data: pointer): cint {.
+  proc ngtcp2_crypto_version_negotiation_cb*(conn: ptr ngtcp2_conn_553648737;
+      version: uint32; client_dcid: ptr ngtcp2_cid_553648620; user_data: pointer): cint {.
       cdecl, importc: "ngtcp2_crypto_version_negotiation_cb".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_version_negotiation_cb" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_release_memory):
-  proc ptls_buffer_release_memory*(buf: ptr ptls_buffer_t_536871644): void {.
+  proc ptls_buffer_release_memory*(buf: ptr ptls_buffer_t_553648859): void {.
       cdecl, importc: "ptls_buffer__release_memory".}
 else:
   static :
     hint("Declaration of " & "ptls_buffer_release_memory" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_reserve):
-  proc ptls_buffer_reserve*(buf: ptr ptls_buffer_t_536871644; delta: csize_t): cint {.
+  proc ptls_buffer_reserve*(buf: ptr ptls_buffer_t_553648859; delta: csize_t): cint {.
       cdecl, importc: "ptls_buffer_reserve".}
 else:
   static :
     hint("Declaration of " & "ptls_buffer_reserve" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_reserve_aligned):
-  proc ptls_buffer_reserve_aligned*(buf: ptr ptls_buffer_t_536871644;
+  proc ptls_buffer_reserve_aligned*(buf: ptr ptls_buffer_t_553648859;
                                     delta: csize_t; align_bits: uint8): cint {.
       cdecl, importc: "ptls_buffer_reserve_aligned".}
 else:
@@ -9160,7 +9164,7 @@ else:
     hint("Declaration of " & "ptls_buffer_reserve_aligned" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_do_pushv):
-  proc ptls_buffer_do_pushv*(buf: ptr ptls_buffer_t_536871644; src: pointer;
+  proc ptls_buffer_do_pushv*(buf: ptr ptls_buffer_t_553648859; src: pointer;
                              len: csize_t): cint {.cdecl,
       importc: "ptls_buffer__do_pushv".}
 else:
@@ -9168,7 +9172,7 @@ else:
     hint("Declaration of " & "ptls_buffer_do_pushv" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_adjust_quic_blocksize):
-  proc ptls_buffer_adjust_quic_blocksize*(buf: ptr ptls_buffer_t_536871644;
+  proc ptls_buffer_adjust_quic_blocksize*(buf: ptr ptls_buffer_t_553648859;
       body_size: csize_t): cint {.cdecl,
                                   importc: "ptls_buffer__adjust_quic_blocksize".}
 else:
@@ -9176,7 +9180,7 @@ else:
     hint("Declaration of " & "ptls_buffer_adjust_quic_blocksize" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_adjust_asn1_blocksize):
-  proc ptls_buffer_adjust_asn1_blocksize*(buf: ptr ptls_buffer_t_536871644;
+  proc ptls_buffer_adjust_asn1_blocksize*(buf: ptr ptls_buffer_t_553648859;
       body_size: csize_t): cint {.cdecl,
                                   importc: "ptls_buffer__adjust_asn1_blocksize".}
 else:
@@ -9184,7 +9188,7 @@ else:
     hint("Declaration of " & "ptls_buffer_adjust_asn1_blocksize" &
         " already exists, not redeclaring")
 when not declared(ptls_buffer_push_asn1_ubigint):
-  proc ptls_buffer_push_asn1_ubigint*(buf: ptr ptls_buffer_t_536871644;
+  proc ptls_buffer_push_asn1_ubigint*(buf: ptr ptls_buffer_t_553648859;
                                       bignum: pointer; size: csize_t): cint {.
       cdecl, importc: "ptls_buffer_push_asn1_ubigint".}
 else:
@@ -9233,18 +9237,18 @@ else:
     hint("Declaration of " & "ptls_decode_quicint" &
         " already exists, not redeclaring")
 when not declared(ptls_log_conn_state_override):
-  var ptls_log_conn_state_override* {.importc: "ptls_log_conn_state_override".}: ptr ptls_log_conn_state_t_536871794
+  var ptls_log_conn_state_override* {.importc: "ptls_log_conn_state_override".}: ptr ptls_log_conn_state_t_553649009
 else:
   static :
     hint("Declaration of " & "ptls_log_conn_state_override" &
         " already exists, not redeclaring")
 when not declared(ptls_log):
-  var ptls_log* {.importc: "ptls_log".}: struct_st_ptls_log_t_536871796
+  var ptls_log* {.importc: "ptls_log".}: struct_st_ptls_log_t_553649011
 else:
   static :
     hint("Declaration of " & "ptls_log" & " already exists, not redeclaring")
 when not declared(ptls_log_init_conn_state):
-  proc ptls_log_init_conn_state*(state: ptr ptls_log_conn_state_t_536871794;
+  proc ptls_log_init_conn_state*(state: ptr ptls_log_conn_state_t_553649009;
       random_bytes: proc (a0: pointer; a1: csize_t): void {.cdecl.}): void {.
       cdecl, importc: "ptls_log_init_conn_state".}
 else:
@@ -9267,7 +9271,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_log_recalc_point):
   proc ptls_log_recalc_point*(caller_locked: cint;
-                              point: ptr struct_st_ptls_log_point_t_536871788): void {.
+                              point: ptr struct_st_ptls_log_point_t_553649003): void {.
       cdecl, importc: "ptls_log__recalc_point".}
 else:
   static :
@@ -9275,7 +9279,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_log_recalc_conn):
   proc ptls_log_recalc_conn*(caller_locked: cint;
-                             conn: ptr struct_st_ptls_log_conn_state_t_536871790;
+                             conn: ptr struct_st_ptls_log_conn_state_t_553649005;
                              get_sni: proc (a0: pointer): cstring {.cdecl.};
                              get_sni_arg: pointer): void {.cdecl,
       importc: "ptls_log__recalc_conn".}
@@ -9359,7 +9363,7 @@ else:
     hint("Declaration of " & "ptls_log_do_push_appdata_element_hexdump" &
         " already exists, not redeclaring")
 when not declared(ptls_log_do_write_start):
-  proc ptls_log_do_write_start*(point: ptr struct_st_ptls_log_point_t_536871788;
+  proc ptls_log_do_write_start*(point: ptr struct_st_ptls_log_point_t_553649003;
                                 add_time: cint): void {.cdecl,
       importc: "ptls_log__do_write_start".}
 else:
@@ -9367,8 +9371,8 @@ else:
     hint("Declaration of " & "ptls_log_do_write_start" &
         " already exists, not redeclaring")
 when not declared(ptls_log_do_write_end):
-  proc ptls_log_do_write_end*(point: ptr struct_st_ptls_log_point_t_536871788;
-                              conn: ptr struct_st_ptls_log_conn_state_t_536871790;
+  proc ptls_log_do_write_end*(point: ptr struct_st_ptls_log_point_t_553649003;
+                              conn: ptr struct_st_ptls_log_conn_state_t_553649005;
                               get_sni: proc (a0: pointer): cstring {.cdecl.};
                               get_sni_arg: pointer; includes_appdata: cint): cint {.
       cdecl, importc: "ptls_log__do_write_end".}
@@ -9377,104 +9381,104 @@ else:
     hint("Declaration of " & "ptls_log_do_write_end" &
         " already exists, not redeclaring")
 when not declared(ptls_client_new):
-  proc ptls_client_new*(ctx: ptr ptls_context_t_536871632): ptr ptls_t_536871630 {.
+  proc ptls_client_new*(ctx: ptr ptls_context_t_553648847): ptr ptls_t_553648845 {.
       cdecl, importc: "ptls_client_new".}
 else:
   static :
     hint("Declaration of " & "ptls_client_new" &
         " already exists, not redeclaring")
 when not declared(ptls_server_new):
-  proc ptls_server_new*(ctx: ptr ptls_context_t_536871632): ptr ptls_t_536871630 {.
+  proc ptls_server_new*(ctx: ptr ptls_context_t_553648847): ptr ptls_t_553648845 {.
       cdecl, importc: "ptls_server_new".}
 else:
   static :
     hint("Declaration of " & "ptls_server_new" &
         " already exists, not redeclaring")
 when not declared(ptls_build_tls12_export_params):
-  proc ptls_build_tls12_export_params*(ctx: ptr ptls_context_t_536871632;
-                                       output: ptr ptls_buffer_t_536871644;
+  proc ptls_build_tls12_export_params*(ctx: ptr ptls_context_t_553648847;
+                                       output: ptr ptls_buffer_t_553648859;
                                        is_server: cint; session_reused: cint;
-                                       cipher: ptr ptls_cipher_suite_t_536871690;
+                                       cipher: ptr ptls_cipher_suite_t_553648905;
                                        master_secret: pointer;
                                        hello_randoms: pointer;
                                        next_send_record_iv: uint64;
                                        server_name: cstring;
-                                       negotiated_protocol: ptls_iovec_t_536871640): cint {.
+                                       negotiated_protocol: ptls_iovec_t_553648855): cint {.
       cdecl, importc: "ptls_build_tls12_export_params".}
 else:
   static :
     hint("Declaration of " & "ptls_build_tls12_export_params" &
         " already exists, not redeclaring")
 when not declared(ptls_export):
-  proc ptls_export*(tls: ptr ptls_t_536871630; output: ptr ptls_buffer_t_536871644): cint {.
+  proc ptls_export*(tls: ptr ptls_t_553648845; output: ptr ptls_buffer_t_553648859): cint {.
       cdecl, importc: "ptls_export".}
 else:
   static :
     hint("Declaration of " & "ptls_export" & " already exists, not redeclaring")
 when not declared(ptls_import):
-  proc ptls_import*(ctx: ptr ptls_context_t_536871632; tls: ptr ptr ptls_t_536871630;
-                    params: ptls_iovec_t_536871640): cint {.cdecl,
+  proc ptls_import*(ctx: ptr ptls_context_t_553648847; tls: ptr ptr ptls_t_553648845;
+                    params: ptls_iovec_t_553648855): cint {.cdecl,
       importc: "ptls_import".}
 else:
   static :
     hint("Declaration of " & "ptls_import" & " already exists, not redeclaring")
 when not declared(ptls_free):
-  proc ptls_free*(tls: ptr ptls_t_536871630): void {.cdecl, importc: "ptls_free".}
+  proc ptls_free*(tls: ptr ptls_t_553648845): void {.cdecl, importc: "ptls_free".}
 else:
   static :
     hint("Declaration of " & "ptls_free" & " already exists, not redeclaring")
 when not declared(ptls_get_context):
-  proc ptls_get_context*(tls: ptr ptls_t_536871630): ptr ptls_context_t_536871632 {.
+  proc ptls_get_context*(tls: ptr ptls_t_553648845): ptr ptls_context_t_553648847 {.
       cdecl, importc: "ptls_get_context".}
 else:
   static :
     hint("Declaration of " & "ptls_get_context" &
         " already exists, not redeclaring")
 when not declared(ptls_set_context):
-  proc ptls_set_context*(tls: ptr ptls_t_536871630; ctx: ptr ptls_context_t_536871632): void {.
+  proc ptls_set_context*(tls: ptr ptls_t_553648845; ctx: ptr ptls_context_t_553648847): void {.
       cdecl, importc: "ptls_set_context".}
 else:
   static :
     hint("Declaration of " & "ptls_set_context" &
         " already exists, not redeclaring")
 when not declared(ptls_get_async_job):
-  proc ptls_get_async_job*(tls: ptr ptls_t_536871630): ptr ptls_async_job_t_536871730 {.
+  proc ptls_get_async_job*(tls: ptr ptls_t_553648845): ptr ptls_async_job_t_553648945 {.
       cdecl, importc: "ptls_get_async_job".}
 else:
   static :
     hint("Declaration of " & "ptls_get_async_job" &
         " already exists, not redeclaring")
 when not declared(ptls_get_client_random):
-  proc ptls_get_client_random*(tls: ptr ptls_t_536871630): ptls_iovec_t_536871640 {.
+  proc ptls_get_client_random*(tls: ptr ptls_t_553648845): ptls_iovec_t_553648855 {.
       cdecl, importc: "ptls_get_client_random".}
 else:
   static :
     hint("Declaration of " & "ptls_get_client_random" &
         " already exists, not redeclaring")
 when not declared(ptls_get_cipher):
-  proc ptls_get_cipher*(tls: ptr ptls_t_536871630): ptr ptls_cipher_suite_t_536871690 {.
+  proc ptls_get_cipher*(tls: ptr ptls_t_553648845): ptr ptls_cipher_suite_t_553648905 {.
       cdecl, importc: "ptls_get_cipher".}
 else:
   static :
     hint("Declaration of " & "ptls_get_cipher" &
         " already exists, not redeclaring")
 when not declared(ptls_find_cipher_suite):
-  proc ptls_find_cipher_suite*(cipher_suites: ptr ptr ptls_cipher_suite_t_536871690;
-                               id: uint16): ptr ptls_cipher_suite_t_536871690 {.
+  proc ptls_find_cipher_suite*(cipher_suites: ptr ptr ptls_cipher_suite_t_553648905;
+                               id: uint16): ptr ptls_cipher_suite_t_553648905 {.
       cdecl, importc: "ptls_find_cipher_suite".}
 else:
   static :
     hint("Declaration of " & "ptls_find_cipher_suite" &
         " already exists, not redeclaring")
 when not declared(ptls_get_protocol_version):
-  proc ptls_get_protocol_version*(tls: ptr ptls_t_536871630): uint16 {.cdecl,
+  proc ptls_get_protocol_version*(tls: ptr ptls_t_553648845): uint16 {.cdecl,
       importc: "ptls_get_protocol_version".}
 else:
   static :
     hint("Declaration of " & "ptls_get_protocol_version" &
         " already exists, not redeclaring")
 when not declared(ptls_get_traffic_keys):
-  proc ptls_get_traffic_keys*(tls: ptr ptls_t_536871630; is_enc: cint;
+  proc ptls_get_traffic_keys*(tls: ptr ptls_t_553648845; is_enc: cint;
                               key: ptr uint8; iv: ptr uint8; seq: ptr uint64): cint {.
       cdecl, importc: "ptls_get_traffic_keys".}
 else:
@@ -9482,14 +9486,14 @@ else:
     hint("Declaration of " & "ptls_get_traffic_keys" &
         " already exists, not redeclaring")
 when not declared(ptls_get_server_name):
-  proc ptls_get_server_name*(tls: ptr ptls_t_536871630): cstring {.cdecl,
+  proc ptls_get_server_name*(tls: ptr ptls_t_553648845): cstring {.cdecl,
       importc: "ptls_get_server_name".}
 else:
   static :
     hint("Declaration of " & "ptls_get_server_name" &
         " already exists, not redeclaring")
 when not declared(ptls_set_server_name):
-  proc ptls_set_server_name*(tls: ptr ptls_t_536871630; server_name: cstring;
+  proc ptls_set_server_name*(tls: ptr ptls_t_553648845; server_name: cstring;
                              server_name_len: csize_t): cint {.cdecl,
       importc: "ptls_set_server_name".}
 else:
@@ -9497,14 +9501,14 @@ else:
     hint("Declaration of " & "ptls_set_server_name" &
         " already exists, not redeclaring")
 when not declared(ptls_get_negotiated_protocol):
-  proc ptls_get_negotiated_protocol*(tls: ptr ptls_t_536871630): cstring {.
+  proc ptls_get_negotiated_protocol*(tls: ptr ptls_t_553648845): cstring {.
       cdecl, importc: "ptls_get_negotiated_protocol".}
 else:
   static :
     hint("Declaration of " & "ptls_get_negotiated_protocol" &
         " already exists, not redeclaring")
 when not declared(ptls_set_negotiated_protocol):
-  proc ptls_set_negotiated_protocol*(tls: ptr ptls_t_536871630;
+  proc ptls_set_negotiated_protocol*(tls: ptr ptls_t_553648845;
                                      protocol: cstring; protocol_len: csize_t): cint {.
       cdecl, importc: "ptls_set_negotiated_protocol".}
 else:
@@ -9512,88 +9516,88 @@ else:
     hint("Declaration of " & "ptls_set_negotiated_protocol" &
         " already exists, not redeclaring")
 when not declared(ptls_handshake_is_complete):
-  proc ptls_handshake_is_complete*(tls: ptr ptls_t_536871630): cint {.cdecl,
+  proc ptls_handshake_is_complete*(tls: ptr ptls_t_553648845): cint {.cdecl,
       importc: "ptls_handshake_is_complete".}
 else:
   static :
     hint("Declaration of " & "ptls_handshake_is_complete" &
         " already exists, not redeclaring")
 when not declared(ptls_is_psk_handshake):
-  proc ptls_is_psk_handshake*(tls: ptr ptls_t_536871630): cint {.cdecl,
+  proc ptls_is_psk_handshake*(tls: ptr ptls_t_553648845): cint {.cdecl,
       importc: "ptls_is_psk_handshake".}
 else:
   static :
     hint("Declaration of " & "ptls_is_psk_handshake" &
         " already exists, not redeclaring")
 when not declared(ptls_is_ech_handshake):
-  proc ptls_is_ech_handshake*(tls: ptr ptls_t_536871630; config_id: ptr uint8;
-                              kem: ptr ptr ptls_hpke_kem_t_536871698;
-                              cipher: ptr ptr ptls_hpke_cipher_suite_t_536871706): cint {.
+  proc ptls_is_ech_handshake*(tls: ptr ptls_t_553648845; config_id: ptr uint8;
+                              kem: ptr ptr ptls_hpke_kem_t_553648913;
+                              cipher: ptr ptr ptls_hpke_cipher_suite_t_553648921): cint {.
       cdecl, importc: "ptls_is_ech_handshake".}
 else:
   static :
     hint("Declaration of " & "ptls_is_ech_handshake" &
         " already exists, not redeclaring")
 when not declared(ptls_get_data_ptr):
-  proc ptls_get_data_ptr*(tls: ptr ptls_t_536871630): ptr pointer {.cdecl,
+  proc ptls_get_data_ptr*(tls: ptr ptls_t_553648845): ptr pointer {.cdecl,
       importc: "ptls_get_data_ptr".}
 else:
   static :
     hint("Declaration of " & "ptls_get_data_ptr" &
         " already exists, not redeclaring")
 when not declared(ptls_get_log_state):
-  proc ptls_get_log_state*(tls: ptr ptls_t_536871630): ptr ptls_log_conn_state_t_536871794 {.
+  proc ptls_get_log_state*(tls: ptr ptls_t_553648845): ptr ptls_log_conn_state_t_553649009 {.
       cdecl, importc: "ptls_get_log_state".}
 else:
   static :
     hint("Declaration of " & "ptls_get_log_state" &
         " already exists, not redeclaring")
 when not declared(ptls_handshake):
-  proc ptls_handshake*(tls: ptr ptls_t_536871630; sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_handshake*(tls: ptr ptls_t_553648845; sendbuf: ptr ptls_buffer_t_553648859;
                        input: pointer; inlen: ptr csize_t;
-                       args: ptr ptls_handshake_properties_t_536871784): cint {.
+                       args: ptr ptls_handshake_properties_t_553648999): cint {.
       cdecl, importc: "ptls_handshake".}
 else:
   static :
     hint("Declaration of " & "ptls_handshake" &
         " already exists, not redeclaring")
 when not declared(ptls_receive):
-  proc ptls_receive*(tls: ptr ptls_t_536871630; plaintextbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_receive*(tls: ptr ptls_t_553648845; plaintextbuf: ptr ptls_buffer_t_553648859;
                      input: pointer; len: ptr csize_t): cint {.cdecl,
       importc: "ptls_receive".}
 else:
   static :
     hint("Declaration of " & "ptls_receive" & " already exists, not redeclaring")
 when not declared(ptls_send):
-  proc ptls_send*(tls: ptr ptls_t_536871630; sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_send*(tls: ptr ptls_t_553648845; sendbuf: ptr ptls_buffer_t_553648859;
                   input: pointer; inlen: csize_t): cint {.cdecl,
       importc: "ptls_send".}
 else:
   static :
     hint("Declaration of " & "ptls_send" & " already exists, not redeclaring")
 when not declared(ptls_update_key):
-  proc ptls_update_key*(tls: ptr ptls_t_536871630; request_update: cint): cint {.
+  proc ptls_update_key*(tls: ptr ptls_t_553648845; request_update: cint): cint {.
       cdecl, importc: "ptls_update_key".}
 else:
   static :
     hint("Declaration of " & "ptls_update_key" &
         " already exists, not redeclaring")
 when not declared(ptls_is_server):
-  proc ptls_is_server*(tls: ptr ptls_t_536871630): cint {.cdecl,
+  proc ptls_is_server*(tls: ptr ptls_t_553648845): cint {.cdecl,
       importc: "ptls_is_server".}
 else:
   static :
     hint("Declaration of " & "ptls_is_server" &
         " already exists, not redeclaring")
 when not declared(ptls_get_record_overhead):
-  proc ptls_get_record_overhead*(tls: ptr ptls_t_536871630): csize_t {.cdecl,
+  proc ptls_get_record_overhead*(tls: ptr ptls_t_553648845): csize_t {.cdecl,
       importc: "ptls_get_record_overhead".}
 else:
   static :
     hint("Declaration of " & "ptls_get_record_overhead" &
         " already exists, not redeclaring")
 when not declared(ptls_send_alert):
-  proc ptls_send_alert*(tls: ptr ptls_t_536871630; sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_send_alert*(tls: ptr ptls_t_553648845; sendbuf: ptr ptls_buffer_t_553648859;
                         level: uint8; description: uint8): cint {.cdecl,
       importc: "ptls_send_alert".}
 else:
@@ -9601,27 +9605,27 @@ else:
     hint("Declaration of " & "ptls_send_alert" &
         " already exists, not redeclaring")
 when not declared(ptls_export_secret):
-  proc ptls_export_secret*(tls: ptr ptls_t_536871630; output: pointer;
+  proc ptls_export_secret*(tls: ptr ptls_t_553648845; output: pointer;
                            outlen: csize_t; label: cstring;
-                           context_value: ptls_iovec_t_536871640; is_early: cint): cint {.
+                           context_value: ptls_iovec_t_553648855; is_early: cint): cint {.
       cdecl, importc: "ptls_export_secret".}
 else:
   static :
     hint("Declaration of " & "ptls_export_secret" &
         " already exists, not redeclaring")
 when not declared(ptls_build_certificate_message):
-  proc ptls_build_certificate_message*(buf: ptr ptls_buffer_t_536871644;
-                                       request_context: ptls_iovec_t_536871640;
-                                       certificates: ptr ptls_iovec_t_536871640;
+  proc ptls_build_certificate_message*(buf: ptr ptls_buffer_t_553648859;
+                                       request_context: ptls_iovec_t_553648855;
+                                       certificates: ptr ptls_iovec_t_553648855;
                                        num_certificates: csize_t;
-                                       ocsp_status: ptls_iovec_t_536871640): cint {.
+                                       ocsp_status: ptls_iovec_t_553648855): cint {.
       cdecl, importc: "ptls_build_certificate_message".}
 else:
   static :
     hint("Declaration of " & "ptls_build_certificate_message" &
         " already exists, not redeclaring")
 when not declared(ptls_calc_hash):
-  proc ptls_calc_hash*(algo: ptr ptls_hash_algorithm_t_536871686;
+  proc ptls_calc_hash*(algo: ptr ptls_hash_algorithm_t_553648901;
                        output: pointer; src: pointer; len: csize_t): cint {.
       cdecl, importc: "ptls_calc_hash".}
 else:
@@ -9629,36 +9633,36 @@ else:
     hint("Declaration of " & "ptls_calc_hash" &
         " already exists, not redeclaring")
 when not declared(ptls_hmac_create):
-  proc ptls_hmac_create*(algo: ptr ptls_hash_algorithm_t_536871686;
-                         key: pointer; key_size: csize_t): ptr ptls_hash_context_t_536871682 {.
+  proc ptls_hmac_create*(algo: ptr ptls_hash_algorithm_t_553648901;
+                         key: pointer; key_size: csize_t): ptr ptls_hash_context_t_553648897 {.
       cdecl, importc: "ptls_hmac_create".}
 else:
   static :
     hint("Declaration of " & "ptls_hmac_create" &
         " already exists, not redeclaring")
 when not declared(ptls_hkdf_extract):
-  proc ptls_hkdf_extract*(hash: ptr ptls_hash_algorithm_t_536871686;
-                          output: pointer; salt: ptls_iovec_t_536871640;
-                          ikm: ptls_iovec_t_536871640): cint {.cdecl,
+  proc ptls_hkdf_extract*(hash: ptr ptls_hash_algorithm_t_553648901;
+                          output: pointer; salt: ptls_iovec_t_553648855;
+                          ikm: ptls_iovec_t_553648855): cint {.cdecl,
       importc: "ptls_hkdf_extract".}
 else:
   static :
     hint("Declaration of " & "ptls_hkdf_extract" &
         " already exists, not redeclaring")
 when not declared(ptls_hkdf_expand):
-  proc ptls_hkdf_expand*(hash: ptr ptls_hash_algorithm_t_536871686;
-                         output: pointer; outlen: csize_t; prk: ptls_iovec_t_536871640;
-                         info: ptls_iovec_t_536871640): cint {.cdecl,
+  proc ptls_hkdf_expand*(hash: ptr ptls_hash_algorithm_t_553648901;
+                         output: pointer; outlen: csize_t; prk: ptls_iovec_t_553648855;
+                         info: ptls_iovec_t_553648855): cint {.cdecl,
       importc: "ptls_hkdf_expand".}
 else:
   static :
     hint("Declaration of " & "ptls_hkdf_expand" &
         " already exists, not redeclaring")
 when not declared(ptls_hkdf_expand_label):
-  proc ptls_hkdf_expand_label*(algo: ptr ptls_hash_algorithm_t_536871686;
+  proc ptls_hkdf_expand_label*(algo: ptr ptls_hash_algorithm_t_553648901;
                                output: pointer; outlen: csize_t;
-                               secret: ptls_iovec_t_536871640; label: cstring;
-                               hash_value: ptls_iovec_t_536871640;
+                               secret: ptls_iovec_t_553648855; label: cstring;
+                               hash_value: ptls_iovec_t_553648855;
                                label_prefix: cstring): cint {.cdecl,
       importc: "ptls_hkdf_expand_label".}
 else:
@@ -9666,55 +9670,55 @@ else:
     hint("Declaration of " & "ptls_hkdf_expand_label" &
         " already exists, not redeclaring")
 when not declared(ptls_tls12_phash):
-  proc ptls_tls12_phash*(algo: ptr ptls_hash_algorithm_t_536871686;
-                         output: pointer; outlen: csize_t; secret: ptls_iovec_t_536871640;
-                         label: cstring; seed: ptls_iovec_t_536871640): cint {.
+  proc ptls_tls12_phash*(algo: ptr ptls_hash_algorithm_t_553648901;
+                         output: pointer; outlen: csize_t; secret: ptls_iovec_t_553648855;
+                         label: cstring; seed: ptls_iovec_t_553648855): cint {.
       cdecl, importc: "ptls_tls12_phash".}
 else:
   static :
     hint("Declaration of " & "ptls_tls12_phash" &
         " already exists, not redeclaring")
 when not declared(ptls_cipher_new):
-  proc ptls_cipher_new*(algo: ptr ptls_cipher_algorithm_t_536871662;
-                        is_enc: cint; key: pointer): ptr ptls_cipher_context_t_536871660 {.
+  proc ptls_cipher_new*(algo: ptr ptls_cipher_algorithm_t_553648877;
+                        is_enc: cint; key: pointer): ptr ptls_cipher_context_t_553648875 {.
       cdecl, importc: "ptls_cipher_new".}
 else:
   static :
     hint("Declaration of " & "ptls_cipher_new" &
         " already exists, not redeclaring")
 when not declared(ptls_cipher_free):
-  proc ptls_cipher_free*(ctx: ptr ptls_cipher_context_t_536871660): void {.
+  proc ptls_cipher_free*(ctx: ptr ptls_cipher_context_t_553648875): void {.
       cdecl, importc: "ptls_cipher_free".}
 else:
   static :
     hint("Declaration of " & "ptls_cipher_free" &
         " already exists, not redeclaring")
 when not declared(ptls_aead_new):
-  proc ptls_aead_new*(aead: ptr ptls_aead_algorithm_t_536871674;
-                      hash: ptr ptls_hash_algorithm_t_536871686; is_enc: cint;
-                      secret: pointer; label_prefix: cstring): ptr ptls_aead_context_t_536871672 {.
+  proc ptls_aead_new*(aead: ptr ptls_aead_algorithm_t_553648889;
+                      hash: ptr ptls_hash_algorithm_t_553648901; is_enc: cint;
+                      secret: pointer; label_prefix: cstring): ptr ptls_aead_context_t_553648887 {.
       cdecl, importc: "ptls_aead_new".}
 else:
   static :
     hint("Declaration of " & "ptls_aead_new" &
         " already exists, not redeclaring")
 when not declared(ptls_aead_new_direct):
-  proc ptls_aead_new_direct*(aead: ptr ptls_aead_algorithm_t_536871674;
-                             is_enc: cint; key: pointer; iv: pointer): ptr ptls_aead_context_t_536871672 {.
+  proc ptls_aead_new_direct*(aead: ptr ptls_aead_algorithm_t_553648889;
+                             is_enc: cint; key: pointer; iv: pointer): ptr ptls_aead_context_t_553648887 {.
       cdecl, importc: "ptls_aead_new_direct".}
 else:
   static :
     hint("Declaration of " & "ptls_aead_new_direct" &
         " already exists, not redeclaring")
 when not declared(ptls_aead_free):
-  proc ptls_aead_free*(ctx: ptr ptls_aead_context_t_536871672): void {.cdecl,
+  proc ptls_aead_free*(ctx: ptr ptls_aead_context_t_553648887): void {.cdecl,
       importc: "ptls_aead_free".}
 else:
   static :
     hint("Declaration of " & "ptls_aead_free" &
         " already exists, not redeclaring")
 when not declared(ptls_aead_xor_iv):
-  proc ptls_aead_xor_iv*(ctx: ptr ptls_aead_context_t_536871672; bytes: pointer;
+  proc ptls_aead_xor_iv*(ctx: ptr ptls_aead_context_t_553648887; bytes: pointer;
                          len: csize_t): void {.cdecl,
       importc: "ptls_aead_xor_iv".}
 else:
@@ -9722,49 +9726,49 @@ else:
     hint("Declaration of " & "ptls_aead_xor_iv" &
         " already exists, not redeclaring")
 when not declared(ptls_get_read_epoch):
-  proc ptls_get_read_epoch*(tls: ptr ptls_t_536871630): csize_t {.cdecl,
+  proc ptls_get_read_epoch*(tls: ptr ptls_t_553648845): csize_t {.cdecl,
       importc: "ptls_get_read_epoch".}
 else:
   static :
     hint("Declaration of " & "ptls_get_read_epoch" &
         " already exists, not redeclaring")
 when not declared(ptls_handle_message):
-  proc ptls_handle_message*(tls: ptr ptls_t_536871630;
-                            sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_handle_message*(tls: ptr ptls_t_553648845;
+                            sendbuf: ptr ptls_buffer_t_553648859;
                             epoch_offsets: array[5'i64, csize_t];
                             in_epoch: csize_t; input: pointer; inlen: csize_t;
-                            properties: ptr ptls_handshake_properties_t_536871784): cint {.
+                            properties: ptr ptls_handshake_properties_t_553648999): cint {.
       cdecl, importc: "ptls_handle_message".}
 else:
   static :
     hint("Declaration of " & "ptls_handle_message" &
         " already exists, not redeclaring")
 when not declared(ptls_client_handle_message):
-  proc ptls_client_handle_message*(tls: ptr ptls_t_536871630;
-                                   sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_client_handle_message*(tls: ptr ptls_t_553648845;
+                                   sendbuf: ptr ptls_buffer_t_553648859;
                                    epoch_offsets: array[5'i64, csize_t];
                                    in_epoch: csize_t; input: pointer;
                                    inlen: csize_t;
-                                   properties: ptr ptls_handshake_properties_t_536871784): cint {.
+                                   properties: ptr ptls_handshake_properties_t_553648999): cint {.
       cdecl, importc: "ptls_client_handle_message".}
 else:
   static :
     hint("Declaration of " & "ptls_client_handle_message" &
         " already exists, not redeclaring")
 when not declared(ptls_server_handle_message):
-  proc ptls_server_handle_message*(tls: ptr ptls_t_536871630;
-                                   sendbuf: ptr ptls_buffer_t_536871644;
+  proc ptls_server_handle_message*(tls: ptr ptls_t_553648845;
+                                   sendbuf: ptr ptls_buffer_t_553648859;
                                    epoch_offsets: array[5'i64, csize_t];
                                    in_epoch: csize_t; input: pointer;
                                    inlen: csize_t;
-                                   properties: ptr ptls_handshake_properties_t_536871784): cint {.
+                                   properties: ptr ptls_handshake_properties_t_553648999): cint {.
       cdecl, importc: "ptls_server_handle_message".}
 else:
   static :
     hint("Declaration of " & "ptls_server_handle_message" &
         " already exists, not redeclaring")
 when not declared(ptls_aead_build_iv):
-  proc ptls_aead_build_iv*(algo: ptr ptls_aead_algorithm_t_536871674;
+  proc ptls_aead_build_iv*(algo: ptr ptls_aead_algorithm_t_553648889;
                            iv: ptr uint8; static_iv: ptr uint8; seq: uint64): void {.
       cdecl, importc: "ptls_aead__build_iv".}
 else:
@@ -9772,7 +9776,7 @@ else:
     hint("Declaration of " & "ptls_aead_build_iv" &
         " already exists, not redeclaring")
 when not declared(ptls_key_schedule_update_hash):
-  proc ptls_key_schedule_update_hash*(sched: ptr ptls_key_schedule_t_536871636;
+  proc ptls_key_schedule_update_hash*(sched: ptr ptls_key_schedule_t_553648851;
                                       msg: ptr uint8; msglen: csize_t;
                                       use_outer: cint): void {.cdecl,
       importc: "ptls__key_schedule_update_hash".}
@@ -9802,10 +9806,10 @@ else:
     hint("Declaration of " & "ptls_server_name_is_ipaddr" &
         " already exists, not redeclaring")
 when not declared(ptls_ech_encode_config):
-  proc ptls_ech_encode_config*(buf: ptr ptls_buffer_t_536871644;
-                               config_id: uint8; kem: ptr ptls_hpke_kem_t_536871698;
-                               public_key: ptls_iovec_t_536871640;
-                               ciphers: ptr ptr ptls_hpke_cipher_suite_t_536871706;
+  proc ptls_ech_encode_config*(buf: ptr ptls_buffer_t_553648859;
+                               config_id: uint8; kem: ptr ptls_hpke_kem_t_553648913;
+                               public_key: ptls_iovec_t_553648855;
+                               ciphers: ptr ptr ptls_hpke_cipher_suite_t_553648921;
                                max_name_length: uint8; public_name: cstring): cint {.
       cdecl, importc: "ptls_ech_encode_config".}
 else:
@@ -9813,7 +9817,7 @@ else:
     hint("Declaration of " & "ptls_ech_encode_config" &
         " already exists, not redeclaring")
 when not declared(ptls_load_certificates):
-  proc ptls_load_certificates*(ctx: ptr ptls_context_t_536871632;
+  proc ptls_load_certificates*(ctx: ptr ptls_context_t_553648847;
                                cert_pem_file: cstring): cint {.cdecl,
       importc: "ptls_load_certificates".}
 else:
@@ -9821,22 +9825,22 @@ else:
     hint("Declaration of " & "ptls_load_certificates" &
         " already exists, not redeclaring")
 when not declared(ptls_hpke_setup_base_s):
-  proc ptls_hpke_setup_base_s*(kem: ptr ptls_hpke_kem_t_536871698;
-                               cipher: ptr ptls_hpke_cipher_suite_t_536871706;
-                               pk_s: ptr ptls_iovec_t_536871640;
-                               ctx: ptr ptr ptls_aead_context_t_536871672;
-                               pk_r: ptls_iovec_t_536871640; info: ptls_iovec_t_536871640): cint {.
+  proc ptls_hpke_setup_base_s*(kem: ptr ptls_hpke_kem_t_553648913;
+                               cipher: ptr ptls_hpke_cipher_suite_t_553648921;
+                               pk_s: ptr ptls_iovec_t_553648855;
+                               ctx: ptr ptr ptls_aead_context_t_553648887;
+                               pk_r: ptls_iovec_t_553648855; info: ptls_iovec_t_553648855): cint {.
       cdecl, importc: "ptls_hpke_setup_base_s".}
 else:
   static :
     hint("Declaration of " & "ptls_hpke_setup_base_s" &
         " already exists, not redeclaring")
 when not declared(ptls_hpke_setup_base_r):
-  proc ptls_hpke_setup_base_r*(kem: ptr ptls_hpke_kem_t_536871698;
-                               cipher: ptr ptls_hpke_cipher_suite_t_536871706;
-                               keyex: ptr ptls_key_exchange_context_t_536871650;
-                               ctx: ptr ptr ptls_aead_context_t_536871672;
-                               pk_s: ptls_iovec_t_536871640; info: ptls_iovec_t_536871640): cint {.
+  proc ptls_hpke_setup_base_r*(kem: ptr ptls_hpke_kem_t_553648913;
+                               cipher: ptr ptls_hpke_cipher_suite_t_553648921;
+                               keyex: ptr ptls_key_exchange_context_t_553648865;
+                               ctx: ptr ptr ptls_aead_context_t_553648887;
+                               pk_s: ptls_iovec_t_553648855; info: ptls_iovec_t_553648855): cint {.
       cdecl, importc: "ptls_hpke_setup_base_r".}
 else:
   static :
@@ -9856,133 +9860,133 @@ else:
     hint("Declaration of " & "ptls_jsonescape" &
         " already exists, not redeclaring")
 when not declared(ptls_build_v4_mapped_v6_address):
-  proc ptls_build_v4_mapped_v6_address*(v6: ptr struct_in6_addr_536871792;
-                                        v4: ptr struct_in_addr_536871798): void {.
+  proc ptls_build_v4_mapped_v6_address*(v6: ptr struct_in6_addr_553649007;
+                                        v4: ptr struct_in_addr_553649013): void {.
       cdecl, importc: "ptls_build_v4_mapped_v6_address".}
 else:
   static :
     hint("Declaration of " & "ptls_build_v4_mapped_v6_address" &
         " already exists, not redeclaring")
 when not declared(ptls_get_time):
-  var ptls_get_time* {.importc: "ptls_get_time".}: ptls_get_time_t_536871718
+  var ptls_get_time* {.importc: "ptls_get_time".}: ptls_get_time_t_553648933
 else:
   static :
     hint("Declaration of " & "ptls_get_time" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_secp256r1):
-  var ptls_openssl_secp256r1* {.importc: "ptls_openssl_secp256r1".}: ptls_key_exchange_algorithm_t_536871654
+  var ptls_openssl_secp256r1* {.importc: "ptls_openssl_secp256r1".}: ptls_key_exchange_algorithm_t_553648869
 else:
   static :
     hint("Declaration of " & "ptls_openssl_secp256r1" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_secp384r1):
-  var ptls_openssl_secp384r1* {.importc: "ptls_openssl_secp384r1".}: ptls_key_exchange_algorithm_t_536871654
+  var ptls_openssl_secp384r1* {.importc: "ptls_openssl_secp384r1".}: ptls_key_exchange_algorithm_t_553648869
 else:
   static :
     hint("Declaration of " & "ptls_openssl_secp384r1" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_secp521r1):
-  var ptls_openssl_secp521r1* {.importc: "ptls_openssl_secp521r1".}: ptls_key_exchange_algorithm_t_536871654
+  var ptls_openssl_secp521r1* {.importc: "ptls_openssl_secp521r1".}: ptls_key_exchange_algorithm_t_553648869
 else:
   static :
     hint("Declaration of " & "ptls_openssl_secp521r1" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_x25519):
-  var ptls_openssl_x25519* {.importc: "ptls_openssl_x25519".}: ptls_key_exchange_algorithm_t_536871654
+  var ptls_openssl_x25519* {.importc: "ptls_openssl_x25519".}: ptls_key_exchange_algorithm_t_553648869
 else:
   static :
     hint("Declaration of " & "ptls_openssl_x25519" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_key_exchanges):
   var ptls_openssl_key_exchanges* {.importc: "ptls_openssl_key_exchanges".}: ptr UncheckedArray[
-      ptr ptls_key_exchange_algorithm_t_536871654]
+      ptr ptls_key_exchange_algorithm_t_553648869]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_key_exchanges" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_key_exchanges_all):
   var ptls_openssl_key_exchanges_all* {.importc: "ptls_openssl_key_exchanges_all".}: ptr UncheckedArray[
-      ptr ptls_key_exchange_algorithm_t_536871654]
+      ptr ptls_key_exchange_algorithm_t_553648869]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_key_exchanges_all" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes128ecb):
-  var ptls_openssl_aes128ecb* {.importc: "ptls_openssl_aes128ecb".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_aes128ecb* {.importc: "ptls_openssl_aes128ecb".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes128ecb" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes128ctr):
-  var ptls_openssl_aes128ctr* {.importc: "ptls_openssl_aes128ctr".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_aes128ctr* {.importc: "ptls_openssl_aes128ctr".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes128ctr" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes128gcm):
-  var ptls_openssl_aes128gcm* {.importc: "ptls_openssl_aes128gcm".}: ptls_aead_algorithm_t_536871674
+  var ptls_openssl_aes128gcm* {.importc: "ptls_openssl_aes128gcm".}: ptls_aead_algorithm_t_553648889
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes128gcm" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes256ecb):
-  var ptls_openssl_aes256ecb* {.importc: "ptls_openssl_aes256ecb".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_aes256ecb* {.importc: "ptls_openssl_aes256ecb".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes256ecb" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes256ctr):
-  var ptls_openssl_aes256ctr* {.importc: "ptls_openssl_aes256ctr".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_aes256ctr* {.importc: "ptls_openssl_aes256ctr".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes256ctr" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes256gcm):
-  var ptls_openssl_aes256gcm* {.importc: "ptls_openssl_aes256gcm".}: ptls_aead_algorithm_t_536871674
+  var ptls_openssl_aes256gcm* {.importc: "ptls_openssl_aes256gcm".}: ptls_aead_algorithm_t_553648889
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes256gcm" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_sha256):
-  var ptls_openssl_sha256* {.importc: "ptls_openssl_sha256".}: ptls_hash_algorithm_t_536871686
+  var ptls_openssl_sha256* {.importc: "ptls_openssl_sha256".}: ptls_hash_algorithm_t_553648901
 else:
   static :
     hint("Declaration of " & "ptls_openssl_sha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_sha384):
-  var ptls_openssl_sha384* {.importc: "ptls_openssl_sha384".}: ptls_hash_algorithm_t_536871686
+  var ptls_openssl_sha384* {.importc: "ptls_openssl_sha384".}: ptls_hash_algorithm_t_553648901
 else:
   static :
     hint("Declaration of " & "ptls_openssl_sha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_sha512):
-  var ptls_openssl_sha512* {.importc: "ptls_openssl_sha512".}: ptls_hash_algorithm_t_536871686
+  var ptls_openssl_sha512* {.importc: "ptls_openssl_sha512".}: ptls_hash_algorithm_t_553648901
 else:
   static :
     hint("Declaration of " & "ptls_openssl_sha512" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes128gcmsha256):
-  var ptls_openssl_aes128gcmsha256* {.importc: "ptls_openssl_aes128gcmsha256".}: ptls_cipher_suite_t_536871690
+  var ptls_openssl_aes128gcmsha256* {.importc: "ptls_openssl_aes128gcmsha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes128gcmsha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_aes256gcmsha384):
-  var ptls_openssl_aes256gcmsha384* {.importc: "ptls_openssl_aes256gcmsha384".}: ptls_cipher_suite_t_536871690
+  var ptls_openssl_aes256gcmsha384* {.importc: "ptls_openssl_aes256gcmsha384".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_aes256gcmsha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_cipher_suites):
   var ptls_openssl_cipher_suites* {.importc: "ptls_openssl_cipher_suites".}: ptr UncheckedArray[
-      ptr ptls_cipher_suite_t_536871690]
+      ptr ptls_cipher_suite_t_553648905]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_cipher_suites" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_cipher_suites_all):
   var ptls_openssl_cipher_suites_all* {.importc: "ptls_openssl_cipher_suites_all".}: ptr UncheckedArray[
-      ptr ptls_cipher_suite_t_536871690]
+      ptr ptls_cipher_suite_t_553648905]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_cipher_suites_all" &
@@ -9990,61 +9994,61 @@ else:
 when not declared(ptls_openssl_tls12_cipher_suites):
   var ptls_openssl_tls12_cipher_suites* {.
       importc: "ptls_openssl_tls12_cipher_suites".}: ptr UncheckedArray[
-      ptr ptls_cipher_suite_t_536871690]
+      ptr ptls_cipher_suite_t_553648905]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_tls12_cipher_suites" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_chacha20):
-  var ptls_openssl_chacha20* {.importc: "ptls_openssl_chacha20".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_chacha20* {.importc: "ptls_openssl_chacha20".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_chacha20" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_chacha20poly1305):
-  var ptls_openssl_chacha20poly1305* {.importc: "ptls_openssl_chacha20poly1305".}: ptls_aead_algorithm_t_536871674
+  var ptls_openssl_chacha20poly1305* {.importc: "ptls_openssl_chacha20poly1305".}: ptls_aead_algorithm_t_553648889
 else:
   static :
     hint("Declaration of " & "ptls_openssl_chacha20poly1305" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_chacha20poly1305sha256):
   var ptls_openssl_chacha20poly1305sha256*
-      {.importc: "ptls_openssl_chacha20poly1305sha256".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_chacha20poly1305sha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_chacha20poly1305sha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_rsa_aes128gcmsha256):
   var ptls_openssl_tls12_ecdhe_rsa_aes128gcmsha256*
-      {.importc: "ptls_openssl_tls12_ecdhe_rsa_aes128gcmsha256".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_rsa_aes128gcmsha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_tls12_ecdhe_rsa_aes128gcmsha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_ecdsa_aes128gcmsha256):
   var ptls_openssl_tls12_ecdhe_ecdsa_aes128gcmsha256*
-      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_aes128gcmsha256".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_aes128gcmsha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_tls12_ecdhe_ecdsa_aes128gcmsha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_rsa_aes256gcmsha384):
   var ptls_openssl_tls12_ecdhe_rsa_aes256gcmsha384*
-      {.importc: "ptls_openssl_tls12_ecdhe_rsa_aes256gcmsha384".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_rsa_aes256gcmsha384".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_tls12_ecdhe_rsa_aes256gcmsha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_ecdsa_aes256gcmsha384):
   var ptls_openssl_tls12_ecdhe_ecdsa_aes256gcmsha384*
-      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_aes256gcmsha384".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_aes256gcmsha384".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " & "ptls_openssl_tls12_ecdhe_ecdsa_aes256gcmsha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_rsa_chacha20poly1305sha256):
   var ptls_openssl_tls12_ecdhe_rsa_chacha20poly1305sha256*
-      {.importc: "ptls_openssl_tls12_ecdhe_rsa_chacha20poly1305sha256".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_rsa_chacha20poly1305sha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " &
@@ -10052,70 +10056,70 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_tls12_ecdhe_ecdsa_chacha20poly1305sha256):
   var ptls_openssl_tls12_ecdhe_ecdsa_chacha20poly1305sha256*
-      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_chacha20poly1305sha256".}: ptls_cipher_suite_t_536871690
+      {.importc: "ptls_openssl_tls12_ecdhe_ecdsa_chacha20poly1305sha256".}: ptls_cipher_suite_t_553648905
 else:
   static :
     hint("Declaration of " &
         "ptls_openssl_tls12_ecdhe_ecdsa_chacha20poly1305sha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_bfecb):
-  var ptls_openssl_bfecb* {.importc: "ptls_openssl_bfecb".}: ptls_cipher_algorithm_t_536871662
+  var ptls_openssl_bfecb* {.importc: "ptls_openssl_bfecb".}: ptls_cipher_algorithm_t_553648877
 else:
   static :
     hint("Declaration of " & "ptls_openssl_bfecb" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_kem_p256sha256):
   var ptls_openssl_hpke_kem_p256sha256* {.
-      importc: "ptls_openssl_hpke_kem_p256sha256".}: ptls_hpke_kem_t_536871698
+      importc: "ptls_openssl_hpke_kem_p256sha256".}: ptls_hpke_kem_t_553648913
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_kem_p256sha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_kem_p384sha384):
   var ptls_openssl_hpke_kem_p384sha384* {.
-      importc: "ptls_openssl_hpke_kem_p384sha384".}: ptls_hpke_kem_t_536871698
+      importc: "ptls_openssl_hpke_kem_p384sha384".}: ptls_hpke_kem_t_553648913
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_kem_p384sha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_kem_x25519sha256):
   var ptls_openssl_hpke_kem_x25519sha256*
-      {.importc: "ptls_openssl_hpke_kem_x25519sha256".}: ptls_hpke_kem_t_536871698
+      {.importc: "ptls_openssl_hpke_kem_x25519sha256".}: ptls_hpke_kem_t_553648913
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_kem_x25519sha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_kems):
   var ptls_openssl_hpke_kems* {.importc: "ptls_openssl_hpke_kems".}: ptr UncheckedArray[
-      ptr ptls_hpke_kem_t_536871698]
+      ptr ptls_hpke_kem_t_553648913]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_kems" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_aes128gcmsha256):
   var ptls_openssl_hpke_aes128gcmsha256* {.
-      importc: "ptls_openssl_hpke_aes128gcmsha256".}: ptls_hpke_cipher_suite_t_536871706
+      importc: "ptls_openssl_hpke_aes128gcmsha256".}: ptls_hpke_cipher_suite_t_553648921
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_aes128gcmsha256" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_aes128gcmsha512):
   var ptls_openssl_hpke_aes128gcmsha512* {.
-      importc: "ptls_openssl_hpke_aes128gcmsha512".}: ptls_hpke_cipher_suite_t_536871706
+      importc: "ptls_openssl_hpke_aes128gcmsha512".}: ptls_hpke_cipher_suite_t_553648921
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_aes128gcmsha512" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_aes256gcmsha384):
   var ptls_openssl_hpke_aes256gcmsha384* {.
-      importc: "ptls_openssl_hpke_aes256gcmsha384".}: ptls_hpke_cipher_suite_t_536871706
+      importc: "ptls_openssl_hpke_aes256gcmsha384".}: ptls_hpke_cipher_suite_t_553648921
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_aes256gcmsha384" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_hpke_chacha20poly1305sha256):
   var ptls_openssl_hpke_chacha20poly1305sha256*
-      {.importc: "ptls_openssl_hpke_chacha20poly1305sha256".}: ptls_hpke_cipher_suite_t_536871706
+      {.importc: "ptls_openssl_hpke_chacha20poly1305sha256".}: ptls_hpke_cipher_suite_t_553648921
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_chacha20poly1305sha256" &
@@ -10123,7 +10127,7 @@ else:
 when not declared(ptls_openssl_hpke_cipher_suites):
   var ptls_openssl_hpke_cipher_suites* {.
       importc: "ptls_openssl_hpke_cipher_suites".}: ptr UncheckedArray[
-      ptr ptls_hpke_cipher_suite_t_536871706]
+      ptr ptls_hpke_cipher_suite_t_553648921]
 else:
   static :
     hint("Declaration of " & "ptls_openssl_hpke_cipher_suites" &
@@ -10137,14 +10141,14 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_create_key_exchange):
   proc ptls_openssl_create_key_exchange*(
-      ctx: ptr ptr ptls_key_exchange_context_t_536871650; pkey: ptr EVP_PKEY_536871800): cint {.
+      ctx: ptr ptr ptls_key_exchange_context_t_553648865; pkey: ptr EVP_PKEY_553649015): cint {.
       cdecl, importc: "ptls_openssl_create_key_exchange".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_create_key_exchange" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_lookup_signature_schemes):
-  proc ptls_openssl_lookup_signature_schemes*(key: ptr EVP_PKEY_536871800): ptr ptls_openssl_signature_scheme_t_536871806 {.
+  proc ptls_openssl_lookup_signature_schemes*(key: ptr EVP_PKEY_553649015): ptr ptls_openssl_signature_scheme_t_553649021 {.
       cdecl, importc: "ptls_openssl_lookup_signature_schemes".}
 else:
   static :
@@ -10152,8 +10156,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_select_signature_scheme):
   proc ptls_openssl_select_signature_scheme*(
-      available: ptr ptls_openssl_signature_scheme_t_536871806;
-      algorithms: ptr uint16; num_algorithms: csize_t): ptr ptls_openssl_signature_scheme_t_536871806 {.
+      available: ptr ptls_openssl_signature_scheme_t_553649021;
+      algorithms: ptr uint16; num_algorithms: csize_t): ptr ptls_openssl_signature_scheme_t_553649021 {.
       cdecl, importc: "ptls_openssl_select_signature_scheme".}
 else:
   static :
@@ -10161,7 +10165,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_init_sign_certificate):
   proc ptls_openssl_init_sign_certificate*(
-      self: ptr ptls_openssl_sign_certificate_t_536871810; key: ptr EVP_PKEY_536871800): cint {.
+      self: ptr ptls_openssl_sign_certificate_t_553649025; key: ptr EVP_PKEY_553649015): cint {.
       cdecl, importc: "ptls_openssl_init_sign_certificate".}
 else:
   static :
@@ -10169,15 +10173,15 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_dispose_sign_certificate):
   proc ptls_openssl_dispose_sign_certificate*(
-      self: ptr ptls_openssl_sign_certificate_t_536871810): void {.cdecl,
+      self: ptr ptls_openssl_sign_certificate_t_553649025): void {.cdecl,
       importc: "ptls_openssl_dispose_sign_certificate".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_dispose_sign_certificate" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_load_certificates):
-  proc ptls_openssl_load_certificates*(ctx: ptr ptls_context_t_536871632;
-                                       cert: ptr X509_536871812;
+  proc ptls_openssl_load_certificates*(ctx: ptr ptls_context_t_553648847;
+                                       cert: ptr X509_553649027;
                                        chain: ptr struct_stack_st_X509): cint {.
       cdecl, importc: "ptls_openssl_load_certificates".}
 else:
@@ -10186,8 +10190,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_init_verify_certificate):
   proc ptls_openssl_init_verify_certificate*(
-      self: ptr ptls_openssl_verify_certificate_t_536871826;
-      store: ptr X509_STORE_536871824): cint {.cdecl,
+      self: ptr ptls_openssl_verify_certificate_t_553649041;
+      store: ptr X509_STORE_553649039): cint {.cdecl,
       importc: "ptls_openssl_init_verify_certificate".}
 else:
   static :
@@ -10195,14 +10199,14 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_dispose_verify_certificate):
   proc ptls_openssl_dispose_verify_certificate*(
-      self: ptr ptls_openssl_verify_certificate_t_536871826): void {.cdecl,
+      self: ptr ptls_openssl_verify_certificate_t_553649041): void {.cdecl,
       importc: "ptls_openssl_dispose_verify_certificate".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_dispose_verify_certificate" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_create_default_certificate_store):
-  proc ptls_openssl_create_default_certificate_store*(): ptr X509_STORE_536871824 {.
+  proc ptls_openssl_create_default_certificate_store*(): ptr X509_STORE_553649039 {.
       cdecl, importc: "ptls_openssl_create_default_certificate_store".}
 else:
   static :
@@ -10210,8 +10214,8 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_raw_pubkey_init_verify_certificate):
   proc ptls_openssl_raw_pubkey_init_verify_certificate*(
-      self: ptr ptls_openssl_raw_pubkey_verify_certificate_t_536871816;
-      pubkey: ptr EVP_PKEY_536871800): cint {.cdecl,
+      self: ptr ptls_openssl_raw_pubkey_verify_certificate_t_553649031;
+      pubkey: ptr EVP_PKEY_553649015): cint {.cdecl,
       importc: "ptls_openssl_raw_pubkey_init_verify_certificate".}
 else:
   static :
@@ -10219,7 +10223,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_raw_pubkey_dispose_verify_certificate):
   proc ptls_openssl_raw_pubkey_dispose_verify_certificate*(
-      self: ptr ptls_openssl_raw_pubkey_verify_certificate_t_536871816): void {.
+      self: ptr ptls_openssl_raw_pubkey_verify_certificate_t_553649031): void {.
       cdecl, importc: "ptls_openssl_raw_pubkey_dispose_verify_certificate".}
 else:
   static :
@@ -10227,54 +10231,54 @@ else:
         "ptls_openssl_raw_pubkey_dispose_verify_certificate" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_encrypt_ticket):
-  proc ptls_openssl_encrypt_ticket*(dst: ptr ptls_buffer_t_536871644;
-                                    src: ptls_iovec_t_536871640; cb: proc (
-      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_536871828;
-      a3: ptr HMAC_CTX_536871830; a4: cint): cint {.cdecl.}): cint {.cdecl,
+  proc ptls_openssl_encrypt_ticket*(dst: ptr ptls_buffer_t_553648859;
+                                    src: ptls_iovec_t_553648855; cb: proc (
+      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_553649043;
+      a3: ptr HMAC_CTX_553649045; a4: cint): cint {.cdecl.}): cint {.cdecl,
       importc: "ptls_openssl_encrypt_ticket".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_encrypt_ticket" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_decrypt_ticket):
-  proc ptls_openssl_decrypt_ticket*(dst: ptr ptls_buffer_t_536871644;
-                                    src: ptls_iovec_t_536871640; cb: proc (
-      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_536871828;
-      a3: ptr HMAC_CTX_536871830; a4: cint): cint {.cdecl.}): cint {.cdecl,
+  proc ptls_openssl_decrypt_ticket*(dst: ptr ptls_buffer_t_553648859;
+                                    src: ptls_iovec_t_553648855; cb: proc (
+      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_553649043;
+      a3: ptr HMAC_CTX_553649045; a4: cint): cint {.cdecl.}): cint {.cdecl,
       importc: "ptls_openssl_decrypt_ticket".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_decrypt_ticket" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_encrypt_ticket_evp):
-  proc ptls_openssl_encrypt_ticket_evp*(dst: ptr ptls_buffer_t_536871644;
-                                        src: ptls_iovec_t_536871640; cb: proc (
-      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_536871828;
-      a3: ptr EVP_MAC_CTX_536871832; a4: cint): cint {.cdecl.}): cint {.cdecl,
+  proc ptls_openssl_encrypt_ticket_evp*(dst: ptr ptls_buffer_t_553648859;
+                                        src: ptls_iovec_t_553648855; cb: proc (
+      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_553649043;
+      a3: ptr EVP_MAC_CTX_553649047; a4: cint): cint {.cdecl.}): cint {.cdecl,
       importc: "ptls_openssl_encrypt_ticket_evp".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_encrypt_ticket_evp" &
         " already exists, not redeclaring")
 when not declared(ptls_openssl_decrypt_ticket_evp):
-  proc ptls_openssl_decrypt_ticket_evp*(dst: ptr ptls_buffer_t_536871644;
-                                        src: ptls_iovec_t_536871640; cb: proc (
-      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_536871828;
-      a3: ptr EVP_MAC_CTX_536871832; a4: cint): cint {.cdecl.}): cint {.cdecl,
+  proc ptls_openssl_decrypt_ticket_evp*(dst: ptr ptls_buffer_t_553648859;
+                                        src: ptls_iovec_t_553648855; cb: proc (
+      a0: ptr uint8; a1: ptr uint8; a2: ptr EVP_CIPHER_CTX_553649043;
+      a3: ptr EVP_MAC_CTX_553649047; a4: cint): cint {.cdecl.}): cint {.cdecl,
       importc: "ptls_openssl_decrypt_ticket_evp".}
 else:
   static :
     hint("Declaration of " & "ptls_openssl_decrypt_ticket_evp" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_ctx_init):
-  proc ngtcp2_crypto_picotls_ctx_init*(cptls: ptr ngtcp2_crypto_picotls_ctx_536871836): void {.
+  proc ngtcp2_crypto_picotls_ctx_init*(cptls: ptr ngtcp2_crypto_picotls_ctx_553649051): void {.
       cdecl, importc: "ngtcp2_crypto_picotls_ctx_init".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_picotls_ctx_init" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_from_epoch):
-  proc ngtcp2_crypto_picotls_from_epoch*(epoch: csize_t): ngtcp2_encryption_level_536871530 {.
+  proc ngtcp2_crypto_picotls_from_epoch*(epoch: csize_t): ngtcp2_encryption_level_553648745 {.
       cdecl, importc: "ngtcp2_crypto_picotls_from_epoch".}
 else:
   static :
@@ -10282,7 +10286,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_from_ngtcp2_encryption_level):
   proc ngtcp2_crypto_picotls_from_ngtcp2_encryption_level*(
-      encryption_level: ngtcp2_encryption_level_536871530): csize_t {.cdecl,
+      encryption_level: ngtcp2_encryption_level_553648745): csize_t {.cdecl,
       importc: "ngtcp2_crypto_picotls_from_ngtcp2_encryption_level".}
 else:
   static :
@@ -10290,14 +10294,14 @@ else:
         "ngtcp2_crypto_picotls_from_ngtcp2_encryption_level" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_configure_server_context):
-  proc ngtcp2_crypto_picotls_configure_server_context*(ctx: ptr ptls_context_t_536871632): cint {.
+  proc ngtcp2_crypto_picotls_configure_server_context*(ctx: ptr ptls_context_t_553648847): cint {.
       cdecl, importc: "ngtcp2_crypto_picotls_configure_server_context".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_picotls_configure_server_context" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_configure_client_context):
-  proc ngtcp2_crypto_picotls_configure_client_context*(ctx: ptr ptls_context_t_536871632): cint {.
+  proc ngtcp2_crypto_picotls_configure_client_context*(ctx: ptr ptls_context_t_553648847): cint {.
       cdecl, importc: "ngtcp2_crypto_picotls_configure_client_context".}
 else:
   static :
@@ -10305,7 +10309,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_configure_server_session):
   proc ngtcp2_crypto_picotls_configure_server_session*(
-      cptls: ptr ngtcp2_crypto_picotls_ctx_536871836): cint {.cdecl,
+      cptls: ptr ngtcp2_crypto_picotls_ctx_553649051): cint {.cdecl,
       importc: "ngtcp2_crypto_picotls_configure_server_session".}
 else:
   static :
@@ -10313,7 +10317,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_configure_client_session):
   proc ngtcp2_crypto_picotls_configure_client_session*(
-      cptls: ptr ngtcp2_crypto_picotls_ctx_536871836; conn: ptr ngtcp2_conn_536871522): cint {.
+      cptls: ptr ngtcp2_crypto_picotls_ctx_553649051; conn: ptr ngtcp2_conn_553648737): cint {.
       cdecl, importc: "ngtcp2_crypto_picotls_configure_client_session".}
 else:
   static :
@@ -10321,31 +10325,31 @@ else:
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_deconfigure_session):
   proc ngtcp2_crypto_picotls_deconfigure_session*(
-      cptls: ptr ngtcp2_crypto_picotls_ctx_536871836): void {.cdecl,
+      cptls: ptr ngtcp2_crypto_picotls_ctx_553649051): void {.cdecl,
       importc: "ngtcp2_crypto_picotls_deconfigure_session".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_picotls_deconfigure_session" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_collect_extension):
-  proc ngtcp2_crypto_picotls_collect_extension*(ptls: ptr ptls_t_536871630;
-      properties: ptr struct_st_ptls_handshake_properties_t_536871782;
+  proc ngtcp2_crypto_picotls_collect_extension*(ptls: ptr ptls_t_553648845;
+      properties: ptr struct_st_ptls_handshake_properties_t_553648997;
       type_arg: uint16): cint {.cdecl, importc: "ngtcp2_crypto_picotls_collect_extension".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_picotls_collect_extension" &
         " already exists, not redeclaring")
 when not declared(ngtcp2_crypto_picotls_collected_extensions):
-  proc ngtcp2_crypto_picotls_collected_extensions*(ptls: ptr ptls_t_536871630;
-      properties: ptr struct_st_ptls_handshake_properties_t_536871782;
-      extensions: ptr ptls_raw_extension_t_536871776): cint {.cdecl,
+  proc ngtcp2_crypto_picotls_collected_extensions*(ptls: ptr ptls_t_553648845;
+      properties: ptr struct_st_ptls_handshake_properties_t_553648997;
+      extensions: ptr ptls_raw_extension_t_553648991): cint {.cdecl,
       importc: "ngtcp2_crypto_picotls_collected_extensions".}
 else:
   static :
     hint("Declaration of " & "ngtcp2_crypto_picotls_collected_extensions" &
         " already exists, not redeclaring")
 when not declared(ptls_cred_buffer_set_from_file):
-  proc ptls_cred_buffer_set_from_file*(buf: ptr ptls_cred_buffer_t_536871840;
+  proc ptls_cred_buffer_set_from_file*(buf: ptr ptls_cred_buffer_t_553649055;
                                        fname: cstring): cint {.cdecl,
       importc: "ptls_cred_buffer_set_from_file".}
 else:
@@ -10353,36 +10357,36 @@ else:
     hint("Declaration of " & "ptls_cred_buffer_set_from_file" &
         " already exists, not redeclaring")
 when not declared(ptls_cred_buffer_set_from_string):
-  proc ptls_cred_buffer_set_from_string*(buf: ptr ptls_cred_buffer_t_536871840;
+  proc ptls_cred_buffer_set_from_string*(buf: ptr ptls_cred_buffer_t_553649055;
       s: cstring): cint {.cdecl, importc: "ptls_cred_buffer_set_from_string".}
 else:
   static :
     hint("Declaration of " & "ptls_cred_buffer_set_from_string" &
         " already exists, not redeclaring")
 when not declared(ptls_cred_buffer_dispose):
-  proc ptls_cred_buffer_dispose*(buf: ptr ptls_cred_buffer_t_536871840): void {.
+  proc ptls_cred_buffer_dispose*(buf: ptr ptls_cred_buffer_t_553649055): void {.
       cdecl, importc: "ptls_cred_buffer_dispose".}
 else:
   static :
     hint("Declaration of " & "ptls_cred_buffer_dispose" &
         " already exists, not redeclaring")
 when not declared(ptls_cred_buffer_rewind):
-  proc ptls_cred_buffer_rewind*(buf: ptr ptls_cred_buffer_t_536871840): void {.
+  proc ptls_cred_buffer_rewind*(buf: ptr ptls_cred_buffer_t_553649055): void {.
       cdecl, importc: "ptls_cred_buffer_rewind".}
 else:
   static :
     hint("Declaration of " & "ptls_cred_buffer_rewind" &
         " already exists, not redeclaring")
 when not declared(ptls_cred_buffer_gets):
-  proc ptls_cred_buffer_gets*(s: cstring; n: cint; buf: ptr ptls_cred_buffer_t_536871840): cstring {.
+  proc ptls_cred_buffer_gets*(s: cstring; n: cint; buf: ptr ptls_cred_buffer_t_553649055): cstring {.
       cdecl, importc: "ptls_cred_buffer_gets".}
 else:
   static :
     hint("Declaration of " & "ptls_cred_buffer_gets" &
         " already exists, not redeclaring")
 when not declared(ptls_load_certificates_from_memory):
-  proc ptls_load_certificates_from_memory*(ctx: ptr ptls_context_t_536871632;
-      mem: ptr ptls_cred_buffer_t_536871840): cint {.cdecl,
+  proc ptls_load_certificates_from_memory*(ctx: ptr ptls_context_t_553648847;
+      mem: ptr ptls_cred_buffer_t_553649055): cint {.cdecl,
       importc: "ptls_load_certificates_from_memory".}
 else:
   static :
@@ -10390,7 +10394,7 @@ else:
         " already exists, not redeclaring")
 when not declared(ptls_openssl_init_sign_certificate_with_mem_key):
   proc ptls_openssl_init_sign_certificate_with_mem_key*(
-      self: ptr ptls_openssl_sign_certificate_t_536871810; buf: pointer;
+      self: ptr ptls_openssl_sign_certificate_t_553649025; buf: pointer;
       len: cint): cint {.cdecl, importc: "ptls_openssl_init_sign_certificate_with_mem_key".}
 else:
   static :
@@ -10428,3 +10432,61 @@ type
     struct_st_ptls_handshake_properties_t_anon0_t_server_t_selected_psk_binder_t
   ptls_handshake_properties_t_anon0_t_server_t_cookie_t* =
     struct_st_ptls_handshake_properties_t_anon0_t_server_t_cookie_t
+
+# OpenSSL/QuicTLS crypto support
+# OpenSSL/QuicTLS type definitions
+type
+  SSL_CTX* = pointer
+  OSSL_ENCRYPTION_LEVEL* = enum
+    OSSL_ENCRYPTION_LEVEL_INITIAL = 0
+    OSSL_ENCRYPTION_LEVEL_EARLY_DATA = 1
+    OSSL_ENCRYPTION_LEVEL_HANDSHAKE = 2
+    OSSL_ENCRYPTION_LEVEL_APPLICATION = 3
+
+# ngtcp2_crypto_quictls error constants
+const
+  NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_X509_LOOKUP* = -10001
+  NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_CLIENT_HELLO_CB* = -10002
+
+# ngtcp2_crypto_quictls function bindings
+when not declared(ngtcp2_crypto_quictls_init):
+  proc ngtcp2_crypto_quictls_init*(): cint {.
+      cdecl, importc: "ngtcp2_crypto_quictls_init".}
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_quictls_init" &
+        " already exists, not redeclaring")
+
+when not declared(ngtcp2_crypto_quictls_from_ossl_encryption_level):
+  proc ngtcp2_crypto_quictls_from_ossl_encryption_level*(
+      ossl_level: OSSL_ENCRYPTION_LEVEL): ngtcp2_encryption_level_553648745 {.
+      cdecl, importc: "ngtcp2_crypto_quictls_from_ossl_encryption_level".}
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_quictls_from_ossl_encryption_level" &
+        " already exists, not redeclaring")
+
+when not declared(ngtcp2_crypto_quictls_from_ngtcp2_encryption_level):
+  proc ngtcp2_crypto_quictls_from_ngtcp2_encryption_level*(
+      encryption_level: ngtcp2_encryption_level_553648745): OSSL_ENCRYPTION_LEVEL {.
+      cdecl, importc: "ngtcp2_crypto_quictls_from_ngtcp2_encryption_level".}
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_quictls_from_ngtcp2_encryption_level" &
+        " already exists, not redeclaring")
+
+when not declared(ngtcp2_crypto_quictls_configure_server_context):
+  proc ngtcp2_crypto_quictls_configure_server_context*(ssl_ctx: SSL_CTX): cint {.
+      cdecl, importc: "ngtcp2_crypto_quictls_configure_server_context".}
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_quictls_configure_server_context" &
+        " already exists, not redeclaring")
+
+when not declared(ngtcp2_crypto_quictls_configure_client_context):
+  proc ngtcp2_crypto_quictls_configure_client_context*(ssl_ctx: SSL_CTX): cint {.
+      cdecl, importc: "ngtcp2_crypto_quictls_configure_client_context".}
+else:
+  static :
+    hint("Declaration of " & "ngtcp2_crypto_quictls_configure_client_context" &
+        " already exists, not redeclaring")

--- a/ngtcp2.nimble
+++ b/ngtcp2.nimble
@@ -1,5 +1,5 @@
 packageName = "ngtcp2"
-version = "0.36.1"
+version = "0.37.0"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the ngtcp2 library"
 license = "MIT"

--- a/prelude.nim
+++ b/prelude.nim
@@ -33,3 +33,7 @@ const picotlsInclude       = root/"libs"/"picotls"/"include"
 {.passc: fmt"-I{ngtcp2Lib}".}
 {.passc: fmt"-I{ngtcp2LibIncludes}".}
 {.passc: fmt"-I{picotlsInclude}".}
+
+# QuicTLS/OpenSSL crypto support
+{.passc: "-DNGTCP2_CRYPTO_QUICTLS".}
+{.passc: "-I/usr/include/openssl".}

--- a/tests/testNgtcp2.nim
+++ b/tests/testNgtcp2.nim
@@ -7,15 +7,32 @@ test "default settings":
   check settings.max_tx_udp_payload_size > 0
 
   var transport_params: ngtcp2_transport_params
-  ngtcp2_transport_params_default_versioned(NGTCP2_TRANSPORT_PARAMS_V1, addr transport_params)
+  ngtcp2_transport_params_default_versioned(
+    NGTCP2_TRANSPORT_PARAMS_V1, addr transport_params
+  )
   check transport_params.active_connection_id_limit > 0
 
 test "ptls_instantiation":
   var ctx: ptls_context_t
   ctx.random_bytes = ptls_openssl_random_bytes
   ctx.get_time = addr ptls_get_time
-  ctx.key_exchanges =  cast[ptr ptr ptls_key_exchange_algorithm_t](addr ptls_openssl_key_exchanges[0])
+  ctx.key_exchanges =
+    cast[ptr ptr ptls_key_exchange_algorithm_t](addr ptls_openssl_key_exchanges[0])
   ctx.cipher_suites = cast[ptr ptr ptls_cipher_suite_t](ptls_openssl_cipher_suites[0])
-  
-  var tls: ptr ptls_t = ptls_client_new(addr ctx);
+
+  var tls: ptr ptls_t = ptls_client_new(addr ctx)
   check tls != nil
+
+test "QuicTLS bindings":
+  # Test error constants
+  check NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_X509_LOOKUP == -10001
+  check NGTCP2_CRYPTO_QUICTLS_ERR_TLS_WANT_CLIENT_HELLO_CB == -10002
+
+  # Test OSSL_ENCRYPTION_LEVEL enum values
+  check ord(OSSL_ENCRYPTION_LEVEL_INITIAL) == 0
+  check ord(OSSL_ENCRYPTION_LEVEL_EARLY_DATA) == 1
+  check ord(OSSL_ENCRYPTION_LEVEL_HANDSHAKE) == 2
+  check ord(OSSL_ENCRYPTION_LEVEL_APPLICATION) == 3
+
+  # Test that SSL_CTX type is properly defined as pointer
+  check sizeof(SSL_CTX) == sizeof(pointer)


### PR DESCRIPTION
This enables nim-quic to use QuicTLS/OpenSSL backend for QUIC connections alongside the existing picotls backend.